### PR TITLE
Add a Pulsar Dead Letter Queue source

### DIFF
--- a/examples/applications/pulsar-dlq-source/README.md
+++ b/examples/applications/pulsar-dlq-source/README.md
@@ -1,0 +1,33 @@
+# Listen to messages on Pulsar DLQ topics
+
+This sample application listens for new messages on all DLQ topics in a Pulsar
+namespace and outputs them to a topic. As new DLQ topics are created, it automatically
+subscribes to them and listens for messages.
+
+## Start a Pulsar container locally
+
+
+Access the pulsar admin interface:
+
+```
+docker exec -it pulsar-standalone /bin/bash
+```
+
+
+## Deploy the LangStream application
+
+Run the application using the built-in Pulsar and exposing its ports.
+
+```
+./bin/langstream docker run test --use-pulsar=true --docker-args=-p --docker-args=6650:6650 -app examples/applications/pulsar-dlq-source
+```
+
+## Send messages to DLQ topics
+
+Use the sample script to simulate failed messages and put them in the DLQ.
+
+```
+pip install pulsar-client
+./python3 simulate_dlq.py
+```
+

--- a/examples/applications/pulsar-dlq-source/configuration.yaml
+++ b/examples/applications/pulsar-dlq-source/configuration.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+configuration:
+  defaults:
+    globals:
+      github-event: "PULLREQUESTCOMMENT"
+  dependencies:

--- a/examples/applications/pulsar-dlq-source/gateways.yaml
+++ b/examples/applications/pulsar-dlq-source/gateways.yaml
@@ -1,0 +1,21 @@
+#
+#
+# Copyright DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+gateways:
+  - id: "github"
+    type: consume
+    topic: "output-topic"

--- a/examples/applications/pulsar-dlq-source/pipeline.yaml
+++ b/examples/applications/pulsar-dlq-source/pipeline.yaml
@@ -1,0 +1,27 @@
+#
+# Copyright DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+topics:
+  - name: "output-topic"
+    creation-mode: create-if-not-exists
+pipeline:
+  - name: "monitor Pulsar DLQ topics in a namespace for messages"
+    output: "output-topic"
+    type: "pulsardlq-source"
+    configuration:
+      pulsar-url: "pulsar://localhost:6650"
+      namespace: "public/default"
+      subscription: "dlq-listener"

--- a/examples/applications/pulsar-dlq-source/simulate_dlq.py
+++ b/examples/applications/pulsar-dlq-source/simulate_dlq.py
@@ -1,3 +1,19 @@
+#
+# Copyright DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 import time
 
 from pulsar import (

--- a/examples/applications/pulsar-dlq-source/simulate_dlq.py
+++ b/examples/applications/pulsar-dlq-source/simulate_dlq.py
@@ -1,0 +1,59 @@
+import time
+
+from pulsar import (
+    Client,
+    ConsumerDeadLetterPolicy,
+    ConsumerType
+)
+
+from _pulsar import ProducerConfiguration, ConsumerConfiguration, RegexSubscriptionMode
+
+# Configuration Variables
+service_url = 'pulsar://localhost:6650'
+topic_name = 'persistent://public/default/my-topic'
+subscription_name = 'my-subscription'
+dlq_topic_name = 'persistent://public/default/my-topic-dlq'
+
+# Create a client
+client = Client(service_url)
+
+# Create a producer
+producer = client.create_producer(topic_name)
+
+max_redeliver_count = 3
+
+dlq_policy = ConsumerDeadLetterPolicy(max_redeliver_count=max_redeliver_count,  
+                                     initial_subscription_name="dlq-listener")
+
+# Create a consumer with a dead letter policy
+consumer = client.subscribe(topic_name, subscription_name,
+                            dead_letter_policy=dlq_policy,
+                            negative_ack_redelivery_delay_ms=1000,  # Redelivery delay
+                            consumer_type=ConsumerType.Shared)
+
+
+# Sen num msgs.
+producer = client.create_producer(topic_name)
+properties = {
+    'property_1': 'value_1',
+    'property_2': 'value_2'
+}
+num = 10
+for i in range(num):
+    producer.send(("hello-%d" % i).encode('utf-8'), properties=properties)
+producer.flush()
+
+# Redeliver all messages maxRedeliverCountNum time.
+for i in range(1, num * max_redeliver_count + num + 1):
+    msg = consumer.receive()
+    if i % num == 0:
+        consumer.redeliver_unacknowledged_messages()
+        print(f"Start redeliver msgs '{i}'")
+
+# Messages should be in DLQ
+try :
+    consumer.receive(100)
+except Exception as e:
+    print(f"Exception: {e}")
+
+print("Script completed.")

--- a/langstream-agents/langstream-agent-pulsardlq/pom.xml
+++ b/langstream-agents/langstream-agent-pulsardlq/pom.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright DataStax, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>ai.langstream</groupId>
+    <artifactId>langstream-agents</artifactId>
+    <version>0.6.1-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>langstream-agent-pulsardlq</artifactId>
+  <packaging>jar</packaging>
+  <name>LangStream - Pulsar DLQ Agent</name>
+  <properties>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
+    <pulsar.version>3.2.2</pulsar.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.pulsar</groupId>
+      <artifactId>pulsar-client</artifactId>
+      <version>${pulsar.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.pulsar</groupId>
+      <artifactId>pulsar-client-admin</artifactId>
+      <version>${pulsar.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>langstream-api</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+    </dependency>
+    		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>pulsar</artifactId>
+			<scope>test</scope>
+		</dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.nifi</groupId>
+        <artifactId>nifi-nar-maven-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <classifier>nar</classifier>
+        </configuration>
+        <executions>
+          <execution>
+            <id>default-nar</id>
+            <phase>package</phase>
+            <goals>
+              <goal>nar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/langstream-agents/langstream-agent-pulsardlq/src/main/java/ai/langstream/agents/pulsardlq/PulsarDLQSource.java
+++ b/langstream-agents/langstream-agent-pulsardlq/src/main/java/ai/langstream/agents/pulsardlq/PulsarDLQSource.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.agents.pulsardlq;
+
+import ai.langstream.api.runner.code.AbstractAgentCode;
+import ai.langstream.api.runner.code.AgentSource;
+import ai.langstream.api.runner.code.Header;
+import ai.langstream.api.runner.code.Record;
+import ai.langstream.api.util.ConfigurationUtils;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.PulsarClient;
+
+@Slf4j
+public class PulsarDLQSource extends AbstractAgentCode implements AgentSource {
+    private String pulsarUrl;
+    private String namespace;
+    private String subscription;
+    private PulsarClient pulsarClient;
+    private Consumer<byte[]> dlqTopicsConsumer;
+
+    private static class SimpleHeader implements Header {
+        private final String key;
+        private final Object value;
+
+        public SimpleHeader(String key, Object value) {
+            this.key = key;
+            this.value = value;
+        }
+
+        @Override
+        public String key() {
+            return key;
+        }
+
+        @Override
+        public Object value() {
+            return value;
+        }
+
+        @Override
+        public String valueAsString() {
+            if (value != null) {
+                return value.toString();
+            } else {
+                return null;
+            }
+        }
+    }
+
+    private static class PulsarRecord implements Record {
+        private final Message<byte[]> message;
+
+        public PulsarRecord(Message<byte[]> message) {
+            this.message = message;
+        }
+
+        @Override
+        public Object key() {
+            return new String(message.getKey());
+        }
+
+        @Override
+        public Object value() {
+            return message.getData();
+        }
+
+        public MessageId messageId() {
+            return message.getMessageId();
+        }
+
+        @Override
+        public String origin() {
+            return message.getTopicName(); // Static or derived from message properties
+        }
+
+        @Override
+        public Long timestamp() {
+            return message.getPublishTime(); // Using publish time as timestamp
+        }
+
+        @Override
+        public Collection<Header> headers() {
+            Collection<Header> headers = new ArrayList<>();
+            Map<String, String> properties = message.getProperties();
+
+            if (properties != null) {
+                for (Map.Entry<String, String> entry : properties.entrySet()) {
+                    headers.add(new SimpleHeader(entry.getKey(), entry.getValue()));
+                }
+            }
+            return headers;
+        }
+
+        @Override
+        public String toString() {
+            return "PulsarRecord{"
+                    + "key="
+                    + key()
+                    + ", value="
+                    + value()
+                    + ", headers="
+                    + headers()
+                    + '}';
+        }
+    }
+
+    @Override
+    public void init(Map<String, Object> configuration) throws Exception {
+        pulsarUrl = ConfigurationUtils.getString("pulsar-url", "", configuration);
+        namespace = ConfigurationUtils.getString("namespace", "", configuration);
+        subscription = ConfigurationUtils.getString("subscription", "", configuration);
+
+        log.info("Initializing PulsarDLQSource with pulsarUrl: {}", pulsarUrl);
+        log.info("Namespace: {}", namespace);
+        log.info("Subscription: {}", subscription);
+    }
+
+    @Override
+    public void start() throws Exception {
+        pulsarClient = PulsarClient.builder().serviceUrl(pulsarUrl).build();
+        Pattern dlqTopicsInNamespace = Pattern.compile("persistent://" + namespace + "/.*-DLQ");
+
+        dlqTopicsConsumer =
+                pulsarClient
+                        .newConsumer()
+                        .topicsPattern(dlqTopicsInNamespace)
+                        .subscriptionName(subscription)
+                        .subscribe();
+    }
+
+    @Override
+    public void close() throws Exception {
+        dlqTopicsConsumer.close();
+        pulsarClient.close();
+    }
+
+    @Override
+    public List<Record> read() throws Exception {
+
+        Message<byte[]> msg = dlqTopicsConsumer.receive();
+
+        log.info("Received message: {}", new String(msg.getData()));
+        Record record = new PulsarRecord(msg);
+        return List.of(record);
+    }
+
+    @Override
+    public void commit(List<Record> records) throws Exception {
+        for (Record r : records) {
+            PulsarRecord record = (PulsarRecord) r;
+            dlqTopicsConsumer.acknowledge(record.messageId()); // acknowledge the message
+        }
+    }
+
+    @Override
+    public void permanentFailure(Record record, Exception error) throws Exception {
+        PulsarRecord pulsarRecord = (PulsarRecord) record;
+        log.error("Failure on record {}", pulsarRecord, error);
+        dlqTopicsConsumer.negativeAcknowledge(pulsarRecord.messageId());
+    }
+}

--- a/langstream-agents/langstream-agent-pulsardlq/src/main/java/ai/langstream/agents/pulsardlq/PulsarDLQSource.java
+++ b/langstream-agents/langstream-agent-pulsardlq/src/main/java/ai/langstream/agents/pulsardlq/PulsarDLQSource.java
@@ -36,6 +36,7 @@ public class PulsarDLQSource extends AbstractAgentCode implements AgentSource {
     private String pulsarUrl;
     private String namespace;
     private String subscription;
+    private String dlqSuffix;
     private PulsarClient pulsarClient;
     private Consumer<byte[]> dlqTopicsConsumer;
 
@@ -77,7 +78,7 @@ public class PulsarDLQSource extends AbstractAgentCode implements AgentSource {
 
         @Override
         public Object key() {
-            return new String(message.getKey());
+            return message.getKey();
         }
 
         @Override
@@ -130,16 +131,18 @@ public class PulsarDLQSource extends AbstractAgentCode implements AgentSource {
         pulsarUrl = ConfigurationUtils.getString("pulsar-url", "", configuration);
         namespace = ConfigurationUtils.getString("namespace", "", configuration);
         subscription = ConfigurationUtils.getString("subscription", "", configuration);
-
+        dlqSuffix = ConfigurationUtils.getString("dlq-suffix", "-DLQ", configuration);
         log.info("Initializing PulsarDLQSource with pulsarUrl: {}", pulsarUrl);
         log.info("Namespace: {}", namespace);
         log.info("Subscription: {}", subscription);
+        log.info("DLQ Suffix: {}", dlqSuffix);
     }
 
     @Override
     public void start() throws Exception {
         pulsarClient = PulsarClient.builder().serviceUrl(pulsarUrl).build();
-        Pattern dlqTopicsInNamespace = Pattern.compile("persistent://" + namespace + "/.*-DLQ");
+        Pattern dlqTopicsInNamespace =
+                Pattern.compile("persistent://" + namespace + "/.*" + dlqSuffix);
 
         dlqTopicsConsumer =
                 pulsarClient

--- a/langstream-agents/langstream-agent-pulsardlq/src/main/java/ai/langstream/agents/pulsardlq/PulsarDLQSourceAgentCodeProvider.java
+++ b/langstream-agents/langstream-agent-pulsardlq/src/main/java/ai/langstream/agents/pulsardlq/PulsarDLQSourceAgentCodeProvider.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.agents.pulsardlq;
+
+import ai.langstream.api.runner.code.AgentCode;
+import ai.langstream.api.runner.code.AgentCodeProvider;
+
+public class PulsarDLQSourceAgentCodeProvider implements AgentCodeProvider {
+    @Override
+    public boolean supports(String agentType) {
+        return "pulsar-dlq-source".equals(agentType);
+    }
+
+    @Override
+    public AgentCode createInstance(String agentType) {
+        return new PulsarDLQSource();
+    }
+}

--- a/langstream-agents/langstream-agent-pulsardlq/src/main/java/ai/langstream/agents/pulsardlq/PulsarDLQSourceAgentCodeProvider.java
+++ b/langstream-agents/langstream-agent-pulsardlq/src/main/java/ai/langstream/agents/pulsardlq/PulsarDLQSourceAgentCodeProvider.java
@@ -21,7 +21,7 @@ import ai.langstream.api.runner.code.AgentCodeProvider;
 public class PulsarDLQSourceAgentCodeProvider implements AgentCodeProvider {
     @Override
     public boolean supports(String agentType) {
-        return "pulsar-dlq-source".equals(agentType);
+        return "pulsardlq-source".equals(agentType);
     }
 
     @Override

--- a/langstream-agents/langstream-agent-pulsardlq/src/main/resources/META-INF/ai.langstream.agents.index
+++ b/langstream-agents/langstream-agent-pulsardlq/src/main/resources/META-INF/ai.langstream.agents.index
@@ -1,1 +1,1 @@
-pulsar-dlq-source
+pulsardlq-source

--- a/langstream-agents/langstream-agent-pulsardlq/src/main/resources/META-INF/ai.langstream.agents.index
+++ b/langstream-agents/langstream-agent-pulsardlq/src/main/resources/META-INF/ai.langstream.agents.index
@@ -1,0 +1,1 @@
+pulsar-dlq-source

--- a/langstream-agents/langstream-agent-pulsardlq/src/main/resources/META-INF/services/ai.langstream.api.runner.code.AgentCodeProvider
+++ b/langstream-agents/langstream-agent-pulsardlq/src/main/resources/META-INF/services/ai.langstream.api.runner.code.AgentCodeProvider
@@ -1,0 +1,1 @@
+ai.langstream.agents.pulsardlq.PulsarDLQSourceAgentCodeProvider

--- a/langstream-agents/langstream-agent-pulsardlq/src/test/java/ai/langstream/agents/pulsardlq/PulsarContainerExtension.java
+++ b/langstream-agents/langstream-agent-pulsardlq/src/test/java/ai/langstream/agents/pulsardlq/PulsarContainerExtension.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.agents.pulsardlq;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.PulsarContainer;
+import org.testcontainers.utility.DockerImageName;
+
+@Slf4j
+public class PulsarContainerExtension implements BeforeAllCallback, AfterAllCallback {
+    private PulsarContainer pulsarContainer;
+
+    private Network network;
+
+    private PulsarAdmin admin;
+    private PulsarClient client;
+
+    @Override
+    public void afterAll(ExtensionContext extensionContext) throws PulsarClientException {
+        if (client != null) {
+            client.close();
+        }
+        if (admin != null) {
+            admin.close();
+        }
+        if (pulsarContainer != null) {
+            pulsarContainer.close();
+        }
+        if (network != null) {
+            network.close();
+        }
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext extensionContext)
+            throws PulsarClientException, PulsarAdminException {
+        network = Network.newNetwork();
+        pulsarContainer =
+                new PulsarContainer(DockerImageName.parse("apachepulsar/pulsar:3.1.0"))
+                        .withNetwork(network)
+                        .withLogConsumer(
+                                outputFrame ->
+                                        log.debug(
+                                                "pulsar> {}", outputFrame.getUtf8String().trim()));
+        // start Pulsar and wait for it to be ready to accept requests
+        pulsarContainer.start();
+
+        admin =
+                PulsarAdmin.builder()
+                        .serviceHttpUrl("http://localhost:" + pulsarContainer.getMappedPort(8080))
+                        .build();
+
+        client = PulsarClient.builder().serviceUrl(pulsarContainer.getPulsarBrokerUrl()).build();
+
+        try {
+            admin.namespaces().createNamespace("public/default");
+        } catch (PulsarAdminException.ConflictException exists) {
+            // ignore
+        }
+    }
+
+    public String getBrokerUrl() {
+        return pulsarContainer.getPulsarBrokerUrl();
+    }
+
+    public String getHttpServiceUrl() {
+        return pulsarContainer.getHttpServiceUrl();
+    }
+
+    public PulsarContainer getPulsarContainer() {
+        return pulsarContainer;
+    }
+
+    public PulsarAdmin getAdmin() {
+        return admin;
+    }
+
+    public PulsarClient getClient() {
+        return client;
+    }
+}

--- a/langstream-agents/langstream-agent-pulsardlq/src/test/java/ai/langstream/agents/pulsardlq/PulsarDLQSourceTest.java
+++ b/langstream-agents/langstream-agent-pulsardlq/src/test/java/ai/langstream/agents/pulsardlq/PulsarDLQSourceTest.java
@@ -1,0 +1,362 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.agents.pulsardlq;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import ai.langstream.api.runner.code.AgentCodeRegistry;
+import ai.langstream.api.runner.code.AgentContext;
+import ai.langstream.api.runner.code.AgentSource;
+import ai.langstream.api.runner.code.MetricsReporter;
+import ai.langstream.api.runner.code.Record;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.TypedMessageBuilder;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Slf4j
+@Testcontainers
+public class PulsarDLQSourceTest {
+
+    private static final AgentCodeRegistry AGENT_CODE_REGISTRY = new AgentCodeRegistry();
+    private static final int DEFAULT_MAX_RETRIES = 5;
+    private static final long DEFAULT_RETRY_INTERVAL_MS = 2000;
+
+    @RegisterExtension
+    static PulsarContainerExtension pulsarContainer = new PulsarContainerExtension();
+
+    @BeforeAll
+    static void setup() {}
+
+    @Test
+    void testReadDLQ() throws Exception {
+
+        pulsarContainer
+                .getAdmin()
+                .topics()
+                .createNonPartitionedTopic("public/default/test-topic-DLQ");
+
+        AgentSource agentSource =
+                buildAgentSource(
+                        pulsarContainer.getBrokerUrl(), "public/default", "dlq-subscription");
+
+        Producer producer =
+                pulsarContainer
+                        .getClient()
+                        .newProducer()
+                        .topic("persistent://public/default/test-topic-DLQ")
+                        .create();
+
+        TypedMessageBuilder<byte[]> messageBuilder =
+                producer.newMessage()
+                        .key("message-key") // e
+                        .value("test-message-1".getBytes());
+
+        // Adding properties to the message
+        messageBuilder.property("property1", "value1");
+        messageBuilder.property("property2", "value2");
+
+        // Send the message
+        messageBuilder.send();
+
+        Awaitility.await()
+                .untilAsserted(
+                        () -> {
+                            List<Record> read = agentSource.read();
+                            assertEquals(1, read.size());
+                            // Verify the message
+                            assertEquals(
+                                    "test-message-1",
+                                    new String(
+                                            (byte[]) read.get(0).value(), StandardCharsets.UTF_8));
+                            // Verify the key
+                            assertEquals("message-key", read.get(0).key());
+                            // Verify the properties
+                            assertEquals(
+                                    "value1", read.get(0).getHeader("property1").valueAsString());
+                            assertEquals(
+                                    "value2", read.get(0).getHeader("property2").valueAsString());
+                            // Verify the origin is the DLQ topic
+                            assertEquals(
+                                    "persistent://public/default/test-topic-DLQ",
+                                    read.get(0).origin());
+                            // Commiting the message means it gets acknowledged and removed from the
+                            // DLQ
+                            agentSource.commit(read);
+                        });
+
+        messageBuilder =
+                producer.newMessage()
+                        .key("message-key") // e
+                        .value("test-message-2".getBytes());
+
+        // Adding properties to the message
+        messageBuilder.property("property1", "value1");
+        messageBuilder.property("property2", "value2");
+
+        messageBuilder.send();
+
+        Awaitility.await()
+                .untilAsserted(
+                        () -> {
+                            List<Record> read = agentSource.read();
+                            assertEquals(1, read.size());
+                            assertEquals(
+                                    "test-message-2",
+                                    new String(
+                                            (byte[]) read.get(0).value(), StandardCharsets.UTF_8));
+                            // Verify the key
+                            assertEquals("message-key", read.get(0).key());
+                            // Verify the properties
+                            assertEquals(
+                                    "value1", read.get(0).getHeader("property1").valueAsString());
+                            assertEquals(
+                                    "value2", read.get(0).getHeader("property2").valueAsString());
+                            // Verify the origin is the DLQ topic
+                            assertEquals(
+                                    "persistent://public/default/test-topic-DLQ",
+                                    read.get(0).origin());
+                            // Not commiting the message means it stays in the DLQ
+                        });
+
+        // Close the agent so we can connect on its subscription
+        agentSource.close();
+
+        // Consume a message from the DLQ
+        Consumer pulsarConsumer =
+                pulsarContainer
+                        .getClient()
+                        .newConsumer()
+                        .topic("test-topic-DLQ")
+                        .subscriptionName("dlq-subscription")
+                        .subscribe();
+
+        Message msg = pulsarConsumer.receive();
+
+        // This should be the second message because the first one was committed
+        assertEquals("test-message-2", new String(msg.getData()));
+        pulsarConsumer.close();
+        producer.close();
+        Thread.sleep(1000);
+        deleteTopicsWithRetries(new String[] {"persistent://public/default/test-topic-DLQ"});
+    }
+
+    @Test
+    void testReadMultipleDLQ() throws Exception {
+        pulsarContainer
+                .getAdmin()
+                .topics()
+                .createNonPartitionedTopic("public/default/test-topic2-DLQ");
+
+        AgentSource agentSource =
+                buildAgentSource(
+                        pulsarContainer.getBrokerUrl(), "public/default", "dlq-subscription");
+
+        Producer producer =
+                pulsarContainer
+                        .getClient()
+                        .newProducer()
+                        .topic("persistent://public/default/test-topic2-DLQ")
+                        .create();
+
+        TypedMessageBuilder<byte[]> messageBuilder =
+                producer.newMessage()
+                        .key("message-key") // e
+                        .value("test-message-1".getBytes());
+
+        // Adding properties to the message
+        messageBuilder.property("property1", "value1");
+        messageBuilder.property("property2", "value2");
+
+        // Send the message
+        messageBuilder.send();
+
+        Awaitility.await()
+                .untilAsserted(
+                        () -> {
+                            List<Record> read = agentSource.read();
+                            assertEquals(1, read.size());
+                            // Verify the message
+                            assertEquals(
+                                    "test-message-1",
+                                    new String(
+                                            (byte[]) read.get(0).value(), StandardCharsets.UTF_8));
+                            // Verify the key
+                            assertEquals("message-key", read.get(0).key());
+                            // Verify the properties
+                            assertEquals(
+                                    "value1", read.get(0).getHeader("property1").valueAsString());
+                            assertEquals(
+                                    "value2", read.get(0).getHeader("property2").valueAsString());
+                            // Verify the origin is the DLQ topic
+                            assertEquals(
+                                    "persistent://public/default/test-topic2-DLQ",
+                                    read.get(0).origin());
+                            // Commiting the message means it gets acknowledged and removed from the
+                            // DLQ
+                            agentSource.commit(read);
+                        });
+        pulsarContainer
+                .getAdmin()
+                .topics()
+                .createNonPartitionedTopic("public/default/test-topic3-DLQ");
+
+        Thread.sleep(2000);
+
+        producer =
+                pulsarContainer
+                        .getClient()
+                        .newProducer()
+                        .topic("persistent://public/default/test-topic3-DLQ")
+                        .create();
+
+        messageBuilder =
+                producer.newMessage()
+                        .key("message-key") // e
+                        .value("test-message-2".getBytes());
+
+        // Adding properties to the message
+        messageBuilder.property("property1", "value1");
+        messageBuilder.property("property2", "value2");
+
+        messageBuilder.send();
+
+        Awaitility.await()
+                .untilAsserted(
+                        () -> {
+                            List<Record> read = agentSource.read();
+                            assertEquals(1, read.size());
+                            assertEquals(
+                                    "test-message-2",
+                                    new String(
+                                            (byte[]) read.get(0).value(), StandardCharsets.UTF_8));
+                            // Verify the key
+                            assertEquals("message-key", read.get(0).key());
+                            // Verify the properties
+                            assertEquals(
+                                    "value1", read.get(0).getHeader("property1").valueAsString());
+                            assertEquals(
+                                    "value2", read.get(0).getHeader("property2").valueAsString());
+                            // Verify the origin is the DLQ topic
+                            assertEquals(
+                                    "persistent://public/default/test-topic3-DLQ",
+                                    read.get(0).origin());
+                            // Commiting the message
+                            agentSource.commit(read);
+                        });
+
+        // Close the agent so we can connect on its subscription
+        agentSource.close();
+
+        // Consume a message from the DLQ
+        Consumer pulsarConsumer =
+                pulsarContainer
+                        .getClient()
+                        .newConsumer()
+                        .topic("test-topic3-DLQ")
+                        .subscriptionName("dlq-subscription")
+                        .subscribe();
+
+        Message msg = pulsarConsumer.receive(2, TimeUnit.SECONDS);
+        // Verify there is no message
+        assertEquals(null, msg);
+        pulsarConsumer.close();
+        producer.close();
+
+        deleteTopicsWithRetries(
+                new String[] {
+                    "persistent://public/default/test-topic2-DLQ",
+                    "persistent://public/default/test-topic3-DLQ"
+                });
+    }
+
+    private AgentSource buildAgentSource(String url, String namespace, String subscription)
+            throws Exception {
+        AgentSource agentSource =
+                (AgentSource) AGENT_CODE_REGISTRY.getAgentCode("pulsar-dlq-source").agentCode();
+        Map<String, Object> configs = new HashMap<>();
+        configs.put("pulsar-url", url);
+        configs.put("namespace", namespace);
+        configs.put("subscription", subscription);
+        AgentContext agentContext = mock(AgentContext.class);
+        when(agentContext.getMetricsReporter()).thenReturn(MetricsReporter.DISABLED);
+        agentSource.init(configs);
+        agentSource.setContext(agentContext);
+        agentSource.start();
+        return agentSource;
+    }
+
+    public void deleteTopicsWithRetries(String[] topics) {
+        deleteTopicsWithRetries(topics, DEFAULT_MAX_RETRIES, DEFAULT_RETRY_INTERVAL_MS);
+    }
+
+    /**
+     * Attempts to delete the specified topics, retrying up to a maximum number of times.
+     *
+     * @param topics An array of topic names to delete.
+     * @param maxAttempts The maximum number of attempts to delete the topics.
+     * @param sleepInterval The time in milliseconds to wait between attempts.
+     */
+    public void deleteTopicsWithRetries(String[] topics, int maxAttempts, long sleepInterval) {
+        int attempt = 0;
+
+        while (attempt < maxAttempts) {
+            try {
+                // Attempt to delete each topic
+                for (String topic : topics) {
+                    pulsarContainer.getAdmin().topics().delete(topic);
+                }
+                System.out.println("Successfully deleted all topics.");
+                break; // Exit the loop if deletion is successful
+            } catch (Exception e) {
+                attempt++; // Increment attempt count
+                if (attempt >= maxAttempts) {
+                    System.err.println(
+                            "Failed to delete topics after " + maxAttempts + " attempts");
+                    e.printStackTrace();
+                    break; // Exit if maximum attempts are reached
+                } else {
+                    System.out.println(
+                            "Attempt "
+                                    + attempt
+                                    + " failed, retrying in "
+                                    + sleepInterval
+                                    + "ms...");
+                    try {
+                        Thread.sleep(sleepInterval); // Sleep before retrying
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt(); // Restore interrupted status
+                        System.err.println("Thread interrupted during sleep between retries.");
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/langstream-agents/langstream-agent-pulsardlq/src/test/resources/logback-test.xml
+++ b/langstream-agents/langstream-agent-pulsardlq/src/test/resources/logback-test.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+    Copyright DataStax, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<!DOCTYPE configuration>
+<configuration>
+    <import class="ch.qos.logback.classic.encoder.PatternLayoutEncoder"/>
+    <import class="ch.qos.logback.core.ConsoleAppender"/>
+
+    <appender name="STDOUT" class="ConsoleAppender">
+        <encoder class="PatternLayoutEncoder">
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} -%kvp- %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/langstream-agents/pom.xml
+++ b/langstream-agents/pom.xml
@@ -36,6 +36,7 @@
         <module>langstream-agent-grpc</module>
         <module>langstream-agent-s3</module>
         <module>langstream-agent-camel</module>
+        <module>langstream-agent-pulsardlq</module>
         <module>langstream-agent-webcrawler</module>
         <module>langstream-agents-text-processing</module>
         <module>langstream-ai-agents</module>

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/PulsarDLQSourceAgentProvider.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/PulsarDLQSourceAgentProvider.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.runtime.impl.k8s.agents;
+
+import ai.langstream.api.doc.AgentConfig;
+import ai.langstream.api.doc.ConfigProperty;
+import ai.langstream.api.model.AgentConfiguration;
+import ai.langstream.api.runtime.ComponentType;
+import ai.langstream.impl.agents.AbstractComposableAgentProvider;
+import ai.langstream.runtime.impl.k8s.KubernetesClusterRuntime;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import java.util.Set;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+
+/** Implements support for Apache Camel based Source Agents. */
+@Slf4j
+public class PulsarDLQSourceAgentProvider extends AbstractComposableAgentProvider {
+
+    protected static final String PULSAR_DLQ_SOURCE = "pulsar-dlq-source";
+
+    public PulsarDLQSourceAgentProvider() {
+        super(Set.of(PULSAR_DLQ_SOURCE), List.of(KubernetesClusterRuntime.CLUSTER_TYPE, "none"));
+    }
+
+    @Override
+    protected final ComponentType getComponentType(AgentConfiguration agentConfiguration) {
+        return ComponentType.SOURCE;
+    }
+
+    @Override
+    protected Class getAgentConfigModelClass(String type) {
+        return PulsarDLQSourceConfiguration.class;
+    }
+
+    @AgentConfig(
+            name = "Pulsar DLQ Source",
+            description = "Listen to all DLQ topics in a namespace in Pulsar")
+    @Data
+    public static class PulsarDLQSourceConfiguration {
+
+        @ConfigProperty(
+                description =
+                        """
+                        The URL of the Pulsar cluster to connect to.
+                        """,
+                defaultValue = "pulsar://localhost:6650",
+                required = true)
+        @JsonProperty("pulsar-url")
+        private String pulsarUrl;
+
+        @ConfigProperty(
+                description =
+                        """
+                        Namespace to listen for DLQ topics.
+                        """,
+                defaultValue = "public/default",
+                required = true)
+        @JsonProperty("namespace")
+        private String namespace;
+
+        @ConfigProperty(
+                description =
+                        """
+                        Subscription name to use for the DLQ topics.
+                        """,
+                defaultValue = "langstream-dlq-subscription",
+                required = true)
+        @JsonProperty("subscription")
+        private String subscription;
+    }
+}

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/PulsarDLQSourceAgentProvider.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/PulsarDLQSourceAgentProvider.java
@@ -31,7 +31,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class PulsarDLQSourceAgentProvider extends AbstractComposableAgentProvider {
 
-    protected static final String PULSAR_DLQ_SOURCE = "pulsar-dlq-source";
+    protected static final String PULSAR_DLQ_SOURCE = "pulsardlq-source";
 
     public PulsarDLQSourceAgentProvider() {
         super(Set.of(PULSAR_DLQ_SOURCE), List.of(KubernetesClusterRuntime.CLUSTER_TYPE, "none"));
@@ -82,5 +82,15 @@ public class PulsarDLQSourceAgentProvider extends AbstractComposableAgentProvide
                 required = true)
         @JsonProperty("subscription")
         private String subscription;
+
+        @ConfigProperty(
+                description =
+                        """
+                        Suffix to use for DLQ topics.
+                        """,
+                defaultValue = "-DLQ",
+                required = true)
+        @JsonProperty("dlq-suffix")
+        private String dlqSuffix;
     }
 }

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/resources/META-INF/services/ai.langstream.api.runtime.AgentNodeProvider
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/resources/META-INF/services/ai.langstream.api.runtime.AgentNodeProvider
@@ -13,3 +13,5 @@ ai.langstream.runtime.impl.k8s.agents.FlowControlAgentsProvider
 ai.langstream.runtime.impl.k8s.agents.FlareControllerAgentProvider
 ai.langstream.runtime.impl.k8s.agents.HttpRequestAgentProvider
 ai.langstream.runtime.impl.k8s.agents.CamelSourceAgentProvider
+ai.langstream.runtime.impl.k8s.agents.PulsarDLQSourceAgentProvider
+

--- a/langstream-runtime/langstream-runtime-impl/pom.xml
+++ b/langstream-runtime/langstream-runtime-impl/pom.xml
@@ -279,6 +279,13 @@
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>langstream-agent-pulsardlq</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
     
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -561,6 +568,16 @@
                 <artifactItem>
                   <groupId>${project.groupId}</groupId>
                   <artifactId>langstream-agent-camel</artifactId>
+                  <version>${project.version}</version>
+                  <type>nar</type>
+                  <classifier>nar</classifier>
+                  <overWrite>false</overWrite>
+                  <outputDirectory>${project.build.directory}/agents</outputDirectory>
+                </artifactItem>
+
+                <artifactItem>
+                  <groupId>${project.groupId}</groupId>
+                  <artifactId>langstream-agent-pulsardlq</artifactId>
                   <version>${project.version}</version>
                   <type>nar</type>
                   <classifier>nar</classifier>

--- a/langstream-runtime/langstream-runtime-tester/pom.xml
+++ b/langstream-runtime/langstream-runtime-tester/pom.xml
@@ -192,8 +192,8 @@
                     <goal>download-single</goal>
                 </goals>
                 <configuration>
-                    <url>https://downloads.apache.org</url>
-                    <fromFile>pulsar/pulsar-3.1.3/apache-pulsar-3.1.3-bin.tar.gz</fromFile>
+                    <url>https://archive.apache.org</url>
+                    <fromFile>dist/pulsar/pulsar-3.2.2/apache-pulsar-3.2.2-bin.tar.gz</fromFile>
                     <toDir>${project.build.directory}/pulsar</toDir>
                     <skipIfExists>true</skipIfExists>
                 </configuration>

--- a/langstream-runtime/langstream-runtime-tester/src/main/docker/Dockerfile
+++ b/langstream-runtime/langstream-runtime-tester/src/main/docker/Dockerfile
@@ -23,7 +23,7 @@ USER 0
 ADD maven/minio /minio/minio
 ADD maven/herddb-services-0.28.0.zip /herddb/herddb-services-0.28.0.zip
 COPY maven/kafka_2.13-3.5.2.tgz /kafka/kafka.tgz
-COPY maven/apache-pulsar-3.1.3-bin.tar.gz /pulsar/pulsar.tar.gz
+COPY maven/apache-pulsar-3.2.2-bin.tar.gz /pulsar/pulsar.tar.gz
 
 
 RUN chmod -R g+w /kafka \

--- a/pom.xml
+++ b/pom.xml
@@ -663,7 +663,7 @@
         <configuration>
           <licenseSets>
             <licenseSet>
-              <header>./license-header.txt</header>
+              <header>${maven.multiModuleProjectDirectory}/license-header.txt</header>
               <excludes>
                 <exclude>LICENSE</exclude>
                 <exclude>**/langstream</exclude>


### PR DESCRIPTION
The source listens to all DLQ topics in a namespace and emits records when new messages are published to those DLQ topics. 

When running pipelines on Pulsar, it can be used to monitor for DLQ events which can be used to notify users of errors in the pipelines.

This PR also enhances the LangStream DLQ functionality by adding the error message as a property (`error-msg`) to the record. 