### PR TITLE
s3 upload: add manual retries

### DIFF
--- a/langstream-codestorage-providers/langstream-codestorage-s3/src/main/java/ai/langstream/impl/storage/k8s/codestorage/S3CodeStorage.java
+++ b/langstream-codestorage-providers/langstream-codestorage-s3/src/main/java/ai/langstream/impl/storage/k8s/codestorage/S3CodeStorage.java
@@ -128,17 +128,21 @@ public class S3CodeStorage implements CodeStorage {
                 if (pyBinariesDigest != null) {
                     userMetadata.put(OBJECT_METADATA_KEY_PY_BINARIES_DIGEST, pyBinariesDigest);
                 }
-                minioClient.uploadObject(
+                UploadObjectArgs uploadObjectArgs =
                         UploadObjectArgs.builder()
                                 .userMetadata(userMetadata)
                                 .bucket(bucketName)
                                 .object(tenant + "/" + codeStoreId)
-                                .contentType("application/zip")
+                                .contentType("application")
                                 .filename(tempFile.toAbsolutePath().toString())
-                                .build());
+                                .build();
+                uploadWithRetry(uploadObjectArgs);
                 return new CodeArchiveMetadata(
                         tenant, codeStoreId, applicationId, pyBinariesDigest, javaBinariesDigest);
-            } catch (MinioException | NoSuchAlgorithmException | InvalidKeyException e) {
+            } catch (MinioException
+                    | NoSuchAlgorithmException
+                    | InvalidKeyException
+                    | IOException e) {
                 throw new CodeStorageException(e);
             } finally {
                 Files.delete(tempFile);
@@ -248,5 +252,38 @@ public class S3CodeStorage implements CodeStorage {
 
     MinioClient getMinioClient() {
         return minioClient;
+    }
+
+    private void uploadWithRetry(UploadObjectArgs args)
+            throws MinioException, NoSuchAlgorithmException, InvalidKeyException, IOException {
+        int attempt = 0;
+        int maxRetries = 5;
+        while (attempt < maxRetries) {
+            try {
+                log.info("attempting to upload object to s3 {}/{}", attempt, maxRetries);
+                attempt++;
+                minioClient.uploadObject(args);
+                return;
+            } catch (IOException e) {
+                log.error("error uploading object to s3", e);
+                if (e.getMessage() != null && e.getMessage().contains("unexpected end of stream")) {
+                    if (attempt == maxRetries) {
+                        throw e;
+                    }
+                    long backoffTime = (long) Math.pow(2, attempt - 1) * 2000;
+                    log.info(
+                            "retrying upload due to unexpected end of stream, retrying in {} ms",
+                            backoffTime);
+                    try {
+                        TimeUnit.MILLISECONDS.sleep(backoffTime);
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        throw new RuntimeException(ie);
+                    }
+                } else {
+                    throw e;
+                }
+            }
+        }
     }
 }

--- a/langstream-codestorage-providers/langstream-codestorage-s3/src/main/java/ai/langstream/impl/storage/k8s/codestorage/S3CodeStorageConfiguration.java
+++ b/langstream-codestorage-providers/langstream-codestorage-s3/src/main/java/ai/langstream/impl/storage/k8s/codestorage/S3CodeStorageConfiguration.java
@@ -16,6 +16,7 @@
 package ai.langstream.impl.storage.k8s.codestorage;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -36,4 +37,13 @@ public class S3CodeStorageConfiguration {
 
     @JsonAlias({"secretkey", "secret-key"})
     private String secretKey;
+
+    @JsonProperty("connection-timeout-seconds")
+    private int connectionTimeoutSeconds = 30;
+
+    @JsonProperty("upload-max-retries")
+    private int uploadMaxRetries = 5;
+
+    @JsonProperty("upload-retries-initial-backoff-ms")
+    private int uploadRetriesInitialBackoffMs = 2000;
 }

--- a/langstream-codestorage-providers/langstream-codestorage-s3/src/test/java/ai/langstream/impl/storage/k8s/codestorage/S3CodeStorageTest.java
+++ b/langstream-codestorage-providers/langstream-codestorage-s3/src/test/java/ai/langstream/impl/storage/k8s/codestorage/S3CodeStorageTest.java
@@ -41,7 +41,26 @@ class S3CodeStorageTest {
             new LocalStackContainer(localstackImage).withServices(S3);
 
     @Test
-    void testConnection() throws Exception {
+    void testConfig() throws Exception {
+        Map<String, Object> config =
+                Map.of(
+                        "type",
+                        "s3",
+                        "bucket-name",
+                        "test-b",
+                        "endpoint",
+                        localstack.getEndpointOverride(S3).toString(),
+                        "connection-timeout-seconds",
+                        60,
+                        "upload-max-retries",
+                        10,
+                        "upload-retries-initial-backoff-ms",
+                        1000);
+        new S3CodeStorageProvider().createImplementation("s3", config);
+    }
+
+    @Test
+    void testAll() throws Exception {
 
         S3CodeStorage storage =
                 (S3CodeStorage)

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
     <tomcat-embed-el.version>10.1.4</tomcat-embed-el.version>
     <commons-collections4.version>4.4</commons-collections4.version>
 <!--    minio requires okhttp3 v4-->
-    <okhttp.version>4.11.0</okhttp.version>
+    <okhttp.version>4.12.0</okhttp.version>
     <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
     <cli-jdk-target-version>11</cli-jdk-target-version>
     <extra-enforcer-rules.version>1.6.1</extra-enforcer-rules.version>


### PR DESCRIPTION
added new config for the code-storage:
- connection-timeout-seconds (default 30s)
- upload-max-retries (5)
- upload-retries-initial-backoff-ms (2000)