### PR TITLE
Refactor auto-upgrade to runtime-version

### DIFF
--- a/langstream-admin-client/src/main/java/ai/langstream/admin/client/AdminClient.java
+++ b/langstream-admin-client/src/main/java/ai/langstream/admin/client/AdminClient.java
@@ -243,7 +243,7 @@ public class AdminClient implements AutoCloseable {
     private class ApplicationsImpl implements Applications {
         @Override
         public String deploy(String application, MultiPartBodyPublisher multiPartBodyPublisher) {
-            return deploy(application, multiPartBodyPublisher, false, false);
+            return deploy(application, multiPartBodyPublisher, false, null, null);
         }
 
         @Override
@@ -252,13 +252,12 @@ public class AdminClient implements AutoCloseable {
                 String application,
                 MultiPartBodyPublisher multiPartBodyPublisher,
                 boolean dryRun,
-                boolean autoUpgrade) {
-            final String path =
-                    tenantAppPath("/" + application)
-                            + "?dry-run="
-                            + dryRun
-                            + "&auto-upgrade="
-                            + autoUpgrade;
+                String runtimeVersion,
+                Boolean autoUpdateConfig) {
+            String path = tenantAppPath("/" + application) + "?dry-run=" + dryRun;
+            path += runtimeVersion != null ? "&runtime-version=" + runtimeVersion : "";
+            path += autoUpdateConfig != null ? "&auto-update-config=" + autoUpdateConfig : "";
+
             final String contentType =
                     String.format(
                             "multipart/form-data; boundary=%s",
@@ -291,17 +290,18 @@ public class AdminClient implements AutoCloseable {
         public void update(
                 String application,
                 MultiPartBodyPublisher multiPartBodyPublisher,
-                boolean autoUpgrade,
+                String runtimeVersion,
+                Boolean autoUpdateConfig,
                 boolean forceRestart,
                 boolean isSkipValidation) {
-            final String path =
+            String path =
                     tenantAppPath("/" + application)
-                            + "?auto-upgrade="
-                            + autoUpgrade
-                            + "&force-restart="
+                            + "?force-restart="
                             + forceRestart
                             + "&skip-validation="
                             + isSkipValidation;
+            path += runtimeVersion != null ? "&runtime-version=" + runtimeVersion : "";
+            path += autoUpdateConfig != null ? "&auto-update-config=" + autoUpdateConfig : "";
             final String contentType =
                     String.format(
                             "multipart/form-data; boundary=%s",

--- a/langstream-admin-client/src/main/java/ai/langstream/admin/client/model/Applications.java
+++ b/langstream-admin-client/src/main/java/ai/langstream/admin/client/model/Applications.java
@@ -28,12 +28,14 @@ public interface Applications {
             String application,
             MultiPartBodyPublisher multiPartBodyPublisher,
             boolean dryRun,
-            boolean autoUpgrade);
+            String runtimeVersion,
+            Boolean autoUpdateConfig);
 
     void update(
             String application,
             MultiPartBodyPublisher multiPartBodyPublisher,
-            boolean autoUpgrade,
+            String runtimeVersion,
+            Boolean autoUpdateConfig,
             boolean forceRestart,
             boolean skipValidation);
 

--- a/langstream-api/src/main/java/ai/langstream/api/model/ApplicationDeploySpecs.java
+++ b/langstream-api/src/main/java/ai/langstream/api/model/ApplicationDeploySpecs.java
@@ -13,28 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package ai.langstream.deployer.k8s.api.crds.apps;
+package ai.langstream.api.model;
 
 import lombok.Data;
-import lombok.NoArgsConstructor;
 
 @Data
-@NoArgsConstructor
-public class ApplicationSpecOptions {
+public class ApplicationDeploySpecs {
 
-    public static String RUNTIME_VERSION_NO_UPGRADE = "no-upgrade";
-    public static String RUNTIME_VERSION_AUTO_UPGRADE = "auto-upgrade";
-
-    public enum DeleteMode {
-        CLEANUP_REQUIRED,
-        CLEANUP_BEST_EFFORT;
-    }
-
-    private DeleteMode deleteMode = DeleteMode.CLEANUP_REQUIRED;
-    private boolean markedForDeletion;
-    private long seed;
     private String runtimeVersion;
-    private boolean autoUpgradeRuntimeImagePullPolicy;
-    private boolean autoUpgradeAgentResources;
-    private boolean autoUpgradeAgentPodTemplate;
+    private Boolean autoUpgradeRuntimeImagePullPolicy;
+    private Boolean autoUpgradeAgentResources;
+    private Boolean autoUpgradeAgentPodTemplate;
 }

--- a/langstream-api/src/main/java/ai/langstream/api/model/ApplicationDeploySpecs.java
+++ b/langstream-api/src/main/java/ai/langstream/api/model/ApplicationDeploySpecs.java
@@ -15,9 +15,13 @@
  */
 package ai.langstream.api.model;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class ApplicationDeploySpecs {
 
     private String runtimeVersion;

--- a/langstream-api/src/main/java/ai/langstream/api/runtime/DeployContext.java
+++ b/langstream-api/src/main/java/ai/langstream/api/runtime/DeployContext.java
@@ -30,8 +30,8 @@ public interface DeployContext extends AutoCloseable {
         }
 
         @Override
-        public boolean isAutoUpgradeRuntimeImage() {
-            return false;
+        public String getRuntimeVersion() {
+            return null;
         }
 
         @Override
@@ -61,7 +61,7 @@ public interface DeployContext extends AutoCloseable {
     ApplicationCodeInfo getApplicationCodeInfo(
             String tenant, String applicationId, String codeArchiveId);
 
-    boolean isAutoUpgradeRuntimeImage();
+    String getRuntimeVersion();
 
     boolean isAutoUpgradeRuntimeImagePullPolicy();
 

--- a/langstream-api/src/main/java/ai/langstream/api/storage/ApplicationStore.java
+++ b/langstream-api/src/main/java/ai/langstream/api/storage/ApplicationStore.java
@@ -15,10 +15,7 @@
  */
 package ai.langstream.api.storage;
 
-import ai.langstream.api.model.Application;
-import ai.langstream.api.model.ApplicationSpecs;
-import ai.langstream.api.model.Secrets;
-import ai.langstream.api.model.StoredApplication;
+import ai.langstream.api.model.*;
 import ai.langstream.api.runtime.ExecutionPlan;
 import java.util.List;
 import java.util.Map;
@@ -42,7 +39,7 @@ public interface ApplicationStore extends GenericStore {
             Application applicationInstance,
             String codeArchiveReference,
             ExecutionPlan executionPlan,
-            boolean autoUpgrade,
+            ApplicationDeploySpecs deploySpecs,
             boolean forceRestart);
 
     StoredApplication get(String tenant, String applicationId, boolean queryPods);

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/applications/AbstractDeployApplicationCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/applications/AbstractDeployApplicationCmd.java
@@ -65,10 +65,16 @@ public abstract class AbstractDeployApplicationCmd extends BaseApplicationCmd {
         private Formats format = Formats.yaml;
 
         @CommandLine.Option(
-                names = {"--auto-upgrade"},
+                names = {"--runtime-version"},
                 description =
-                        "Whether to make the executors to automatically upgrades the environment (image, resources mapping etc.) when restarted")
-        private boolean autoUpgrade;
+                        "Set the runtime version for the application. Values could be:\n\t'no-upgrade': to use the current runtime version and stick to it\n\t'auto-upgrade': to make the application to use the latest configured runtime version when restarted\n\t'x.y.z': to set a specific runtime version and stick to it.")
+        private String runtimeVersion;
+
+        @CommandLine.Option(
+                names = {"--auto-update-config"},
+                description =
+                        "Set whether the application should auto-update its configuration (resources, pod template..) to the latest configured.")
+        private Boolean autoUpdateConfig;
 
         @Override
         String applicationId() {
@@ -101,8 +107,13 @@ public abstract class AbstractDeployApplicationCmd extends BaseApplicationCmd {
         }
 
         @Override
-        boolean isAutoUpgrade() {
-            return autoUpgrade;
+        String getRuntimeVersion() {
+            return runtimeVersion;
+        }
+
+        @Override
+        Boolean isAutoUpdateConfig() {
+            return autoUpdateConfig;
         }
 
         @Override
@@ -149,10 +160,16 @@ public abstract class AbstractDeployApplicationCmd extends BaseApplicationCmd {
         private boolean skipValidation;
 
         @CommandLine.Option(
-                names = {"--auto-upgrade"},
+                names = {"--runtime-version"},
                 description =
-                        "Whether to make the executors to automatically upgrades the environment (image, resources mapping etc.) when restarted")
-        private boolean autoUpgrade;
+                        "Set the runtime version for the application. Values could be:\n\t'no-upgrade': to use the current runtime version and stick to it\n\t'auto-upgrade': to make the application to use the latest configured runtime version when restarted\n\t'x.y.z': to set a specific runtime version and stick to it..")
+        private String runtimeVersion;
+
+        @CommandLine.Option(
+                names = {"--auto-update-config"},
+                description =
+                        "Set whether the application should auto-update its configuration (resources, pod template..) to the latest configured.")
+        private Boolean autoUpdateConfig;
 
         @CommandLine.Option(
                 names = {"--force-restart"},
@@ -190,8 +207,13 @@ public abstract class AbstractDeployApplicationCmd extends BaseApplicationCmd {
         }
 
         @Override
-        boolean isAutoUpgrade() {
-            return autoUpgrade;
+        String getRuntimeVersion() {
+            return runtimeVersion;
+        }
+
+        @Override
+        Boolean isAutoUpdateConfig() {
+            return autoUpdateConfig;
         }
 
         @Override
@@ -222,7 +244,9 @@ public abstract class AbstractDeployApplicationCmd extends BaseApplicationCmd {
 
     abstract boolean isDryRun();
 
-    abstract boolean isAutoUpgrade();
+    abstract String getRuntimeVersion();
+
+    abstract Boolean isAutoUpdateConfig();
 
     abstract Boolean isForceRestart();
 
@@ -292,7 +316,8 @@ public abstract class AbstractDeployApplicationCmd extends BaseApplicationCmd {
                     .update(
                             applicationId,
                             bodyPublisher,
-                            isAutoUpgrade(),
+                            getRuntimeVersion(),
+                            isAutoUpdateConfig(),
                             isForceRestart(),
                             isSkipValidation());
             log(String.format("application %s updated", applicationId));
@@ -309,7 +334,12 @@ public abstract class AbstractDeployApplicationCmd extends BaseApplicationCmd {
             final String response =
                     getClient()
                             .applications()
-                            .deploy(applicationId, bodyPublisher, dryRun, isAutoUpgrade());
+                            .deploy(
+                                    applicationId,
+                                    bodyPublisher,
+                                    dryRun,
+                                    getRuntimeVersion(),
+                                    isAutoUpdateConfig());
             if (dryRun) {
                 final Formats format = format();
                 print(format == Formats.raw ? Formats.yaml : format, response, null, null);

--- a/langstream-k8s-deployer/langstream-k8s-deployer-api/src/main/java/ai/langstream/deployer/k8s/api/crds/agents/AgentSpec.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-api/src/main/java/ai/langstream/deployer/k8s/api/crds/agents/AgentSpec.java
@@ -38,7 +38,7 @@ public class AgentSpec extends NamespacedSpec {
 
     public record Options(
             List<Disk> disks,
-            boolean autoUpgradeRuntimeImage,
+            String runtimeVersion,
             boolean autoUpgradeRuntimeImagePullPolicy,
             boolean autoUpgradeAgentResources,
             boolean autoUpgradeAgentPodTemplate,
@@ -83,12 +83,12 @@ public class AgentSpec extends NamespacedSpec {
     }
 
     @JsonIgnore
-    public boolean isAutoUpgradeRuntimeImage() {
+    public String getRuntimeVersion() {
         final Options options = parseOptions();
         if (options == null) {
-            return false;
+            return null;
         }
-        return options.autoUpgradeRuntimeImage();
+        return options.runtimeVersion();
     }
 
     @JsonIgnore

--- a/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/apps/AppResourcesFactory.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/apps/AppResourcesFactory.java
@@ -97,7 +97,7 @@ public class AppResourcesFactory {
 
         RuntimeDeployerConfiguration.DeployFlags deployFlags =
                 new RuntimeDeployerConfiguration.DeployFlags();
-        deployFlags.setAutoUpgradeRuntimeImage(applicationSpecOptions.isAutoUpgradeRuntimeImage());
+        deployFlags.setRuntimeVersion(applicationSpecOptions.getRuntimeVersion());
         deployFlags.setAutoUpgradeRuntimeImagePullPolicy(
                 applicationSpecOptions.isAutoUpgradeRuntimeImagePullPolicy());
         deployFlags.setAutoUpgradeAgentResources(

--- a/langstream-k8s-deployer/langstream-k8s-deployer-core/src/test/java/ai/langstream/deployer/k8s/apps/AppResourcesFactoryTest.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-core/src/test/java/ai/langstream/deployer/k8s/apps/AppResourcesFactoryTest.java
@@ -115,7 +115,7 @@ class AppResourcesFactoryTest {
                                   name: cluster-config
                               initContainers:
                               - args:
-                                - "echo '{\\"applicationId\\":\\"test-'\\"'\\"'app\\",\\"tenant\\":\\"my-tenant\\",\\"application\\":\\"{app: true}\\",\\"codeStorageArchiveId\\":\\"iiii\\",\\"deployFlags\\":{\\"autoUpgradeRuntimeImage\\":false,\\"autoUpgradeRuntimeImagePullPolicy\\":false,\\"autoUpgradeAgentResources\\":false,\\"autoUpgradeAgentPodTemplate\\":false,\\"seed\\":0}}' > /app-config/config && echo '{}' > /cluster-runtime-config/config"
+                                - "echo '{\\"applicationId\\":\\"test-'\\"'\\"'app\\",\\"tenant\\":\\"my-tenant\\",\\"application\\":\\"{app: true}\\",\\"codeStorageArchiveId\\":\\"iiii\\",\\"deployFlags\\":{\\"runtimeVersion\\":null,\\"autoUpgradeRuntimeImagePullPolicy\\":false,\\"autoUpgradeAgentResources\\":false,\\"autoUpgradeAgentPodTemplate\\":false,\\"seed\\":0}}' > /app-config/config && echo '{}' > /cluster-runtime-config/config"
                                 command:
                                 - bash
                                 - -c
@@ -214,7 +214,7 @@ class AppResourcesFactoryTest {
                                   name: cluster-config
                               initContainers:
                               - args:
-                                - "echo '{\\"applicationId\\":\\"test-'\\"'\\"'app\\",\\"tenant\\":\\"my-tenant\\",\\"application\\":\\"{app: true}\\",\\"codeStorageArchiveId\\":\\"iiii\\",\\"deployFlags\\":{\\"autoUpgradeRuntimeImage\\":false,\\"autoUpgradeRuntimeImagePullPolicy\\":false,\\"autoUpgradeAgentResources\\":false,\\"autoUpgradeAgentPodTemplate\\":false,\\"seed\\":0}}' > /app-config/config && echo '{}' > /cluster-runtime-config/config"
+                                - "echo '{\\"applicationId\\":\\"test-'\\"'\\"'app\\",\\"tenant\\":\\"my-tenant\\",\\"application\\":\\"{app: true}\\",\\"codeStorageArchiveId\\":\\"iiii\\",\\"deployFlags\\":{\\"runtimeVersion\\":null,\\"autoUpgradeRuntimeImagePullPolicy\\":false,\\"autoUpgradeAgentResources\\":false,\\"autoUpgradeAgentPodTemplate\\":false,\\"seed\\":0}}' > /app-config/config && echo '{}' > /cluster-runtime-config/config"
                                 command:
                                 - bash
                                 - -c
@@ -556,7 +556,7 @@ class AppResourcesFactoryTest {
                     application: "{app: true}"
                     tenant: my-tenant
                     codeArchiveId: "iiii"
-                    options: '{"autoUpgradeRuntimeImage": false, "autoUpgradeRuntimeImagePullPolicy": false, "autoUpgradeAgentResources": false, "autoUpgradeAgentPodTemplate": false}'
+                    options: '{"runtimeImage": null, "autoUpgradeRuntimeImagePullPolicy": false, "autoUpgradeAgentResources": false, "autoUpgradeAgentPodTemplate": false}'
                 """);
 
         Job job =
@@ -575,7 +575,7 @@ class AppResourcesFactoryTest {
                         .getArgs()
                         .get(0)
                         .contains(
-                                "\"deployFlags\":{\"autoUpgradeRuntimeImage\":false,\"autoUpgradeRuntimeImagePullPolicy\":false,\"autoUpgradeAgentResources\":false,\"autoUpgradeAgentPodTemplate\":false,\"seed\":0}"));
+                                "\"deployFlags\":{\"runtimeVersion\":null,\"autoUpgradeRuntimeImagePullPolicy\":false,\"autoUpgradeAgentResources\":false,\"autoUpgradeAgentPodTemplate\":false,\"seed\":0}"));
     }
 
     @Test
@@ -592,7 +592,7 @@ class AppResourcesFactoryTest {
                     application: "{app: true}"
                     tenant: my-tenant
                     codeArchiveId: "iiii"
-                    options: '{"autoUpgradeRuntimeImage": true, "autoUpgradeRuntimeImagePullPolicy": true, "autoUpgradeAgentResources": true, "autoUpgradeAgentPodTemplate": true}'
+                    options: '{"runtimeVersion": "auto-upgrade", "autoUpgradeRuntimeImagePullPolicy": true, "autoUpgradeAgentResources": true, "autoUpgradeAgentPodTemplate": true}'
                 """);
 
         Job job =
@@ -611,7 +611,7 @@ class AppResourcesFactoryTest {
                         .getArgs()
                         .get(0)
                         .contains(
-                                "\"deployFlags\":{\"autoUpgradeRuntimeImage\":true,\"autoUpgradeRuntimeImagePullPolicy\":true,\"autoUpgradeAgentResources\":true,\"autoUpgradeAgentPodTemplate\":true,\"seed\":0}"));
+                                "\"deployFlags\":{\"runtimeVersion\":\"auto-upgrade\",\"autoUpgradeRuntimeImagePullPolicy\":true,\"autoUpgradeAgentResources\":true,\"autoUpgradeAgentPodTemplate\":true,\"seed\":0}"));
     }
 
     private ApplicationCustomResource getCr(String yaml) {

--- a/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/main/java/ai/langstream/deployer/k8s/controllers/agents/AgentController.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/main/java/ai/langstream/deployer/k8s/controllers/agents/AgentController.java
@@ -149,11 +149,13 @@ public class AgentController extends BaseController<AgentCustomResource>
                 }
 
                 if (status != null && status.getLastConfigApplied() != null) {
+                    log.infof(
+                            "Update for the agent statefulset %s, options: %s, last applied: %s",
+                            primary.getMetadata().getName(),
+                            primary.getSpec().getOptions(),
+                            status.getLastConfigApplied());
                     isUpdate = true;
                     // this is an update for the statefulset.
-                    // It's required to not keep the same deployer configuration of the current
-                    // version
-
                     String runtimeVersion = primary.getSpec().getRuntimeVersion();
                     if (runtimeVersion != null) {
 
@@ -183,7 +185,10 @@ public class AgentController extends BaseController<AgentCustomResource>
                                     autoUpgradeAgentResources
                                             ? configuration.getAgentResources()
                                             : lastAppliedConfig.getAgentResourceUnitConfiguration())
-                            .image(runtimeVersion)
+                            .image(
+                                    runtimeVersion != null
+                                            ? runtimeVersion
+                                            : lastAppliedConfig.getImage())
                             .imagePullPolicy(
                                     autoUpgradeRuntimeImagePullPolicy
                                             ? configuration.getRuntimeImagePullPolicy()

--- a/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/main/java/ai/langstream/deployer/k8s/controllers/agents/AgentController.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/main/java/ai/langstream/deployer/k8s/controllers/agents/AgentController.java
@@ -22,6 +22,7 @@ import ai.langstream.deployer.k8s.agents.AgentResourceUnitConfiguration;
 import ai.langstream.deployer.k8s.agents.AgentResourcesFactory;
 import ai.langstream.deployer.k8s.api.crds.agents.AgentCustomResource;
 import ai.langstream.deployer.k8s.api.crds.agents.AgentStatus;
+import ai.langstream.deployer.k8s.api.crds.apps.ApplicationSpecOptions;
 import ai.langstream.deployer.k8s.controllers.BaseController;
 import ai.langstream.deployer.k8s.controllers.InfiniteRetry;
 import ai.langstream.deployer.k8s.util.JSONComparator;
@@ -153,7 +154,21 @@ public class AgentController extends BaseController<AgentCustomResource>
                     // It's required to not keep the same deployer configuration of the current
                     // version
 
-                    boolean autoUpgradeRuntimeImage = primary.getSpec().isAutoUpgradeRuntimeImage();
+                    String runtimeVersion = primary.getSpec().getRuntimeVersion();
+                    if (runtimeVersion != null) {
+
+                        if (runtimeVersion.equals(
+                                ApplicationSpecOptions.RUNTIME_VERSION_NO_UPGRADE)) {
+                            runtimeVersion = null;
+                        } else if (runtimeVersion.equals(
+                                ApplicationSpecOptions.RUNTIME_VERSION_AUTO_UPGRADE)) {
+                            runtimeVersion = configuration.getRuntimeImage();
+                        } else {
+                            String imageName = extractImageName(configuration.getRuntimeImage());
+                            runtimeVersion = imageName + ":" + runtimeVersion;
+                        }
+                    }
+
                     boolean autoUpgradeRuntimeImagePullPolicy =
                             primary.getSpec().isAutoUpgradeRuntimeImagePullPolicy();
                     boolean autoUpgradeAgentResources =
@@ -168,10 +183,7 @@ public class AgentController extends BaseController<AgentCustomResource>
                                     autoUpgradeAgentResources
                                             ? configuration.getAgentResources()
                                             : lastAppliedConfig.getAgentResourceUnitConfiguration())
-                            .image(
-                                    autoUpgradeRuntimeImage
-                                            ? configuration.getRuntimeImage()
-                                            : lastAppliedConfig.getImage())
+                            .image(runtimeVersion)
                             .imagePullPolicy(
                                     autoUpgradeRuntimeImagePullPolicy
                                             ? configuration.getRuntimeImagePullPolicy()
@@ -199,6 +211,14 @@ public class AgentController extends BaseController<AgentCustomResource>
                 throw new RuntimeException(t);
             }
         }
+    }
+
+    private static String extractImageName(String image) {
+        int colonIndex = image.lastIndexOf(':');
+        if (colonIndex > -1) {
+            return image.substring(0, colonIndex);
+        }
+        return image;
     }
 
     @JBossLog

--- a/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/test/java/ai/langstream/deployer/k8s/controllers/AppControllerIT.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/test/java/ai/langstream/deployer/k8s/controllers/AppControllerIT.java
@@ -446,7 +446,7 @@ public class AppControllerIT {
         assertEquals("bash", initContainer.getCommand().get(0));
         assertEquals("-c", initContainer.getCommand().get(1));
         assertEquals(
-                "echo '{\"applicationId\":\"my-app\",\"tenant\":\"my-tenant\",\"application\":\"{\\\"modules\\\": {}}\",\"codeStorageArchiveId\":null,\"deployFlags\":{\"autoUpgradeRuntimeImage\":false,\"autoUpgradeRuntimeImagePullPolicy\":false,\"autoUpgradeAgentResources\":false,\"autoUpgradeAgentPodTemplate\":false,\"seed\":0}}' > /app-config/config && echo '{}' > /cluster-runtime-config/config",
+                "echo '{\"applicationId\":\"my-app\",\"tenant\":\"my-tenant\",\"application\":\"{\\\"modules\\\": {}}\",\"codeStorageArchiveId\":null,\"deployFlags\":{\"runtimeVersion\":null,\"autoUpgradeRuntimeImagePullPolicy\":false,\"autoUpgradeAgentResources\":false,\"autoUpgradeAgentPodTemplate\":false,\"seed\":0}}' > /app-config/config && echo '{}' > /cluster-runtime-config/config",
                 initContainer.getArgs().get(0));
     }
 

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/KubernetesClusterRuntime.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/KubernetesClusterRuntime.java
@@ -349,7 +349,7 @@ public class KubernetesClusterRuntime extends BasicClusterRuntime {
         AgentSpec.Options options =
                 new AgentSpec.Options(
                         disks,
-                        deployContext.isAutoUpgradeRuntimeImage(),
+                        deployContext.getRuntimeVersion(),
                         deployContext.isAutoUpgradeRuntimeImagePullPolicy(),
                         deployContext.isAutoUpgradeAgentResources(),
                         deployContext.isAutoUpgradeAgentPodTemplate(),

--- a/langstream-runtime/langstream-runtime-api/src/main/java/ai/langstream/runtime/api/deployer/RuntimeDeployerConfiguration.java
+++ b/langstream-runtime/langstream-runtime-api/src/main/java/ai/langstream/runtime/api/deployer/RuntimeDeployerConfiguration.java
@@ -36,7 +36,7 @@ public class RuntimeDeployerConfiguration {
      * Flags specifically used for this deploy operation.
      */
     public static class DeployFlags {
-        private boolean autoUpgradeRuntimeImage;
+        private String runtimeVersion;
         private boolean autoUpgradeRuntimeImagePullPolicy;
         private boolean autoUpgradeAgentResources;
         private boolean autoUpgradeAgentPodTemplate;

--- a/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/deployer/RuntimeDeployer.java
+++ b/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/deployer/RuntimeDeployer.java
@@ -74,7 +74,7 @@ public class RuntimeDeployer {
                         clusterConfiguration,
                         token,
                         tenant,
-                        deployFlags.isAutoUpgradeRuntimeImage(),
+                        deployFlags.getRuntimeVersion(),
                         deployFlags.isAutoUpgradeRuntimeImagePullPolicy(),
                         deployFlags.isAutoUpgradeAgentResources(),
                         deployFlags.isAutoUpgradeAgentPodTemplate(),
@@ -127,7 +127,7 @@ public class RuntimeDeployer {
     private static class DeployContextImpl implements DeployContext {
 
         private final AdminClient adminClient;
-        private final boolean autoUpgradeRuntimeImage;
+        private final String runtimeVersion;
         private final boolean autoUpgradeRuntimeImagePullPolicy;
         private final boolean autoUpgradeAgentResources;
         private final boolean autoUpgradeAgentPodTemplate;
@@ -137,7 +137,7 @@ public class RuntimeDeployer {
                 ClusterConfiguration clusterConfiguration,
                 String token,
                 String tenant,
-                boolean autoUpgradeRuntimeImage,
+                String runtimeVersion,
                 boolean autoUpgradeRuntimeImagePullPolicy,
                 boolean autoUpgradeAgentResources,
                 boolean autoUpgradeAgentPodTemplate,
@@ -147,7 +147,7 @@ public class RuntimeDeployer {
             } else {
                 adminClient = createAdminClient(clusterConfiguration, token, tenant);
             }
-            this.autoUpgradeRuntimeImage = autoUpgradeRuntimeImage;
+            this.runtimeVersion = runtimeVersion;
             this.autoUpgradeRuntimeImagePullPolicy = autoUpgradeRuntimeImagePullPolicy;
             this.autoUpgradeAgentResources = autoUpgradeAgentResources;
             this.autoUpgradeAgentPodTemplate = autoUpgradeAgentPodTemplate;
@@ -155,8 +155,8 @@ public class RuntimeDeployer {
         }
 
         @Override
-        public boolean isAutoUpgradeRuntimeImage() {
-            return autoUpgradeRuntimeImage;
+        public String getRuntimeVersion() {
+            return runtimeVersion;
         }
 
         @Override

--- a/langstream-runtime/langstream-runtime-tester/src/main/java/ai/langstream/runtime/tester/InMemoryApplicationStore.java
+++ b/langstream-runtime/langstream-runtime-tester/src/main/java/ai/langstream/runtime/tester/InMemoryApplicationStore.java
@@ -15,13 +15,7 @@
  */
 package ai.langstream.runtime.tester;
 
-import ai.langstream.api.model.AgentLifecycleStatus;
-import ai.langstream.api.model.Application;
-import ai.langstream.api.model.ApplicationLifecycleStatus;
-import ai.langstream.api.model.ApplicationSpecs;
-import ai.langstream.api.model.ApplicationStatus;
-import ai.langstream.api.model.Secrets;
-import ai.langstream.api.model.StoredApplication;
+import ai.langstream.api.model.*;
 import ai.langstream.api.runner.code.AgentStatusResponse;
 import ai.langstream.api.runtime.ExecutionPlan;
 import ai.langstream.api.storage.ApplicationStore;
@@ -87,7 +81,7 @@ public class InMemoryApplicationStore implements ApplicationStore {
             Application applicationInstance,
             String codeArchiveReference,
             ExecutionPlan executionPlan,
-            boolean autoUpgrade,
+            ApplicationDeploySpecs deploySpecs,
             boolean forceRestart) {
         APPLICATIONS.put(
                 getKey(tenant, applicationId),

--- a/langstream-runtime/langstream-runtime-tester/src/main/java/ai/langstream/runtime/tester/LocalApplicationRunner.java
+++ b/langstream-runtime/langstream-runtime-tester/src/main/java/ai/langstream/runtime/tester/LocalApplicationRunner.java
@@ -148,7 +148,7 @@ public class LocalApplicationRunner
                 applicationInstance,
                 "no-code-archive-reference",
                 implementation,
-                false,
+                null,
                 false);
 
         return new ApplicationRuntime(

--- a/langstream-webservice/src/main/java/ai/langstream/webservice/application/ApplicationService.java
+++ b/langstream-webservice/src/main/java/ai/langstream/webservice/application/ApplicationService.java
@@ -15,13 +15,7 @@
  */
 package ai.langstream.webservice.application;
 
-import ai.langstream.api.model.Application;
-import ai.langstream.api.model.ApplicationSpecs;
-import ai.langstream.api.model.Gateway;
-import ai.langstream.api.model.ResourcesSpec;
-import ai.langstream.api.model.Secrets;
-import ai.langstream.api.model.StoredApplication;
-import ai.langstream.api.model.TopicDefinition;
+import ai.langstream.api.model.*;
 import ai.langstream.api.runner.topics.TopicConnectionsRuntimeRegistry;
 import ai.langstream.api.runtime.*;
 import ai.langstream.api.storage.ApplicationStore;
@@ -73,7 +67,7 @@ public class ApplicationService {
             String applicationId,
             ModelBuilder.ApplicationWithPackageInfo applicationInstance,
             String codeArchiveReference,
-            boolean autoUpgrade) {
+            ApplicationDeploySpecs applicationDeploySpecs) {
         checkTenant(tenant);
         if (applicationStore.get(tenant, applicationId, false) != null) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, "Application already exists");
@@ -91,7 +85,7 @@ public class ApplicationService {
                 applicationInstance.getApplication(),
                 codeArchiveReference,
                 executionPlan,
-                autoUpgrade,
+                applicationDeploySpecs,
                 false);
     }
 
@@ -174,7 +168,7 @@ public class ApplicationService {
             ModelBuilder.ApplicationWithPackageInfo applicationInstance,
             String codeArchiveReference,
             boolean skipValidation,
-            boolean autoUpgrade,
+            ApplicationDeploySpecs applicationDeploySpecs,
             boolean forceRestart) {
         checkTenant(tenant);
         validateDeployMergeAndUpdate(
@@ -183,7 +177,7 @@ public class ApplicationService {
                 applicationInstance,
                 codeArchiveReference,
                 skipValidation,
-                autoUpgrade,
+                applicationDeploySpecs,
                 forceRestart);
     }
 
@@ -193,7 +187,7 @@ public class ApplicationService {
             ModelBuilder.ApplicationWithPackageInfo applicationInstance,
             String codeArchiveReference,
             boolean skipValidation,
-            boolean autoUpgrade,
+            ApplicationDeploySpecs applicationDeploySpecs,
             boolean forceRestart) {
 
         final StoredApplication existing = applicationStore.get(tenant, applicationId, false);
@@ -239,7 +233,7 @@ public class ApplicationService {
                 newApplication,
                 codeArchiveReference,
                 newPlan,
-                autoUpgrade,
+                applicationDeploySpecs,
                 forceRestart);
     }
 

--- a/langstream-webservice/src/main/java/ai/langstream/webservice/archetype/ArchetypeResource.java
+++ b/langstream-webservice/src/main/java/ai/langstream/webservice/archetype/ArchetypeResource.java
@@ -150,7 +150,7 @@ public class ArchetypeResource {
                     applicationId,
                     parsedApplication.getApplication(),
                     parsedApplication.getCodeArchiveReference(),
-                    false);
+                    null);
             application = parsedApplication.getApplication().getApplication();
         }
         return new ApplicationDescription.ApplicationDefinition(application);

--- a/langstream-webservice/src/test/java/ai/langstream/webservice/application/ApplicationServiceResourceLimitTest.java
+++ b/langstream-webservice/src/test/java/ai/langstream/webservice/application/ApplicationServiceResourceLimitTest.java
@@ -15,10 +15,7 @@
  */
 package ai.langstream.webservice.application;
 
-import ai.langstream.api.model.Application;
-import ai.langstream.api.model.ApplicationSpecs;
-import ai.langstream.api.model.Secrets;
-import ai.langstream.api.model.StoredApplication;
+import ai.langstream.api.model.*;
 import ai.langstream.api.runtime.ExecutionPlan;
 import ai.langstream.api.storage.ApplicationStore;
 import ai.langstream.api.webservice.tenant.TenantConfiguration;
@@ -200,7 +197,7 @@ class ApplicationServiceResourceLimitTest {
                 Application applicationInstance,
                 String codeArchiveReference,
                 ExecutionPlan executionPlan,
-                boolean autoUpgrade,
+                ApplicationDeploySpecs deploySpecs,
                 boolean forceRestart) {
             throw new UnsupportedOperationException();
         }


### PR DESCRIPTION
Split `--auto-upgrade` into two new flags:
1. `--runtime-version` (string) -> no-upgrade, auto-upgrade or free string
2. `--auto-update-config` (bool) -> to set if the app should gets the latest config for pods template and resources config


no-update will make the app stick to the same version when installed.
auto-upgrade will make the app to always get the latest configured image from the operator config.
free string will set the docker image tag to a fixed string. (repository is not settable. In case you need to change the base image, you will need to set the image back to "auto-upgrade")


note that now if the CLI doesn't set any of these values, they are kept overtime (--auto-upgrade was always setting true|false when updating the app)