### PR TITLE
s3 code storage: retry on connection failures

### DIFF
--- a/langstream-agents/langstream-agent-camel/pom.xml
+++ b/langstream-agents/langstream-agent-camel/pom.xml
@@ -98,6 +98,10 @@
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/langstream-agents/langstream-agent-camel/pom.xml
+++ b/langstream-agents/langstream-agent-camel/pom.xml
@@ -96,6 +96,7 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
   <build>

--- a/langstream-agents/langstream-agent-camel/src/main/java/ai/langstream/agents/camel/CamelSource.java
+++ b/langstream-agents/langstream-agent-camel/src/main/java/ai/langstream/agents/camel/CamelSource.java
@@ -21,6 +21,8 @@ import ai.langstream.api.runner.code.Header;
 import ai.langstream.api.runner.code.Record;
 import ai.langstream.api.runner.code.SimpleRecord;
 import ai.langstream.api.util.ConfigurationUtils;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -35,9 +37,6 @@ import org.apache.camel.Message;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.support.AsyncProcessorSupport;
-import org.jetbrains.annotations.Nullable;
-import org.testcontainers.shaded.com.fasterxml.jackson.core.JsonProcessingException;
-import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 
 @Slf4j
 public class CamelSource extends AbstractAgentCode implements AgentSource {
@@ -153,7 +152,6 @@ public class CamelSource extends AbstractAgentCode implements AgentSource {
             return true;
         }
 
-        @Nullable
         private static Object safeObject(Object v) throws JsonProcessingException {
             Object converted;
             if (v == null) {

--- a/langstream-agents/langstream-agent-pulsardlq/pom.xml
+++ b/langstream-agents/langstream-agent-pulsardlq/pom.xml
@@ -76,6 +76,7 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>

--- a/langstream-agents/langstream-agent-pulsardlq/pom.xml
+++ b/langstream-agents/langstream-agent-pulsardlq/pom.xml
@@ -77,11 +77,11 @@
       <groupId>org.testcontainers</groupId>
       <artifactId>junit-jupiter</artifactId>
     </dependency>
-    		<dependency>
-			<groupId>org.testcontainers</groupId>
-			<artifactId>pulsar</artifactId>
-			<scope>test</scope>
-		</dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>pulsar</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/langstream-agents/langstream-agent-s3/pom.xml
+++ b/langstream-agents/langstream-agent-s3/pom.xml
@@ -77,10 +77,12 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>localstack</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
   <build>

--- a/langstream-agents/langstream-agent-webcrawler/pom.xml
+++ b/langstream-agents/langstream-agent-webcrawler/pom.xml
@@ -78,10 +78,12 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>localstack</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.github.tomakehurst</groupId>

--- a/langstream-codestorage-providers/langstream-codestorage-s3/pom.xml
+++ b/langstream-codestorage-providers/langstream-codestorage-s3/pom.xml
@@ -57,6 +57,7 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/langstream-codestorage-providers/langstream-codestorage-s3/pom.xml
+++ b/langstream-codestorage-providers/langstream-codestorage-s3/pom.xml
@@ -49,6 +49,15 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>localstack</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/langstream-codestorage-providers/langstream-codestorage-s3/src/test/java/ai/langstream/impl/storage/k8s/codestorage/S3CodeStorageTest.java
+++ b/langstream-codestorage-providers/langstream-codestorage-s3/src/test/java/ai/langstream/impl/storage/k8s/codestorage/S3CodeStorageTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.impl.storage.k8s.codestorage;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.testcontainers.containers.localstack.LocalStackContainer.Service.S3;
+
+import ai.langstream.api.codestorage.*;
+import io.minio.BucketExistsArgs;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers
+class S3CodeStorageTest {
+
+    private static final DockerImageName localstackImage =
+            DockerImageName.parse("localstack/localstack:2.2.0");
+
+    @Container
+    private static final LocalStackContainer localstack =
+            new LocalStackContainer(localstackImage).withServices(S3);
+
+    @Test
+    void testConnection() throws Exception {
+
+        S3CodeStorage storage =
+                (S3CodeStorage)
+                        new S3CodeStorageProvider()
+                                .createImplementation(
+                                        "s3",
+                                        Map.of(
+                                                "type",
+                                                "s3",
+                                                "bucket-name",
+                                                "test-b",
+                                                "endpoint",
+                                                localstack.getEndpointOverride(S3).toString()));
+
+        CodeArchiveMetadata metadata =
+                storage.storeApplicationCode(
+                        "mytenant",
+                        "myapp",
+                        "001",
+                        new UploadableCodeArchive() {
+                            @Override
+                            public InputStream getData() throws IOException, CodeStorageException {
+                                return new ByteArrayInputStream("test".getBytes());
+                            }
+
+                            @Override
+                            public String getPyBinariesDigest() {
+                                return null;
+                            }
+
+                            @Override
+                            public String getJavaBinariesDigest() {
+                                return null;
+                            }
+                        });
+
+        assertEquals("myapp", metadata.applicationId());
+        assertEquals("mytenant", metadata.tenant());
+
+        storage.getMinioClient().bucketExists(BucketExistsArgs.builder().bucket("test-b").build());
+        storage.downloadApplicationCode(
+                metadata.tenant(),
+                metadata.codeStoreId(),
+                archive -> {
+                    try {
+                        assertEquals("test", new String(archive.getData()));
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+        storage.deleteApplication("mytenant", "myapp-001");
+
+        try {
+            storage.downloadApplicationCode(
+                    "mytenant",
+                    "myapp-001",
+                    archive -> {
+                        fail("Should not be able to download the archive");
+                    });
+            fail();
+        } catch (CodeStorageException ex) {
+            assertTrue(ex.getMessage().contains("Object does not exist"));
+        }
+    }
+}


### PR DESCRIPTION
As explained [here](https://github.com/square/okhttp/issues/2738), this seems a viable solution to fix this problem:

```
14:01:33.601 [http-nio-8090-exec-4] INFO  a.l.w.a.ApplicationResource -- Deleting temporary file /tmp/zip-extract1071380007255396661/extract-text.yaml
14:01:33.601 [http-nio-8090-exec-4] INFO  a.l.w.a.ApplicationResource -- Deleting temporary file /tmp/zip-extract1071380007255396661/configuration.yaml
14:01:33.602 [http-nio-8090-exec-4] INFO  a.l.w.a.ApplicationResource -- Deleting temporary file /tmp/zip-extract1071380007255396661/README.md
14:01:33.602 [http-nio-8090-exec-4] INFO  a.l.w.a.ApplicationResource -- Deleting temporary file /tmp/zip-extract1071380007255396661
14:01:33.606 [http-nio-8090-exec-4] ERROR a.l.w.common.ResourceErrorsHandler -- Bad request
java.lang.IllegalArgumentException: ai.langstream.api.codestorage.CodeStorageException: java.io.IOException: unexpected end of stream on https://vectorize-comparator-code-storage.s3.us-east-1.amazonaws.com/...
	at ai.langstream.webservice.application.ApplicationResource.lambda$parseApplicationInstance$2(ApplicationResource.java:250)
	at ai.langstream.webservice.application.ApplicationResource.withApplicationZip(ApplicationResource.java:266)
	at ai.langstream.webservice.application.ApplicationResource.parseApplicationInstance(ApplicationResource.java:221)
	at ai.langstream.webservice.application.ApplicationResource.updateApplication(ApplicationResource.java:195)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
	at java.base/java.lang.reflect.Method.invoke(Unknown Source)
	at org.springframework.web.method.support.InvocableHandlerMethod.doInvoke(InvocableHandlerMethod.java:207)
	at org.springframework.web.method.support.InvocableHandlerMethod.invokeForRequest(InvocableHandlerMethod.java:152)
	at org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod.invokeAndHandle(ServletInvocableHandlerMethod.java:118)
	at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.invokeHandlerMethod(RequestMappingHandlerAdapter.java:884)
	at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.handleInternal(RequestMappingHandlerAdapter.java:797)
	at org.springframework.web.servlet.mvc.method.AbstractHandlerMethodAdapter.handle(AbstractHandlerMethodAdapter.java:87)
	at org.springframework.web.servlet.DispatcherServlet.doDispatch(DispatcherServlet.java:1081)
	at org.springframework.web.servlet.DispatcherServlet.doService(DispatcherServlet.java:974)
	at org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:1011)
	at org.springframework.web.servlet.FrameworkServlet.service(FrameworkServlet.java:888)
	at jakarta.servlet.http.HttpServlet.service(HttpServlet.java:658)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:205)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:149)
	at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:51)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:174)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:149)
	at org.springframework.web.filter.CorsFilter.doFilterInternal(CorsFilter.java:91)
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:174)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:149)
	at org.springframework.security.web.ObservationFilterChainDecorator$FilterObservation$SimpleFilterObservation.lambda$wrap$1(ObservationFilterChainDecorator.java:425)
	at org.springframework.security.web.ObservationFilterChainDecorator.lambda$wrapUnsecured$1(ObservationFilterChainDecorator.java:86)
	at org.springframework.security.web.FilterChainProxy.doFilterInternal(FilterChainProxy.java:219)
	at org.springframework.security.web.FilterChainProxy.doFilter(FilterChainProxy.java:191)
	at org.springframework.web.filter.DelegatingFilterProxy.invokeDelegate(DelegatingFilterProxy.java:352)
	at org.springframework.web.filter.DelegatingFilterProxy.doFilter(DelegatingFilterProxy.java:268)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:174)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:149)
	at org.springframework.web.filter.RequestContextFilter.doFilterInternal(RequestContextFilter.java:100)
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:174)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:149)
	at org.springframework.web.filter.FormContentFilter.doFilterInternal(FormContentFilter.java:93)
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:174)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:149)
	at org.springframework.web.filter.ServerHttpObservationFilter.doFilterInternal(ServerHttpObservationFilter.java:109)
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:174)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:149)
	at org.springframework.web.filter.CharacterEncodingFilter.doFilterInternal(CharacterEncodingFilter.java:201)
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:174)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:149)
	at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:166)
	at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:90)
	at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:482)
	at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:115)
	at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:93)
	at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:74)
	at org.apache.catalina.valves.RemoteIpValve.invoke(RemoteIpValve.java:738)
	at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:341)
	at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:390)
	at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:63)
	at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:894)
	at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1741)
	at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:52)
	at org.apache.tomcat.util.threads.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1191)
	at org.apache.tomcat.util.threads.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:659)
	at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
	at java.base/java.lang.Thread.run(Unknown Source)
Caused by: ai.langstream.api.codestorage.CodeStorageException: java.io.IOException: unexpected end of stream on https://vectorize-comparator-code-storage.s3.us-east-1.amazonaws.com/...
	at ai.langstream.impl.storage.k8s.codestorage.S3CodeStorage.storeApplicationCode(S3CodeStorage.java:145)
	at ai.langstream.webservice.application.CodeStorageService.deployApplicationCodeStorage(CodeStorageService.java:57)
	at ai.langstream.webservice.application.ApplicationResource.lambda$parseApplicationInstance$2(ApplicationResource.java:235)
	... 68 common frames omitted
Caused by: java.io.IOException: unexpected end of stream on https://vectorize-comparator-code-storage.s3.us-east-1.amazonaws.com/...
	at okhttp3.internal.http1.Http1ExchangeCodec.readResponseHeaders(Http1ExchangeCodec.kt:210)
	at okhttp3.internal.connection.Exchange.readResponseHeaders(Exchange.kt:110)
	at okhttp3.internal.http.CallServerInterceptor.intercept(CallServerInterceptor.kt:93)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
	at okhttp3.internal.connection.ConnectInterceptor.intercept(ConnectInterceptor.kt:34)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
	at okhttp3.internal.cache.CacheInterceptor.intercept(CacheInterceptor.kt:95)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
	at okhttp3.internal.http.BridgeInterceptor.intercept(BridgeInterceptor.kt:83)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
	at okhttp3.internal.http.RetryAndFollowUpInterceptor.intercept(RetryAndFollowUpInterceptor.kt:76)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
	at okhttp3.internal.connection.RealCall.getResponseWithInterceptorChain$okhttp(RealCall.kt:201)
	at okhttp3.internal.connection.RealCall$AsyncCall.run(RealCall.kt:517)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	... 1 common frames omitted
Caused by: java.io.EOFException: \n not found: limit=0 content=…
	at okio.RealBufferedSource.readUtf8LineStrict(RealBufferedSource.kt:332)
	at okhttp3.internal.http1.HeadersReader.readLine(HeadersReader.kt:29)
	at okhttp3.internal.http1.Http1ExchangeCodec.readResponseHeaders(Http1ExchangeCodec.kt:180)
	... 16 common frames omitted
```