### PR TITLE
webcrawler: option to add prefix to status filename

### DIFF
--- a/langstream-agents/langstream-agent-grpc/src/test/java/ai/langstream/agents/grpc/AbstractGrpcAgentTest.java
+++ b/langstream-agents/langstream-agent-grpc/src/test/java/ai/langstream/agents/grpc/AbstractGrpcAgentTest.java
@@ -253,6 +253,11 @@ public class AbstractGrpcAgentTest {
         }
 
         @Override
+        public String getTenant() {
+            return null;
+        }
+
+        @Override
         public TopicAdmin getTopicAdmin() {
             return null;
         }

--- a/langstream-agents/langstream-agent-grpc/src/test/java/ai/langstream/agents/grpc/GrpcAgentProcessorTest.java
+++ b/langstream-agents/langstream-agent-grpc/src/test/java/ai/langstream/agents/grpc/GrpcAgentProcessorTest.java
@@ -322,6 +322,11 @@ public class GrpcAgentProcessorTest {
         }
 
         @Override
+        public String getTenant() {
+            return null;
+        }
+
+        @Override
         public TopicAdmin getTopicAdmin() {
             return null;
         }

--- a/langstream-agents/langstream-agent-grpc/src/test/java/ai/langstream/agents/grpc/GrpcAgentSinkTest.java
+++ b/langstream-agents/langstream-agent-grpc/src/test/java/ai/langstream/agents/grpc/GrpcAgentSinkTest.java
@@ -231,6 +231,11 @@ public class GrpcAgentSinkTest {
         }
 
         @Override
+        public String getTenant() {
+            return null;
+        }
+
+        @Override
         public TopicAdmin getTopicAdmin() {
             return null;
         }

--- a/langstream-agents/langstream-agent-grpc/src/test/java/ai/langstream/agents/grpc/GrpcAgentSourceTest.java
+++ b/langstream-agents/langstream-agent-grpc/src/test/java/ai/langstream/agents/grpc/GrpcAgentSourceTest.java
@@ -255,6 +255,11 @@ public class GrpcAgentSourceTest {
         }
 
         @Override
+        public String getTenant() {
+            return null;
+        }
+
+        @Override
         public TopicAdmin getTopicAdmin() {
             return null;
         }

--- a/langstream-agents/langstream-agent-http-request/src/test/java/ai/langstream/agents/http/LangServeInvokeAgentTest.java
+++ b/langstream-agents/langstream-agent-http-request/src/test/java/ai/langstream/agents/http/LangServeInvokeAgentTest.java
@@ -369,6 +369,11 @@ class LangServeInvokeAgentTest {
                     }
 
                     @Override
+                    public String getTenant() {
+                        return null;
+                    }
+
+                    @Override
                     public TopicAdmin getTopicAdmin() {
                         return null;
                     }

--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/WebCrawlerSource.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/WebCrawlerSource.java
@@ -33,16 +33,16 @@ import ai.langstream.api.runner.code.Header;
 import ai.langstream.api.runner.code.Record;
 import ai.langstream.api.runner.code.SimpleRecord;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.minio.BucketExistsArgs;
-import io.minio.GetObjectArgs;
-import io.minio.GetObjectResponse;
-import io.minio.MakeBucketArgs;
-import io.minio.MinioClient;
+import io.minio.*;
 import io.minio.errors.ErrorResponseException;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.net.Socket;
+import java.net.SocketException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.HashMap;
@@ -52,7 +52,11 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+import io.minio.errors.MinioException;
 import lombok.Getter;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -111,13 +115,13 @@ public class WebCrawlerSource extends AbstractAgentCode implements AgentSource {
         maxUnflushedPages = getInt("max-unflushed-pages", 100, configuration);
 
         flushNext.set(maxUnflushedPages);
-        int minTimeBetweenRequests = getInt("min-time-between-requests", 500, configuration);
-        String userAgent = getString("user-agent", DEFAULT_USER_AGENT, configuration);
-        int maxErrorCount = getInt("max-error-count", 5, configuration);
-        int httpTimeout = getInt("http-timeout", 10000, configuration);
-        boolean allowNonHtmlContents = getBoolean("allow-non-html-contents", false, configuration);
+        final int minTimeBetweenRequests = getInt("min-time-between-requests", 500, configuration);
+        final String userAgent = getString("user-agent", DEFAULT_USER_AGENT, configuration);
+        final int maxErrorCount = getInt("max-error-count", 5, configuration);
+        final int httpTimeout = getInt("http-timeout", 10000, configuration);
+        final boolean allowNonHtmlContents = getBoolean("allow-non-html-contents", false, configuration);
 
-        boolean handleCookies = getBoolean("handle-cookies", true, configuration);
+        final boolean handleCookies = getBoolean("handle-cookies", true, configuration);
 
         log.info("allowed-domains: {}", allowedDomains);
         log.info("forbidden-paths: {}", forbiddenPaths);
@@ -156,12 +160,12 @@ public class WebCrawlerSource extends AbstractAgentCode implements AgentSource {
     @Override
     public void setContext(AgentContext context) throws Exception {
         super.setContext(context);
-        String globalAgentId = context.getGlobalAgentId();
-        statusFileName = globalAgentId + ".webcrawler.status.json";
-        log.info("Status file is {}", statusFileName);
+        final String globalAgentId = context.getGlobalAgentId();
+        final boolean prependTenant = getBoolean("state-storage-prepend-tenant", false, agentConfiguration);
         final String agentId = agentId();
         localDiskPath = context.getPersistentStateDirectoryForAgent(agentId);
         String stateStorage = getString("state-storage", "s3", agentConfiguration);
+
         if (stateStorage.equals("disk")) {
             if (!localDiskPath.isPresent()) {
                 throw new IllegalArgumentException(
@@ -170,6 +174,13 @@ public class WebCrawlerSource extends AbstractAgentCode implements AgentSource {
                                 + " and state-storage was set to 'disk'");
             }
             log.info("Using local disk storage");
+            final String pathPrefix;
+            if (prependTenant) {
+                pathPrefix = context.getTenant() + "-" + globalAgentId;
+            } else {
+                pathPrefix = globalAgentId;
+            }
+            statusFileName = pathPrefix + ".webcrawler.status.json";
 
             statusStorage = new LocalDiskStatusStorage();
         } else {
@@ -196,8 +207,16 @@ public class WebCrawlerSource extends AbstractAgentCode implements AgentSource {
             minioClient = builder.build();
 
             makeBucketIfNotExists(bucketName);
+            final String pathPrefix;
+            if (prependTenant) {
+                pathPrefix = context.getTenant() + "/" + globalAgentId;
+            } else {
+                pathPrefix = globalAgentId;
+            }
+            statusFileName = pathPrefix + ".webcrawler.status.json";
             statusStorage = new S3StatusStorage();
         }
+        log.info("Status file is {}", statusFileName);
     }
 
     @SneakyThrows
@@ -392,13 +411,50 @@ public class WebCrawlerSource extends AbstractAgentCode implements AgentSource {
         public void storeStatus(Status status) throws Exception {
             byte[] content = MAPPER.writeValueAsBytes(status);
             log.info("Storing status in {}, {} bytes", statusFileName, content.length);
-            minioClient.putObject(
-                    io.minio.PutObjectArgs.builder()
-                            .bucket(bucketName)
-                            .object(statusFileName)
-                            .contentType("text/json")
-                            .stream(new ByteArrayInputStream(content), content.length, -1)
-                            .build());
+            putWithRetries(() -> PutObjectArgs.builder()
+                    .bucket(bucketName)
+                    .object(statusFileName)
+                    .contentType("text/json")
+                    .stream(new ByteArrayInputStream(content), content.length, -1)
+                    .build());
+        }
+
+
+        private void putWithRetries(Supplier<PutObjectArgs> args)
+                throws MinioException, NoSuchAlgorithmException, InvalidKeyException, IOException {
+            int attempt = 0;
+            int maxRetries = 5;
+            while (attempt < maxRetries) {
+                try {
+                    attempt++;
+                    log.info("attempting to put object to s3 {}/{}", attempt, maxRetries);
+                    minioClient.putObject(args.get());
+                    return;
+                } catch (IOException e) {
+                    log.error("error putting object to s3", e);
+                    if (e.getMessage() != null &&
+                            e.getMessage().contains("unexpected end of stream")
+                            || e.getMessage().contains("unexpected EOF")
+                            || e.getMessage().contains("Broken pipe")) {
+                        if (attempt == maxRetries) {
+                            throw e;
+                        }
+                        long backoffTime =
+                                (long) Math.pow(2, attempt - 1) * 2000;
+                        log.info(
+                                "retrying put due to unexpected end of stream, retrying in {} ms",
+                                backoffTime);
+                        try {
+                            TimeUnit.MILLISECONDS.sleep(backoffTime);
+                        } catch (InterruptedException ie) {
+                            Thread.currentThread().interrupt();
+                            throw new RuntimeException(ie);
+                        }
+                    } else {
+                        throw e;
+                    }
+                }
+            }
         }
 
         @Override

--- a/langstream-agents/langstream-agent-webcrawler/src/test/java/ai/langstream/agents/webcrawler/WebCrawlerSourceTest.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/test/java/ai/langstream/agents/webcrawler/WebCrawlerSourceTest.java
@@ -82,7 +82,7 @@ public class WebCrawlerSourceTest {
     }
 
     @Test
-    @Disabled("This test is disabled because it connects to a real live website")
+    // @Disabled("This test is disabled because it connects to a real live website")
     void testReadWebSite() throws Exception {
         String bucket = "langstream-test-" + UUID.randomUUID();
         String url = "https://www.datastax.com/";
@@ -95,6 +95,8 @@ public class WebCrawlerSourceTest {
                         Set.of(),
                         url,
                         Map.of(
+                                "state-storage-prepend-tenant",
+                                "true",
                                 "reindex-interval-seconds",
                                 "3600",
                                 "scan-html-documents",
@@ -440,6 +442,11 @@ public class WebCrawlerSourceTest {
                     @Override
                     public String getGlobalAgentId() {
                         return "test-global-agent-id";
+                    }
+
+                    @Override
+                    public String getTenant() {
+                        return "test-tenant";
                     }
 
                     @Override

--- a/langstream-agents/langstream-agent-webcrawler/src/test/java/ai/langstream/agents/webcrawler/WebCrawlerSourceTest.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/test/java/ai/langstream/agents/webcrawler/WebCrawlerSourceTest.java
@@ -36,9 +36,8 @@ import ai.langstream.api.runner.topics.TopicConsumer;
 import ai.langstream.api.runner.topics.TopicProducer;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
-import io.minio.MakeBucketArgs;
-import io.minio.MinioClient;
-import io.minio.PutObjectArgs;
+import io.minio.*;
+import io.minio.messages.Item;
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
@@ -82,7 +81,7 @@ public class WebCrawlerSourceTest {
     }
 
     @Test
-    // @Disabled("This test is disabled because it connects to a real live website")
+    @Disabled("This test is disabled because it connects to a real live website")
     void testReadWebSite() throws Exception {
         String bucket = "langstream-test-" + UUID.randomUUID();
         String url = "https://www.datastax.com/";
@@ -95,8 +94,6 @@ public class WebCrawlerSourceTest {
                         Set.of(),
                         url,
                         Map.of(
-                                "state-storage-prepend-tenant",
-                                "true",
                                 "reindex-interval-seconds",
                                 "3600",
                                 "scan-html-documents",
@@ -124,37 +121,85 @@ public class WebCrawlerSourceTest {
     }
 
     @Test
-    @Disabled("This test is disabled because it connects to a real live website")
     void testReadLangStreamDocs() throws Exception {
         String bucket = "langstream-test-" + UUID.randomUUID();
         String url = "https://docs.langstream.ai/";
         String allowed = "https://docs.langstream.ai/";
 
-        WebCrawlerSource agentSource =
+        try (WebCrawlerSource agentSource =
                 buildAgentSource(
                         bucket,
                         allowed,
                         Set.of("/pipeline-agents", "/building-applications"),
                         url,
-                        Map.of("reindex-interval-seconds", "30", "max-urls", 5));
-        List<Record> read = agentSource.read();
-        Set<String> urls = new HashSet<>();
-        agentSource.setOnReindexStart(
-                () -> {
-                    urls.clear();
-                });
-        int count = 0;
-        while (count < 30000) {
-            log.info("read: {}", read);
-            for (Record r : read) {
-                String docUrl = r.key().toString();
-                assertTrue(urls.add(docUrl), "Read twice the same url: " + docUrl);
+                        Map.of(
+                                "reindex-interval-seconds",
+                                "1",
+                                "max-urls",
+                                50,
+                                "state-storage-file-prepend-tenant",
+                                "true",
+                                "state-storage-file-prefix",
+                                "langstream-apps/")); ) {
+            List<Record> read = agentSource.read();
+            Set<String> urls = new HashSet<>();
+            agentSource.setOnReindexStart(
+                    () -> {
+                        urls.clear();
+                    });
+            int count = 0;
+            while (count < 5) {
+                log.info("read: {}", read);
+                for (Record r : read) {
+                    String docUrl = r.key().toString();
+                    assertTrue(urls.add(docUrl), "Read twice the same url: " + docUrl);
+                }
+                count += read.size();
+                agentSource.commit(read);
+                read = agentSource.read();
             }
-            count += read.size();
-            agentSource.commit(read);
-            read = agentSource.read();
         }
-        agentSource.close();
+        Iterable<Result<Item>> results =
+                minioClient.listObjects(ListObjectsArgs.builder().bucket(bucket).build());
+        int count = 0;
+        for (Result<Item> result : results) {
+            count++;
+            Item item = result.get();
+            assertEquals("langstream-apps/", item.objectName());
+            assertTrue(item.isDir());
+        }
+        assertEquals(1, count);
+        results =
+                minioClient.listObjects(
+                        ListObjectsArgs.builder()
+                                .bucket(bucket)
+                                .prefix("langstream-apps/")
+                                .build());
+        count = 0;
+        for (Result<Item> result : results) {
+            count++;
+            Item item = result.get();
+            assertEquals("langstream-apps/test-tenant/", item.objectName());
+            assertTrue(item.isDir());
+        }
+        assertEquals(1, count);
+
+        results =
+                minioClient.listObjects(
+                        ListObjectsArgs.builder()
+                                .bucket(bucket)
+                                .prefix("langstream-apps/test-tenant/")
+                                .build());
+        count = 0;
+        for (Result<Item> result : results) {
+            count++;
+            Item item = result.get();
+            assertEquals(
+                    "langstream-apps/test-tenant/test-global-agent-id.webcrawler.status.json",
+                    item.objectName());
+            assertFalse(item.isDir());
+        }
+        assertEquals(1, count);
     }
 
     @Test

--- a/langstream-api/src/main/java/ai/langstream/api/runner/code/AgentContext.java
+++ b/langstream-api/src/main/java/ai/langstream/api/runner/code/AgentContext.java
@@ -38,6 +38,8 @@ public interface AgentContext {
 
     String getGlobalAgentId();
 
+    String getTenant();
+
     TopicAdmin getTopicAdmin();
 
     TopicConnectionProvider getTopicConnectionProvider();

--- a/langstream-codestorage-providers/langstream-codestorage-s3/src/main/java/ai/langstream/impl/storage/k8s/codestorage/S3CodeStorage.java
+++ b/langstream-codestorage-providers/langstream-codestorage-s3/src/main/java/ai/langstream/impl/storage/k8s/codestorage/S3CodeStorage.java
@@ -40,7 +40,6 @@ import java.security.NoSuchAlgorithmException;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
-
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.OkHttpClient;
@@ -142,19 +141,20 @@ public class S3CodeStorage implements CodeStorage {
                     userMetadata.put(OBJECT_METADATA_KEY_PY_BINARIES_DIGEST, pyBinariesDigest);
                 }
                 String filename = tempFile.toAbsolutePath().toString();
-                uploadWithRetry(() -> {
-                    try {
-                        return UploadObjectArgs.builder()
-                                .userMetadata(userMetadata)
-                                .bucket(bucketName)
-                                .object(tenant + "/" + codeStoreId)
-                                .contentType("application/zip")
-                                .filename(filename)
-                                .build();
-                    } catch (IOException e) {
-                        throw new RuntimeException(e);
-                    }
-                });
+                uploadWithRetry(
+                        () -> {
+                            try {
+                                return UploadObjectArgs.builder()
+                                        .userMetadata(userMetadata)
+                                        .bucket(bucketName)
+                                        .object(tenant + "/" + codeStoreId)
+                                        .contentType("application/zip")
+                                        .filename(filename)
+                                        .build();
+                            } catch (IOException e) {
+                                throw new RuntimeException(e);
+                            }
+                        });
                 return new CodeArchiveMetadata(
                         tenant, codeStoreId, applicationId, pyBinariesDigest, javaBinariesDigest);
             } catch (MinioException

--- a/langstream-codestorage-providers/langstream-codestorage-s3/src/main/java/ai/langstream/impl/storage/k8s/codestorage/S3CodeStorage.java
+++ b/langstream-codestorage-providers/langstream-codestorage-s3/src/main/java/ai/langstream/impl/storage/k8s/codestorage/S3CodeStorage.java
@@ -39,6 +39,8 @@ import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.OkHttpClient;
@@ -139,15 +141,20 @@ public class S3CodeStorage implements CodeStorage {
                 if (pyBinariesDigest != null) {
                     userMetadata.put(OBJECT_METADATA_KEY_PY_BINARIES_DIGEST, pyBinariesDigest);
                 }
-                UploadObjectArgs uploadObjectArgs =
-                        UploadObjectArgs.builder()
+                String filename = tempFile.toAbsolutePath().toString();
+                uploadWithRetry(() -> {
+                    try {
+                        return UploadObjectArgs.builder()
                                 .userMetadata(userMetadata)
                                 .bucket(bucketName)
                                 .object(tenant + "/" + codeStoreId)
                                 .contentType("application/zip")
-                                .filename(tempFile.toAbsolutePath().toString())
+                                .filename(filename)
                                 .build();
-                uploadWithRetry(uploadObjectArgs);
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                });
                 return new CodeArchiveMetadata(
                         tenant, codeStoreId, applicationId, pyBinariesDigest, javaBinariesDigest);
             } catch (MinioException
@@ -265,7 +272,7 @@ public class S3CodeStorage implements CodeStorage {
         return minioClient;
     }
 
-    private void uploadWithRetry(UploadObjectArgs args)
+    private void uploadWithRetry(Supplier<UploadObjectArgs> args)
             throws MinioException, NoSuchAlgorithmException, InvalidKeyException, IOException {
         int attempt = 0;
         int maxRetries = uploadMaxRetries;
@@ -273,11 +280,13 @@ public class S3CodeStorage implements CodeStorage {
             try {
                 attempt++;
                 log.info("attempting to upload object to s3 {}/{}", attempt, maxRetries);
-                minioClient.uploadObject(args);
+                minioClient.uploadObject(args.get());
                 return;
             } catch (IOException e) {
                 log.error("error uploading object to s3", e);
-                if (e.getMessage() != null && e.getMessage().contains("unexpected end of stream")) {
+                if (e.getMessage() != null && e.getMessage().contains("unexpected end of stream")
+                        || e.getMessage().contains("unexpected EOF")
+                        || e.getMessage().contains("Broken pipe")) {
                     if (attempt == maxRetries) {
                         throw e;
                     }

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/WebCrawlerSourceAgentProvider.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/WebCrawlerSourceAgentProvider.java
@@ -109,6 +109,15 @@ public class WebCrawlerSourceAgentProvider extends AbstractComposableAgentProvid
         @ConfigProperty(
                 description =
                         """
+                        Whether to prepend the tenant to the state storage path.
+                        """,
+                defaultValue = "s3")
+        @JsonProperty("state-storage-prepend-tenant")
+        private String stateStoragePrependTenant;
+
+        @ConfigProperty(
+                description =
+                        """
                                 Configuration for handling the agent status.
                                 The name of the bucket.
                                         """,

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/WebCrawlerSourceAgentProvider.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/WebCrawlerSourceAgentProvider.java
@@ -111,9 +111,18 @@ public class WebCrawlerSourceAgentProvider extends AbstractComposableAgentProvid
                         """
                         Whether to prepend the tenant to the state storage path.
                         """,
-                defaultValue = "s3")
-        @JsonProperty("state-storage-prepend-tenant")
-        private String stateStoragePrependTenant;
+                defaultValue = "false")
+        @JsonProperty("state-storage-file-prepend-tenant")
+        private boolean stateStorageFilePrependTenant;
+
+        @ConfigProperty(
+                description =
+                        """
+                        Prepend a prefix to the state storage path, before the tenant (if enabled).
+                        """,
+                defaultValue = "")
+        @JsonProperty("state-storage-file-prefix")
+        private boolean stateStorageFilePrefix;
 
         @ConfigProperty(
                 description =

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/test/java/ai/langstream/runtime/impl/k8s/agents/QueryVectorDBAgentProviderTest.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/test/java/ai/langstream/runtime/impl/k8s/agents/QueryVectorDBAgentProviderTest.java
@@ -163,454 +163,459 @@ class QueryVectorDBAgentProviderTest {
 
         Assertions.assertEquals(
                 """
-                {
-                  "query-vector-db" : {
-                    "name" : "Query a vector database",
-                    "description" : "Query a vector database using Vector Search capabilities.",
-                    "properties" : {
-                      "composable" : {
-                        "description" : "Whether this step can be composed with other steps.",
-                        "required" : false,
-                        "type" : "boolean",
-                        "defaultValue" : "true"
-                      },
-                      "datasource" : {
-                        "description" : "Reference to a datasource id configured in the application.",
-                        "required" : true,
-                        "type" : "string"
-                      },
-                      "fields" : {
-                        "description" : "Fields of the record to use as input parameters for the query.",
-                        "required" : false,
-                        "type" : "array",
-                        "items" : {
-                          "description" : "Fields of the record to use as input parameters for the query.",
-                          "required" : false,
-                          "type" : "string",
-                          "extendedValidationType" : "EL_EXPRESSION"
-                        },
-                        "extendedValidationType" : "EL_EXPRESSION"
-                      },
-                      "generated-keys" : {
-                        "description" : "List of fields to use as generated keys. The generated keys are returned in the output, depending on the database.",
-                        "required" : false,
-                        "type" : "array",
-                        "items" : {
-                          "description" : "List of fields to use as generated keys. The generated keys are returned in the output, depending on the database.",
-                          "required" : false,
-                          "type" : "string"
-                        }
-                      },
-                      "loop-over" : {
-                        "description" : "Loop over a list of items taken from the record. For instance value.documents.\\nIt must refer to a list of maps. In this case the output-field parameter\\nbut be like \\"record.fieldname\\" in order to replace or set a field in each record\\nwith the results of the query. In the query parameters you can refer to the\\nrecord fields using \\"record.field\\".",
-                        "required" : false,
-                        "type" : "string",
-                        "extendedValidationType" : "EL_EXPRESSION"
-                      },
-                      "mode" : {
-                        "description" : "Execution mode: query or execute. In query mode, the query is executed and the results are returned. In execute mode, the query is executed and the result is the number of rows affected (depending on the database).",
-                        "required" : false,
-                        "type" : "string",
-                        "defaultValue" : "query"
-                      },
-                      "only-first" : {
-                        "description" : "If true, only the first result of the query is stored in the output field.",
-                        "required" : false,
-                        "type" : "boolean",
-                        "defaultValue" : "false"
-                      },
-                      "output-field" : {
-                        "description" : "The name of the field to use to store the query result.",
-                        "required" : true,
-                        "type" : "string"
-                      },
-                      "query" : {
-                        "description" : "The query to use to extract the data.",
-                        "required" : true,
-                        "type" : "string"
-                      },
-                      "when" : {
-                        "description" : "Execute the step only when the condition is met.\\nYou can use the expression language to reference the message.\\nExample: when: \\"value.first == 'f1' && value.last.toUpperCase() == 'L1'\\"",
-                        "required" : false,
-                        "type" : "string"
-                      }
-                    }
-                  },
-                  "vector-db-sink_astra" : {
-                    "type" : "vector-db-sink",
-                    "name" : "Astra",
-                    "description" : "Writes data to DataStax Astra service.\\nAll the options from DataStax Kafka Sink are supported: https://docs.datastax.com/en/kafka/doc/kafka/kafkaConfigTasksTOC.html",
-                    "properties" : {
-                      "datasource" : {
-                        "description" : "Resource id. The target resource must be type: 'datasource' or 'vector-database' and service: 'astra'.",
-                        "required" : true,
-                        "type" : "string"
-                      },
-                      "keyspace" : {
-                        "description" : "The keyspace of the table to write to.",
-                        "required" : false,
-                        "type" : "string"
-                      },
-                      "mapping" : {
-                        "description" : "Comma separated list of mapping between the table column and the record field. e.g. my_colum_id=key, my_column_name=value.name.",
-                        "required" : true,
-                        "type" : "string"
-                      },
-                      "table-name" : {
-                        "description" : "The name of the table to write to. The table must already exist.",
-                        "required" : true,
-                        "type" : "string"
-                      }
-                    }
-                  },
-                  "vector-db-sink_astra-vector-db" : {
-                    "type" : "vector-db-sink",
-                    "name" : "Astra Vector DB",
-                    "description" : "Writes data to Apache Cassandra.\\nAll the options from DataStax Kafka Sink are supported: https://docs.datastax.com/en/kafka/doc/kafka/kafkaConfigTasksTOC.html",
-                    "properties" : {
-                      "collection-name" : {
-                        "description" : "The name of the collection to write to. The collection must already exist.",
-                        "required" : true,
-                        "type" : "string"
-                      },
-                      "datasource" : {
-                        "description" : "Resource id. The target resource must be type: 'datasource' or 'vector-database' and service: 'astra-vector-db'.",
-                        "required" : true,
-                        "type" : "string"
-                      },
-                      "fields" : {
-                        "description" : "Fields of the collection to write to.",
-                        "required" : true,
-                        "type" : "array",
-                        "items" : {
-                          "description" : "Fields of the collection to write to.",
-                          "required" : true,
-                          "type" : "object",
-                          "properties" : {
-                            "expression" : {
-                              "description" : "JSTL Expression for computing the field value.",
-                              "required" : true,
-                              "type" : "string"
-                            },
-                            "name" : {
-                              "description" : "Field name",
-                              "required" : true,
-                              "type" : "string"
+                        {
+                          "query-vector-db" : {
+                            "name" : "Query a vector database",
+                            "description" : "Query a vector database using Vector Search capabilities.",
+                            "properties" : {
+                              "composable" : {
+                                "description" : "Whether this step can be composed with other steps.",
+                                "required" : false,
+                                "type" : "boolean",
+                                "defaultValue" : "true"
+                              },
+                              "datasource" : {
+                                "description" : "Reference to a datasource id configured in the application.",
+                                "required" : true,
+                                "type" : "string"
+                              },
+                              "fields" : {
+                                "description" : "Fields of the record to use as input parameters for the query.",
+                                "required" : false,
+                                "type" : "array",
+                                "items" : {
+                                  "description" : "Fields of the record to use as input parameters for the query.",
+                                  "required" : false,
+                                  "type" : "string",
+                                  "extendedValidationType" : "EL_EXPRESSION"
+                                },
+                                "extendedValidationType" : "EL_EXPRESSION"
+                              },
+                              "generated-keys" : {
+                                "description" : "List of fields to use as generated keys. The generated keys are returned in the output, depending on the database.",
+                                "required" : false,
+                                "type" : "array",
+                                "items" : {
+                                  "description" : "List of fields to use as generated keys. The generated keys are returned in the output, depending on the database.",
+                                  "required" : false,
+                                  "type" : "string"
+                                }
+                              },
+                              "loop-over" : {
+                                "description" : "Loop over a list of items taken from the record. For instance value.documents.\\nIt must refer to a list of maps. In this case the output-field parameter\\nbut be like \\"record.fieldname\\" in order to replace or set a field in each record\\nwith the results of the query. In the query parameters you can refer to the\\nrecord fields using \\"record.field\\".",
+                                "required" : false,
+                                "type" : "string",
+                                "extendedValidationType" : "EL_EXPRESSION"
+                              },
+                              "mode" : {
+                                "description" : "Execution mode: query or execute. In query mode, the query is executed and the results are returned. In execute mode, the query is executed and the result is the number of rows affected (depending on the database).",
+                                "required" : false,
+                                "type" : "string",
+                                "defaultValue" : "query"
+                              },
+                              "only-first" : {
+                                "description" : "If true, only the first result of the query is stored in the output field.",
+                                "required" : false,
+                                "type" : "boolean",
+                                "defaultValue" : "false"
+                              },
+                              "output-field" : {
+                                "description" : "The name of the field to use to store the query result.",
+                                "required" : true,
+                                "type" : "string"
+                              },
+                              "query" : {
+                                "description" : "The query to use to extract the data.",
+                                "required" : true,
+                                "type" : "string"
+                              },
+                              "when" : {
+                                "description" : "Execute the step only when the condition is met.\\nYou can use the expression language to reference the message.\\nExample: when: \\"value.first == 'f1' && value.last.toUpperCase() == 'L1'\\"",
+                                "required" : false,
+                                "type" : "string"
+                              }
+                            }
+                          },
+                          "vector-db-sink_astra" : {
+                            "type" : "vector-db-sink",
+                            "name" : "Astra",
+                            "description" : "Writes data to DataStax Astra service.\\nAll the options from DataStax Kafka Sink are supported: https://docs.datastax.com/en/kafka/doc/kafka/kafkaConfigTasksTOC.html",
+                            "properties" : {
+                              "datasource" : {
+                                "description" : "Resource id. The target resource must be type: 'datasource' or 'vector-database' and service: 'astra'.",
+                                "required" : true,
+                                "type" : "string"
+                              },
+                              "keyspace" : {
+                                "description" : "The keyspace of the table to write to.",
+                                "required" : false,
+                                "type" : "string"
+                              },
+                              "mapping" : {
+                                "description" : "Comma separated list of mapping between the table column and the record field. e.g. my_colum_id=key, my_column_name=value.name.",
+                                "required" : true,
+                                "type" : "string"
+                              },
+                              "table-name" : {
+                                "description" : "The name of the table to write to. The table must already exist.",
+                                "required" : true,
+                                "type" : "string"
+                              }
+                            }
+                          },
+                          "vector-db-sink_astra-vector-db" : {
+                            "type" : "vector-db-sink",
+                            "name" : "Astra Vector DB",
+                            "description" : "Writes data to Apache Cassandra.\\nAll the options from DataStax Kafka Sink are supported: https://docs.datastax.com/en/kafka/doc/kafka/kafkaConfigTasksTOC.html",
+                            "properties" : {
+                              "collection-name" : {
+                                "description" : "The name of the collection to write to. The collection must already exist.",
+                                "required" : true,
+                                "type" : "string"
+                              },
+                              "datasource" : {
+                                "description" : "Resource id. The target resource must be type: 'datasource' or 'vector-database' and service: 'astra-vector-db'.",
+                                "required" : true,
+                                "type" : "string"
+                              },
+                              "fields" : {
+                                "description" : "Fields of the collection to write to.",
+                                "required" : true,
+                                "type" : "array",
+                                "items" : {
+                                  "description" : "Fields of the collection to write to.",
+                                  "required" : true,
+                                  "type" : "object",
+                                  "properties" : {
+                                    "expression" : {
+                                      "description" : "JSTL Expression for computing the field value.",
+                                      "required" : true,
+                                      "type" : "string"
+                                    },
+                                    "name" : {
+                                      "description" : "Field name",
+                                      "required" : true,
+                                      "type" : "string"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "vector-db-sink_cassandra" : {
+                            "type" : "vector-db-sink",
+                            "name" : "Cassandra",
+                            "description" : "Writes data to Apache Cassandra.\\nAll the options from DataStax Kafka Sink are supported: https://docs.datastax.com/en/kafka/doc/kafka/kafkaConfigTasksTOC.html",
+                            "properties" : {
+                              "datasource" : {
+                                "description" : "Resource id. The target resource must be type: 'datasource' or 'vector-database' and service: 'cassandra'.",
+                                "required" : true,
+                                "type" : "string"
+                              },
+                              "keyspace" : {
+                                "description" : "The keyspace of the table to write to.",
+                                "required" : false,
+                                "type" : "string"
+                              },
+                              "mapping" : {
+                                "description" : "Comma separated list of mapping between the table column and the record field. e.g. my_colum_id=key, my_column_name=value.name.",
+                                "required" : true,
+                                "type" : "string"
+                              },
+                              "table-name" : {
+                                "description" : "The name of the table to write to. The table must already exist.",
+                                "required" : true,
+                                "type" : "string"
+                              }
+                            }
+                          },
+                          "vector-db-sink_couchbase" : {
+                            "type" : "vector-db-sink",
+                            "name" : "Couchbase Vector DB",
+                            "description" : "Writes data to Couchbase Capella.\\nAll the options from DataStax Kafka Sink are supported: https://docs.datastax.com/en/kafka/doc/kafka/kafkaConfigTasksTOC.html",
+                            "properties" : {
+                              "bucket-name" : {
+                                "description" : "The name of the bucket to write to.",
+                                "required" : true,
+                                "type" : "string"
+                              },
+                              "collection-name" : {
+                                "description" : "Collection to use in Couchbase.",
+                                "required" : false,
+                                "type" : "string"
+                              },
+                              "connection-string" : {
+                                "description" : "The connection string to the Couchbase cluster.",
+                                "required" : true,
+                                "type" : "string"
+                              },
+                              "datasource" : {
+                                "description" : "Resource id. The target resource must be type: 'datasource' or 'vector-database' and service: 'couchbase'.",
+                                "required" : true,
+                                "type" : "string"
+                              },
+                              "scope-name" : {
+                                "description" : "Scope to use in Couchbase.",
+                                "required" : false,
+                                "type" : "string"
+                              },
+                              "username" : {
+                                "description" : "The username to connect to the Couchbase cluster.",
+                                "required" : true,
+                                "type" : "string"
+                              }
+                            }
+                          },
+                          "vector-db-sink_jdbc" : {
+                            "type" : "vector-db-sink",
+                            "name" : "JDBC",
+                            "description" : "Writes data to any JDBC compatible database.",
+                            "properties" : {
+                              "datasource" : {
+                                "description" : "Resource id. The target resource must be type: 'datasource' or 'vector-database' and service: 'jdbc'.",
+                                "required" : true,
+                                "type" : "string"
+                              },
+                              "fields" : {
+                                "description" : "Fields of the table to write to.",
+                                "required" : true,
+                                "type" : "array",
+                                "items" : {
+                                  "description" : "Fields of the table to write to.",
+                                  "required" : true,
+                                  "type" : "object",
+                                  "properties" : {
+                                    "expression" : {
+                                      "description" : "JSTL Expression for computing the field value.",
+                                      "required" : true,
+                                      "type" : "string"
+                                    },
+                                    "name" : {
+                                      "description" : "Field name",
+                                      "required" : true,
+                                      "type" : "string"
+                                    },
+                                    "primary-key" : {
+                                      "description" : "Is this field part of the primary key?",
+                                      "required" : false,
+                                      "type" : "boolean",
+                                      "defaultValue" : "false"
+                                    }
+                                  }
+                                }
+                              },
+                              "table-name" : {
+                                "description" : "The name of the table to write to. The table must already exist.",
+                                "required" : true,
+                                "type" : "string"
+                              }
+                            }
+                          },
+                          "vector-db-sink_milvus" : {
+                            "type" : "vector-db-sink",
+                            "name" : "Milvus",
+                            "description" : "Writes data to Milvus/Zillis service.",
+                            "properties" : {
+                              "collection-name" : {
+                                "description" : "Collection name",
+                                "required" : false,
+                                "type" : "string"
+                              },
+                              "database-name" : {
+                                "description" : "Collection name",
+                                "required" : false,
+                                "type" : "string"
+                              },
+                              "datasource" : {
+                                "description" : "Resource id. The target resource must be type: 'datasource' or 'vector-database' and service: 'milvus'.",
+                                "required" : true,
+                                "type" : "string"
+                              },
+                              "fields" : {
+                                "description" : "Fields definition.",
+                                "required" : true,
+                                "type" : "array",
+                                "items" : {
+                                  "description" : "Fields definition.",
+                                  "required" : true,
+                                  "type" : "object",
+                                  "properties" : {
+                                    "expression" : {
+                                      "description" : "JSTL Expression for computing the field value.",
+                                      "required" : true,
+                                      "type" : "string"
+                                    },
+                                    "name" : {
+                                      "description" : "Field name",
+                                      "required" : true,
+                                      "type" : "string"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "vector-db-sink_opensearch" : {
+                            "type" : "vector-db-sink",
+                            "name" : "OpenSearch",
+                            "description" : "Writes data to OpenSearch or AWS OpenSearch serverless.",
+                            "properties" : {
+                              "batch-size" : {
+                                "description" : "Batch size for bulk operations. Hitting the batch size will trigger a flush.",
+                                "required" : false,
+                                "type" : "integer",
+                                "defaultValue" : "10"
+                              },
+                              "bulk-parameters" : {
+                                "description" : "OpenSearch bulk URL parameters.",
+                                "required" : false,
+                                "type" : "object",
+                                "properties" : {
+                                  "pipeline" : {
+                                    "description" : "The pipeline ID for preprocessing documents.\\nRefer to the OpenSearch documentation for more details.",
+                                    "required" : false,
+                                    "type" : "string"
+                                  },
+                                  "refresh" : {
+                                    "description" : "Whether to refresh the affected shards after performing the indexing operations. Default is false. true makes the changes show up in search results immediately, but hurts cluster performance. wait_for waits for a refresh. Requests take longer to return, but cluster performance doesn’t suffer.\\nNote that AWS OpenSearch supports only false.\\nRefer to the OpenSearch documentation for more details.",
+                                    "required" : false,
+                                    "type" : "string"
+                                  },
+                                  "require_alias" : {
+                                    "description" : "Set to true to require that all actions target an index alias rather than an index.\\nRefer to the OpenSearch documentation for more details.",
+                                    "required" : false,
+                                    "type" : "boolean"
+                                  },
+                                  "routing" : {
+                                    "description" : "Routes the request to the specified shard.\\nRefer to the OpenSearch documentation for more details.",
+                                    "required" : false,
+                                    "type" : "string"
+                                  },
+                                  "timeout" : {
+                                    "description" : "How long to wait for the request to return.\\nRefer to the OpenSearch documentation for more details.",
+                                    "required" : false,
+                                    "type" : "string"
+                                  },
+                                  "wait_for_active_shards" : {
+                                    "description" : "Specifies the number of active shards that must be available before OpenSearch processes the bulk request. Default is 1 (only the primary shard). Set to all or a positive integer. Values greater than 1 require replicas. For example, if you specify a value of 3, the index must have two replicas distributed across two additional nodes for the request to succeed.\\nRefer to the OpenSearch documentation for more details.",
+                                    "required" : false,
+                                    "type" : "string"
+                                  }
+                                }
+                              },
+                              "datasource" : {
+                                "description" : "Resource id. The target resource must be type: 'datasource' or 'vector-database' and service: 'opensearch'.",
+                                "required" : true,
+                                "type" : "string"
+                              },
+                              "fields" : {
+                                "description" : "Index fields definition.",
+                                "required" : true,
+                                "type" : "array",
+                                "items" : {
+                                  "description" : "Index fields definition.",
+                                  "required" : true,
+                                  "type" : "object",
+                                  "properties" : {
+                                    "expression" : {
+                                      "description" : "JSTL Expression for computing the field value.",
+                                      "required" : true,
+                                      "type" : "string"
+                                    },
+                                    "name" : {
+                                      "description" : "Field name",
+                                      "required" : true,
+                                      "type" : "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "flush-interval" : {
+                                "description" : "Flush interval in milliseconds",
+                                "required" : false,
+                                "type" : "integer",
+                                "defaultValue" : "1000"
+                              },
+                              "id" : {
+                                "description" : "JSTL Expression to compute the index _id field. Leave it empty to let OpenSearch auto-generate the _id field.",
+                                "required" : false,
+                                "type" : "string"
+                              }
+                            }
+                          },
+                          "vector-db-sink_pinecone" : {
+                            "type" : "vector-db-sink",
+                            "name" : "Pinecone",
+                            "description" : "Writes data to Pinecone service.\\n    To add metadata fields you can add vector.metadata.my-field: \\"value.my-field\\". The value is a JSTL Expression to compute the actual value.",
+                            "properties" : {
+                              "datasource" : {
+                                "description" : "Resource id. The target resource must be type: 'datasource' or 'vector-database' and service: 'pinecone'.",
+                                "required" : true,
+                                "type" : "string"
+                              },
+                              "vector.id" : {
+                                "description" : "JSTL Expression to compute the id.",
+                                "required" : false,
+                                "type" : "string"
+                              },
+                              "vector.metadata" : {
+                                "description" : "Metadata to append. The key is the metadata name and the value the JSTL Expression to compute the actual value.",
+                                "required" : false,
+                                "type" : "object"
+                              },
+                              "vector.namespace" : {
+                                "description" : "JSTL Expression to compute the namespace.",
+                                "required" : false,
+                                "type" : "string"
+                              },
+                              "vector.vector" : {
+                                "description" : "JSTL Expression to compute the vector.",
+                                "required" : false,
+                                "type" : "string"
+                              }
+                            }
+                          },
+                          "vector-db-sink_solr" : {
+                            "type" : "vector-db-sink",
+                            "name" : "Apache Solr",
+                            "description" : "Writes data to Apache Solr service.\\n    The collection-name is configured at datasource level.",
+                            "properties" : {
+                              "commit-within" : {
+                                "description" : "Commit within option",
+                                "required" : false,
+                                "type" : "integer",
+                                "defaultValue" : "1000"
+                              },
+                              "datasource" : {
+                                "description" : "Resource id. The target resource must be type: 'datasource' or 'vector-database' and service: 'solr'.",
+                                "required" : true,
+                                "type" : "string"
+                              },
+                              "fields" : {
+                                "description" : "Fields definition.",
+                                "required" : true,
+                                "type" : "array",
+                                "items" : {
+                                  "description" : "Fields definition.",
+                                  "required" : true,
+                                  "type" : "object",
+                                  "properties" : {
+                                    "expression" : {
+                                      "description" : "JSTL Expression for computing the field value.",
+                                      "required" : true,
+                                      "type" : "string"
+                                    },
+                                    "name" : {
+                                      "description" : "Field name",
+                                      "required" : true,
+                                      "type" : "string"
+                                    }
+                                  }
+                                }
+                              }
                             }
                           }
-                        }
-                      }
-                    }
-                  },
-                  "vector-db-sink_cassandra" : {
-                    "type" : "vector-db-sink",
-                    "name" : "Cassandra",
-                    "description" : "Writes data to Apache Cassandra.\\nAll the options from DataStax Kafka Sink are supported: https://docs.datastax.com/en/kafka/doc/kafka/kafkaConfigTasksTOC.html",
-                    "properties" : {
-                      "datasource" : {
-                        "description" : "Resource id. The target resource must be type: 'datasource' or 'vector-database' and service: 'cassandra'.",
-                        "required" : true,
-                        "type" : "string"
-                      },
-                      "keyspace" : {
-                        "description" : "The keyspace of the table to write to.",
-                        "required" : false,
-                        "type" : "string"
-                      },
-                      "mapping" : {
-                        "description" : "Comma separated list of mapping between the table column and the record field. e.g. my_colum_id=key, my_column_name=value.name.",
-                        "required" : true,
-                        "type" : "string"
-                      },
-                      "table-name" : {
-                        "description" : "The name of the table to write to. The table must already exist.",
-                        "required" : true,
-                        "type" : "string"
-                      }
-                    }
-                  },
-                  "vector-db-sink_couchbase" : {
-                    "type" : "vector-db-sink",
-                    "name" : "Couchbase Vector DB",
-                    "description" : "Writes data to Couchbase Capella.\\nAll the options from DataStax Kafka Sink are supported: https://docs.datastax.com/en/kafka/doc/kafka/kafkaConfigTasksTOC.html",
-                    "properties" : {
-                      "bucket-name" : {
-                        "description" : "The name of the bucket to write to.",
-                        "required" : true,
-                        "type" : "string"
-                      },
-                      "connection-string" : {
-                        "description" : "The connection string to the Couchbase cluster.",
-                        "required" : true,
-                        "type" : "string"
-                      },
-                      "datasource" : {
-                        "description" : "Resource id. The target resource must be type: 'datasource' or 'vector-database' and service: 'couchbase'.",
-                        "required" : true,
-                        "type" : "string"
-                      },
-                      "password" : {
-                        "description" : "The password to connect to the Couchbase cluster.",
-                        "required" : true,
-                        "type" : "string"
-                      },
-                      "username" : {
-                        "description" : "The username to connect to the Couchbase cluster.",
-                        "required" : true,
-                        "type" : "string"
-                      }
-                    }
-                  },
-                  "vector-db-sink_jdbc" : {
-                    "type" : "vector-db-sink",
-                    "name" : "JDBC",
-                    "description" : "Writes data to any JDBC compatible database.",
-                    "properties" : {
-                      "datasource" : {
-                        "description" : "Resource id. The target resource must be type: 'datasource' or 'vector-database' and service: 'jdbc'.",
-                        "required" : true,
-                        "type" : "string"
-                      },
-                      "fields" : {
-                        "description" : "Fields of the table to write to.",
-                        "required" : true,
-                        "type" : "array",
-                        "items" : {
-                          "description" : "Fields of the table to write to.",
-                          "required" : true,
-                          "type" : "object",
-                          "properties" : {
-                            "expression" : {
-                              "description" : "JSTL Expression for computing the field value.",
-                              "required" : true,
-                              "type" : "string"
-                            },
-                            "name" : {
-                              "description" : "Field name",
-                              "required" : true,
-                              "type" : "string"
-                            },
-                            "primary-key" : {
-                              "description" : "Is this field part of the primary key?",
-                              "required" : false,
-                              "type" : "boolean",
-                              "defaultValue" : "false"
-                            }
-                          }
-                        }
-                      },
-                      "table-name" : {
-                        "description" : "The name of the table to write to. The table must already exist.",
-                        "required" : true,
-                        "type" : "string"
-                      }
-                    }
-                  },
-                  "vector-db-sink_milvus" : {
-                    "type" : "vector-db-sink",
-                    "name" : "Milvus",
-                    "description" : "Writes data to Milvus/Zillis service.",
-                    "properties" : {
-                      "collection-name" : {
-                        "description" : "Collection name",
-                        "required" : false,
-                        "type" : "string"
-                      },
-                      "database-name" : {
-                        "description" : "Collection name",
-                        "required" : false,
-                        "type" : "string"
-                      },
-                      "datasource" : {
-                        "description" : "Resource id. The target resource must be type: 'datasource' or 'vector-database' and service: 'milvus'.",
-                        "required" : true,
-                        "type" : "string"
-                      },
-                      "fields" : {
-                        "description" : "Fields definition.",
-                        "required" : true,
-                        "type" : "array",
-                        "items" : {
-                          "description" : "Fields definition.",
-                          "required" : true,
-                          "type" : "object",
-                          "properties" : {
-                            "expression" : {
-                              "description" : "JSTL Expression for computing the field value.",
-                              "required" : true,
-                              "type" : "string"
-                            },
-                            "name" : {
-                              "description" : "Field name",
-                              "required" : true,
-                              "type" : "string"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "vector-db-sink_opensearch" : {
-                    "type" : "vector-db-sink",
-                    "name" : "OpenSearch",
-                    "description" : "Writes data to OpenSearch or AWS OpenSearch serverless.",
-                    "properties" : {
-                      "batch-size" : {
-                        "description" : "Batch size for bulk operations. Hitting the batch size will trigger a flush.",
-                        "required" : false,
-                        "type" : "integer",
-                        "defaultValue" : "10"
-                      },
-                      "bulk-parameters" : {
-                        "description" : "OpenSearch bulk URL parameters.",
-                        "required" : false,
-                        "type" : "object",
-                        "properties" : {
-                          "pipeline" : {
-                            "description" : "The pipeline ID for preprocessing documents.\\nRefer to the OpenSearch documentation for more details.",
-                            "required" : false,
-                            "type" : "string"
-                          },
-                          "refresh" : {
-                            "description" : "Whether to refresh the affected shards after performing the indexing operations. Default is false. true makes the changes show up in search results immediately, but hurts cluster performance. wait_for waits for a refresh. Requests take longer to return, but cluster performance doesn’t suffer.\\nNote that AWS OpenSearch supports only false.\\nRefer to the OpenSearch documentation for more details.",
-                            "required" : false,
-                            "type" : "string"
-                          },
-                          "require_alias" : {
-                            "description" : "Set to true to require that all actions target an index alias rather than an index.\\nRefer to the OpenSearch documentation for more details.",
-                            "required" : false,
-                            "type" : "boolean"
-                          },
-                          "routing" : {
-                            "description" : "Routes the request to the specified shard.\\nRefer to the OpenSearch documentation for more details.",
-                            "required" : false,
-                            "type" : "string"
-                          },
-                          "timeout" : {
-                            "description" : "How long to wait for the request to return.\\nRefer to the OpenSearch documentation for more details.",
-                            "required" : false,
-                            "type" : "string"
-                          },
-                          "wait_for_active_shards" : {
-                            "description" : "Specifies the number of active shards that must be available before OpenSearch processes the bulk request. Default is 1 (only the primary shard). Set to all or a positive integer. Values greater than 1 require replicas. For example, if you specify a value of 3, the index must have two replicas distributed across two additional nodes for the request to succeed.\\nRefer to the OpenSearch documentation for more details.",
-                            "required" : false,
-                            "type" : "string"
-                          }
-                        }
-                      },
-                      "datasource" : {
-                        "description" : "Resource id. The target resource must be type: 'datasource' or 'vector-database' and service: 'opensearch'.",
-                        "required" : true,
-                        "type" : "string"
-                      },
-                      "fields" : {
-                        "description" : "Index fields definition.",
-                        "required" : true,
-                        "type" : "array",
-                        "items" : {
-                          "description" : "Index fields definition.",
-                          "required" : true,
-                          "type" : "object",
-                          "properties" : {
-                            "expression" : {
-                              "description" : "JSTL Expression for computing the field value.",
-                              "required" : true,
-                              "type" : "string"
-                            },
-                            "name" : {
-                              "description" : "Field name",
-                              "required" : true,
-                              "type" : "string"
-                            }
-                          }
-                        }
-                      },
-                      "flush-interval" : {
-                        "description" : "Flush interval in milliseconds",
-                        "required" : false,
-                        "type" : "integer",
-                        "defaultValue" : "1000"
-                      },
-                      "id" : {
-                        "description" : "JSTL Expression to compute the index _id field. Leave it empty to let OpenSearch auto-generate the _id field.",
-                        "required" : false,
-                        "type" : "string"
-                      }
-                    }
-                  },
-                  "vector-db-sink_pinecone" : {
-                    "type" : "vector-db-sink",
-                    "name" : "Pinecone",
-                    "description" : "Writes data to Pinecone service.\\n    To add metadata fields you can add vector.metadata.my-field: \\"value.my-field\\". The value is a JSTL Expression to compute the actual value.",
-                    "properties" : {
-                      "datasource" : {
-                        "description" : "Resource id. The target resource must be type: 'datasource' or 'vector-database' and service: 'pinecone'.",
-                        "required" : true,
-                        "type" : "string"
-                      },
-                      "vector.id" : {
-                        "description" : "JSTL Expression to compute the id.",
-                        "required" : false,
-                        "type" : "string"
-                      },
-                      "vector.metadata" : {
-                        "description" : "Metadata to append. The key is the metadata name and the value the JSTL Expression to compute the actual value.",
-                        "required" : false,
-                        "type" : "object"
-                      },
-                      "vector.namespace" : {
-                        "description" : "JSTL Expression to compute the namespace.",
-                        "required" : false,
-                        "type" : "string"
-                      },
-                      "vector.vector" : {
-                        "description" : "JSTL Expression to compute the vector.",
-                        "required" : false,
-                        "type" : "string"
-                      }
-                    }
-                  },
-                  "vector-db-sink_solr" : {
-                    "type" : "vector-db-sink",
-                    "name" : "Apache Solr",
-                    "description" : "Writes data to Apache Solr service.\\n    The collection-name is configured at datasource level.",
-                    "properties" : {
-                      "commit-within" : {
-                        "description" : "Commit within option",
-                        "required" : false,
-                        "type" : "integer",
-                        "defaultValue" : "1000"
-                      },
-                      "datasource" : {
-                        "description" : "Resource id. The target resource must be type: 'datasource' or 'vector-database' and service: 'solr'.",
-                        "required" : true,
-                        "type" : "string"
-                      },
-                      "fields" : {
-                        "description" : "Fields definition.",
-                        "required" : true,
-                        "type" : "array",
-                        "items" : {
-                          "description" : "Fields definition.",
-                          "required" : true,
-                          "type" : "object",
-                          "properties" : {
-                            "expression" : {
-                              "description" : "JSTL Expression for computing the field value.",
-                              "required" : true,
-                              "type" : "string"
-                            },
-                            "name" : {
-                              "description" : "Field name",
-                              "required" : true,
-                              "type" : "string"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }""",
+                        }""",
                 SerializationUtil.prettyPrintJson(model));
     }
 }

--- a/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/AgentRunner.java
+++ b/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/AgentRunner.java
@@ -370,6 +370,7 @@ public class AgentRunner {
                     topicAdmin.start();
                     AgentContext agentContext =
                             new SimpleAgentContext(
+                                    configuration.agent().tenant(),
                                     agentId,
                                     consumer,
                                     producer,
@@ -1039,6 +1040,8 @@ public class AgentRunner {
         private final TopicConsumer consumer;
         private final TopicProducer producer;
         private final TopicAdmin topicAdmin;
+
+        private final String tenant;
         private final String globalAgentId;
 
         private final TopicConnectionProvider topicConnectionProvider;
@@ -1051,6 +1054,7 @@ public class AgentRunner {
         private final Set<String> agentsWithPersistentState;
 
         public SimpleAgentContext(
+                String tenant,
                 String globalAgentId,
                 TopicConsumer consumer,
                 TopicProducer producer,
@@ -1061,6 +1065,7 @@ public class AgentRunner {
                 Path basePersistentStateDirectory,
                 Set<String> agentsWithPersistentState,
                 MetricsReporter metricsReporter) {
+            this.tenant = tenant;
             this.consumer = consumer;
             this.producer = producer;
             this.topicAdmin = topicAdmin;
@@ -1098,6 +1103,11 @@ public class AgentRunner {
         @Override
         public String getGlobalAgentId() {
             return globalAgentId;
+        }
+
+        @Override
+        public String getTenant() {
+            return tenant;
         }
 
         @Override


### PR DESCRIPTION
- new boolean option `state-storage-file-prepend-tenant` to prepend the tenant to the status filename. In this way it's possible to reuse the same bucket for the same application in different tenants 
- new string option `state-storage-file-prefix` to set arbitrary string as prefix (before the tenant)
