### PR TITLE
webcrawler: handle content changed and url deleted events

### DIFF
--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/WebCrawlerSource.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/WebCrawlerSource.java
@@ -32,10 +32,12 @@ import ai.langstream.api.runner.code.AgentSource;
 import ai.langstream.api.runner.code.Header;
 import ai.langstream.api.runner.code.Record;
 import ai.langstream.api.runner.code.SimpleRecord;
+import ai.langstream.api.runner.topics.TopicProducer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.minio.*;
 import io.minio.errors.ErrorResponseException;
 import io.minio.errors.MinioException;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -54,6 +56,8 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
+
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -74,7 +78,8 @@ public class WebCrawlerSource extends AbstractAgentCode implements AgentSource {
     private MinioClient minioClient;
     private int reindexIntervalSeconds;
 
-    @Getter private String statusFileName;
+    @Getter
+    private String statusFileName;
     Optional<Path> localDiskPath;
 
     private WebCrawler crawler;
@@ -85,9 +90,12 @@ public class WebCrawlerSource extends AbstractAgentCode implements AgentSource {
 
     private final BlockingQueue<Document> foundDocuments = new LinkedBlockingQueue<>();
 
+    @Getter
     private StatusStorage statusStorage;
 
     private Runnable onReindexStart;
+
+    private TopicProducer deletedDocumentsProducer;
 
     public Runnable getOnReindexStart() {
         return onReindexStart;
@@ -152,7 +160,15 @@ public class WebCrawlerSource extends AbstractAgentCode implements AgentSource {
         WebCrawlerStatus status = new WebCrawlerStatus();
         // this can be overwritten when the status is reloaded
         status.setLastIndexStartTimestamp(System.currentTimeMillis());
-        crawler = new WebCrawler(webCrawlerConfiguration, status, foundDocuments::add);
+        crawler = new WebCrawler(webCrawlerConfiguration, status, foundDocuments::add, this::sendDeletedDocument);
+    }
+
+    private void sendDeletedDocument(String url) throws Exception {
+        if (deletedDocumentsProducer != null) {
+            SimpleRecord simpleRecord = SimpleRecord.of(null, url);
+            // sync so we can handle status correctly
+            deletedDocumentsProducer.write(simpleRecord).get();
+        }
     }
 
     @Override
@@ -217,6 +233,13 @@ public class WebCrawlerSource extends AbstractAgentCode implements AgentSource {
             statusStorage = new S3StatusStorage();
         }
         log.info("Status file is {}", statusFileName);
+
+        final String deletedDocumentsTopic = getString("deleted-documents-topic", null, agentConfiguration);
+        if (deletedDocumentsTopic != null) {
+            deletedDocumentsProducer = agentContext.getTopicConnectionProvider()
+                    .createProducer(agentContext.getGlobalAgentId(), deletedDocumentsTopic, Map.of());
+            deletedDocumentsProducer.start();
+        }
     }
 
     @SneakyThrows
@@ -260,7 +283,13 @@ public class WebCrawlerSource extends AbstractAgentCode implements AgentSource {
             boolean somethingDone = crawler.runCycle();
             if (!somethingDone) {
                 finished = true;
-                log.info("No more documents found.");
+                log.info("No more documents found, checking deleted documents");
+                try {
+                    crawler.runDeletedDocumentsChecker();
+                } catch (Throwable tt) {
+                    log.error("Error checking deleted documents", tt);
+                }
+                log.info("No more documents to check");
                 crawler.getStatus().setLastIndexEndTimestamp(System.currentTimeMillis());
                 if (reindexIntervalSeconds > 0) {
                     Instant next =
@@ -290,7 +319,7 @@ public class WebCrawlerSource extends AbstractAgentCode implements AgentSource {
         processed(0, 1);
         return List.of(
                 new WebCrawlerSourceRecord(
-                        document.content(), document.url(), document.contentType()));
+                        document.content(), document.url(), document.contentType(), document.contentDiff().toString().toLowerCase()));
     }
 
     private void checkReindexIsNeeded() {
@@ -354,16 +383,12 @@ public class WebCrawlerSource extends AbstractAgentCode implements AgentSource {
         }
     }
 
+    @AllArgsConstructor
     private static class WebCrawlerSourceRecord implements Record {
         private final byte[] read;
         private final String url;
         private final String contentType;
-
-        public WebCrawlerSourceRecord(byte[] read, String url, String contentType) {
-            this.read = read;
-            this.url = url;
-            this.contentType = contentType;
-        }
+        private final String contentDiff;
 
         /**
          * the key is used for routing, so it is better to set it to something meaningful. In case
@@ -395,7 +420,8 @@ public class WebCrawlerSource extends AbstractAgentCode implements AgentSource {
         public Collection<Header> headers() {
             return List.of(
                     new SimpleRecord.SimpleHeader("url", url),
-                    new SimpleRecord.SimpleHeader("content_type", contentType));
+                    new SimpleRecord.SimpleHeader("content_type", contentType),
+                    new SimpleRecord.SimpleHeader("content_diff", contentDiff));
         }
 
         @Override
@@ -434,7 +460,7 @@ public class WebCrawlerSource extends AbstractAgentCode implements AgentSource {
                 } catch (IOException e) {
                     log.error("error putting object to s3", e);
                     if (e.getMessage() != null
-                                    && e.getMessage().contains("unexpected end of stream")
+                            && e.getMessage().contains("unexpected end of stream")
                             || e.getMessage().contains("unexpected EOF")
                             || e.getMessage().contains("Broken pipe")) {
                         if (attempt == maxRetries) {
@@ -476,7 +502,7 @@ public class WebCrawlerSource extends AbstractAgentCode implements AgentSource {
                 }
             } catch (ErrorResponseException e) {
                 if (e.errorResponse().code().equals("NoSuchKey")) {
-                    return new Status(List.of(), List.of(), null, null, Map.of());
+                    return new Status(List.of(), List.of(), null, null, Map.of(), Map.of());
                 }
                 throw e;
             }
@@ -512,6 +538,13 @@ public class WebCrawlerSource extends AbstractAgentCode implements AgentSource {
             } else {
                 return null;
             }
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (deletedDocumentsProducer != null) {
+            deletedDocumentsProducer.close();
         }
     }
 }

--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/DocumentDeletedVisitor.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/DocumentDeletedVisitor.java
@@ -15,10 +15,6 @@
  */
 package ai.langstream.agents.webcrawler.crawler;
 
-public record Document(String url, byte[] content, String contentType, ContentDiff contentDiff) {
-    public enum ContentDiff {
-        NEW,
-        CONTENT_CHANGED,
-        CONTENT_UNCHANGED,
-    }
+public interface DocumentDeletedVisitor {
+    void visit(String url) throws Exception;
 }

--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/StatusStorage.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/StatusStorage.java
@@ -17,6 +17,7 @@ package ai.langstream.agents.webcrawler.crawler;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public interface StatusStorage {
     void storeStatus(Status metadata) throws Exception;
@@ -30,7 +31,8 @@ public interface StatusStorage {
             List<StoreUrlReference> urls,
             Long lastIndexEndTimestamp,
             Long lastIndexStartTimestamp,
-            Map<String, RobotsFile> robotFiles) {}
+            Map<String, RobotsFile> robotFiles,
+            Map<String, String> allTimeDocuments) {}
 
     Status getCurrentStatus() throws Exception;
 }

--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/StatusStorage.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/StatusStorage.java
@@ -17,7 +17,6 @@ package ai.langstream.agents.webcrawler.crawler;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 public interface StatusStorage {
     void storeStatus(Status metadata) throws Exception;

--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/WebCrawler.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/WebCrawler.java
@@ -34,7 +34,6 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
-
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.jsoup.Connection;
@@ -303,13 +302,19 @@ public class WebCrawler {
                     Connection.Response response = connect.response();
                     int statusCode = response.statusCode();
                     if (statusCode >= 300) {
-                        log.info("Found document deleted, url {} returned status code: {}", url, statusCode);
+                        log.info(
+                                "Found document deleted, url {} returned status code: {}",
+                                url,
+                                statusCode);
                         deleted = true;
                     }
                 } catch (HttpStatusException e) {
                     int code = e.getStatusCode();
                     if (code >= 400 && code < 500) {
-                        log.info("Found document deleted, url {} returned status code: {}", url, code);
+                        log.info(
+                                "Found document deleted, url {} returned status code: {}",
+                                url,
+                                code);
                         deleted = true;
                     } else {
                         // might be a temporary error
@@ -322,7 +327,10 @@ public class WebCrawler {
                         continue;
                     }
                     if (statusCode >= 300 && statusCode < 500) {
-                        log.info("Found document deleted, url {} returned status code: {}", url, statusCode);
+                        log.info(
+                                "Found document deleted, url {} returned status code: {}",
+                                url,
+                                statusCode);
                         deleted = true;
                     } else {
                         // might be a temporary error
@@ -345,12 +353,11 @@ public class WebCrawler {
     }
 
     private void onDocumentFound(String url, byte[] content, String contentType) {
-        ai.langstream.agents.webcrawler.crawler.Document.ContentDiff contentDiff = status.onDocumentFound(url, content);
-        ai.langstream.agents.webcrawler.crawler.Document doc = new ai.langstream.agents.webcrawler.crawler.Document(
-                url,
-                content,
-                contentType,
-                contentDiff);
+        ai.langstream.agents.webcrawler.crawler.Document.ContentDiff contentDiff =
+                status.onDocumentFound(url, content);
+        ai.langstream.agents.webcrawler.crawler.Document doc =
+                new ai.langstream.agents.webcrawler.crawler.Document(
+                        url, content, contentType, contentDiff);
         visitor.visit(doc);
     }
 

--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/WebCrawler.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/WebCrawler.java
@@ -33,12 +33,8 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
+
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.jsoup.Connection;
@@ -61,10 +57,22 @@ public class WebCrawler {
 
     private final Map<String, SimpleRobotRules> robotsRules = new HashMap<>();
 
+    private final HttpClient httpClient = HttpClient.newHttpClient();
+
+    private final DocumentDeletedVisitor onDocumentDeleted;
+
     public WebCrawler(
             WebCrawlerConfiguration configuration,
             WebCrawlerStatus status,
             DocumentVisitor visitor) {
+        this(configuration, status, visitor, url -> {});
+    }
+
+    public WebCrawler(
+            WebCrawlerConfiguration configuration,
+            WebCrawlerStatus status,
+            DocumentVisitor visitor,
+            DocumentDeletedVisitor onDocumentDeleted) {
         this.configuration = configuration;
         this.visitor = visitor;
         this.status = status;
@@ -75,6 +83,7 @@ public class WebCrawler {
                         ? CookiePolicy.ACCEPT_ALL
                         : CookiePolicy.ACCEPT_NONE);
         this.cookieStore = cookieManager.getCookieStore();
+        this.onDocumentDeleted = onDocumentDeleted;
     }
 
     public void crawl(String startUrl) {
@@ -152,18 +161,12 @@ public class WebCrawler {
             return true;
         }
 
-        Connection connect = Jsoup.connect(current);
-        connect.cookieStore(cookieStore);
-        connect.followRedirects(false);
-        if (configuration.getUserAgent() != null) {
-            connect.userAgent(configuration.getUserAgent());
-        }
-        connect.timeout(configuration.getHttpTimeout());
+        Connection connect = jsoupConnect(current);
 
         boolean redirectedToForbiddenDomain = false;
-        Document document = null;
-        String contentType = null;
-        byte[] binaryContent = null;
+        Document document;
+        String contentType;
+        byte[] binaryContent;
         try {
             document = connect.get();
             Connection.Response response = connect.response();
@@ -222,10 +225,7 @@ public class WebCrawler {
                                 .firstValue("content-type")
                                 .orElse("application/octet-stream");
                 binaryContent = httpResponse.body();
-                visitor.visit(
-                        new ai.langstream.agents.webcrawler.crawler.Document(
-                                current, binaryContent, contentType));
-
+                onDocumentFound(current, binaryContent, contentType);
                 handleThrottling(current);
 
                 return true;
@@ -270,17 +270,88 @@ public class WebCrawler {
                                     }
                                 });
             }
-            visitor.visit(
-                    new ai.langstream.agents.webcrawler.crawler.Document(
-                            current,
-                            document.html().getBytes(StandardCharsets.UTF_8),
-                            contentType));
+            onDocumentFound(current, document.html().getBytes(StandardCharsets.UTF_8), contentType);
         }
 
         // prevent from being banned for flooding
         handleThrottling(current);
 
         return true;
+    }
+
+    private Connection jsoupConnect(String current) {
+        Connection connect = Jsoup.connect(current);
+        connect.cookieStore(cookieStore);
+        connect.followRedirects(false);
+        if (configuration.getUserAgent() != null) {
+            connect.userAgent(configuration.getUserAgent());
+        }
+        connect.timeout(configuration.getHttpTimeout());
+        return connect;
+    }
+
+    public void runDeletedDocumentsChecker() throws Exception {
+        Set<String> toRemove = new HashSet<>();
+        for (String url : status.getAllTimeDocuments().keySet()) {
+            log.info("Checking url still available: {}", url);
+            handleThrottling(url);
+            boolean deleted = false;
+            try {
+                try {
+                    Connection connect = jsoupConnect(url);
+                    connect.get();
+                    Connection.Response response = connect.response();
+                    int statusCode = response.statusCode();
+                    if (statusCode >= 300) {
+                        log.info("Found document deleted, url {} returned status code: {}", url, statusCode);
+                        deleted = true;
+                    }
+                } catch (HttpStatusException e) {
+                    int code = e.getStatusCode();
+                    if (code >= 400 && code < 500) {
+                        log.info("Found document deleted, url {} returned status code: {}", url, code);
+                        deleted = true;
+                    } else {
+                        // might be a temporary error
+                    }
+                } catch (UnsupportedMimeTypeException notHtml) {
+                    handleThrottling(url);
+                    HttpResponse<byte[]> httpResponse = downloadUrl(url);
+                    int statusCode = httpResponse.statusCode();
+                    if (statusCode < 300) {
+                        continue;
+                    }
+                    if (statusCode >= 300 && statusCode < 500) {
+                        log.info("Found document deleted, url {} returned status code: {}", url, statusCode);
+                        deleted = true;
+                    } else {
+                        // might be a temporary error
+                    }
+                }
+            } catch (IOException e) {
+                log.warn("Error while checking the url: {}", url, e);
+            }
+            if (deleted) {
+                toRemove.add(url);
+            }
+        }
+        if (toRemove.isEmpty()) {
+            return;
+        }
+        for (String url : toRemove) {
+            onDocumentDeleted.visit(url);
+            status.getAllTimeDocuments().remove(url);
+        }
+    }
+
+    private void onDocumentFound(String url, byte[] content, String contentType) {
+        ai.langstream.agents.webcrawler.crawler.Document.ContentDiff contentDiff = status.onDocumentFound(url, content);
+        ai.langstream.agents.webcrawler.crawler.Document doc = new ai.langstream.agents.webcrawler.crawler.Document(
+                url,
+                content,
+                contentType,
+                contentDiff);
+        visitor.visit(doc);
     }
 
     private void handleThrottling(String current) throws InterruptedException {
@@ -434,11 +505,10 @@ public class WebCrawler {
     }
 
     private HttpResponse<byte[]> downloadUrl(String url) throws IOException, InterruptedException {
-        HttpClient client = HttpClient.newHttpClient();
         IOException lastError = null;
         for (int i = 0; i < configuration.getMaxErrorCount(); i++) {
             try {
-                return client.send(
+                return httpClient.send(
                         HttpRequest.newBuilder()
                                 .uri(URI.create(url))
                                 .header("User-Agent", configuration.getUserAgent())

--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerStatus.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerStatus.java
@@ -73,7 +73,7 @@ public class WebCrawlerStatus {
     public void reloadFrom(StatusStorage statusStorage) throws Exception {
         StatusStorage.Status currentStatus = statusStorage.getCurrentStatus();
         if (currentStatus != null) {
-            log.info("Found a saved status, reloading... {}", currentStatus);
+            log.info("Found a saved status, reloading");
             pendingUrls.clear();
             remainingUrls.clear();
             urls.clear();

--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerStatus.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerStatus.java
@@ -15,6 +15,8 @@
  */
 package ai.langstream.agents.webcrawler.crawler;
 
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
@@ -28,6 +30,8 @@ import lombok.extern.slf4j.Slf4j;
 @Getter
 @Slf4j
 public class WebCrawlerStatus {
+    private static final char[] HEX_ARRAY = "0123456789ABCDEF".toCharArray();
+
 
     /** Timestamp of the last index start. This is used to avoid reprocessing the indexing. */
     private long lastIndexStartTimestamp = 0;
@@ -65,10 +69,12 @@ public class WebCrawlerStatus {
      */
     private final Map<String, Integer> errorCount = new HashMap<>();
 
+    private final Map<String, String> allTimeDocuments = new HashMap<>();
+
     public void reloadFrom(StatusStorage statusStorage) throws Exception {
         StatusStorage.Status currentStatus = statusStorage.getCurrentStatus();
         if (currentStatus != null) {
-            log.info("Found a saved status, reloading...");
+            log.info("Found a saved status, reloading... {}", currentStatus);
             pendingUrls.clear();
             remainingUrls.clear();
             urls.clear();
@@ -113,6 +119,10 @@ public class WebCrawlerStatus {
             if (robots != null) {
                 robotsFiles.putAll(robots);
             }
+            this.allTimeDocuments.clear();
+            if (currentStatus.allTimeDocuments() != null) {
+                this.allTimeDocuments.putAll(currentStatus.allTimeDocuments());
+            }
         } else {
             log.info("No saved status found, starting from scratch");
         }
@@ -156,7 +166,8 @@ public class WebCrawlerStatus {
                         urlReferencesForStore,
                         lastIndexEndTimestamp,
                         lastIndexStartTimestamp,
-                        new HashMap<>(robotsFiles)));
+                        new HashMap<>(robotsFiles),
+                        allTimeDocuments));
     }
 
     public void addUrl(String url, URLReference.Type type, int depth, boolean toScan) {
@@ -234,5 +245,38 @@ public class WebCrawlerStatus {
             throw new IllegalStateException("Unknown url " + current);
         }
         return reference;
+    }
+
+    public Document.ContentDiff onDocumentFound(final String url, final byte[] content) {
+        try {
+            byte[] md5 = MessageDigest.getInstance("MD5").digest(content);
+            String contentHash = bytesToHex(md5);
+            Document.ContentDiff contentDiff;
+            if (allTimeDocuments.containsKey(url)) {
+                String previousHash = allTimeDocuments.get(url);
+                if (!previousHash.equals(contentHash)) {
+                    contentDiff = Document.ContentDiff.CONTENT_CHANGED;
+                } else {
+                    contentDiff = Document.ContentDiff.CONTENT_UNCHANGED;
+                }
+            } else {
+                contentDiff = Document.ContentDiff.NEW;
+            }
+            allTimeDocuments.put(url, contentHash);
+            return contentDiff;
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+
+    public static String bytesToHex(byte[] bytes) {
+        char[] hexChars = new char[bytes.length * 2];
+        for (int j = 0; j < bytes.length; j++) {
+            int v = bytes[j] & 0xFF;
+            hexChars[j * 2] = HEX_ARRAY[v >>> 4];
+            hexChars[j * 2 + 1] = HEX_ARRAY[v & 0x0F];
+        }
+        return new String(hexChars);
     }
 }

--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerStatus.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerStatus.java
@@ -32,7 +32,6 @@ import lombok.extern.slf4j.Slf4j;
 public class WebCrawlerStatus {
     private static final char[] HEX_ARRAY = "0123456789ABCDEF".toCharArray();
 
-
     /** Timestamp of the last index start. This is used to avoid reprocessing the indexing. */
     private long lastIndexStartTimestamp = 0;
 
@@ -268,7 +267,6 @@ public class WebCrawlerStatus {
             throw new RuntimeException(e);
         }
     }
-
 
     public static String bytesToHex(byte[] bytes) {
         char[] hexChars = new char[bytes.length * 2];

--- a/langstream-agents/langstream-agent-webcrawler/src/test/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerStatusTest.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/test/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerStatusTest.java
@@ -170,7 +170,7 @@ class WebCrawlerStatusTest {
         public Status getCurrentStatus() {
             return lastMetadata != null
                     ? lastMetadata
-                    : new Status(List.of(), List.of(), null, null, Map.of());
+                    : new Status(List.of(), List.of(), null, null, Map.of(), Map.of());
         }
     }
 }

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/WebCrawlerSourceAgentProvider.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/WebCrawlerSourceAgentProvider.java
@@ -301,5 +301,14 @@ public class WebCrawlerSourceAgentProvider extends AbstractComposableAgentProvid
                 defaultValue = "true")
         @JsonProperty("handle-cookies")
         private boolean handleCookies;
+
+        @ConfigProperty(
+                description =
+                        """
+                        Detect documents that have been deleted from the website and send the URL to this topic.
+                        """,
+                defaultValue = "")
+        @JsonProperty("deleted-documents-topic")
+        private String deletedDocumentsTopic;
     }
 }

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/WebCrawlerSourceIT.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/WebCrawlerSourceIT.java
@@ -105,12 +105,10 @@ class WebCrawlerSourceIT extends AbstractKafkaApplicationRunner {
                 deployApplication(
                         tenant, appId, application, buildInstanceYaml(), expectedAgents)) {
 
-
-
             try (KafkaConsumer<String, String> deletedDocumentsConsumer =
-                         createConsumer("deleted-documents");
-                 KafkaConsumer<String, String> consumer =
-                    createConsumer(applicationRuntime.getGlobal("output-topic")); ) {
+                            createConsumer("deleted-documents");
+                    KafkaConsumer<String, String> consumer =
+                            createConsumer(applicationRuntime.getGlobal("output-topic")); ) {
 
                 executeAgentRunners(applicationRuntime);
 
@@ -145,16 +143,15 @@ class WebCrawlerSourceIT extends AbstractKafkaApplicationRunner {
                                 .resolve("%s-%s.webcrawler.status.json".formatted(appId, "step1"));
                 assertTrue(Files.exists(statusFile));
 
-                stubFor(
-                        get("/thirdPage.html")
-                                .willReturn(notFound()));
+                stubFor(get("/thirdPage.html").willReturn(notFound()));
 
                 executeAgentRunners(applicationRuntime);
 
                 waitForMessages(
                         deletedDocumentsConsumer,
-                        List.of("%s/thirdPage.html".formatted(wireMockRuntimeInfo.getHttpBaseUrl())));
-
+                        List.of(
+                                "%s/thirdPage.html"
+                                        .formatted(wireMockRuntimeInfo.getHttpBaseUrl())));
             }
         }
     }

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/WebCrawlerSourceIT.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/WebCrawlerSourceIT.java
@@ -15,9 +15,7 @@
  */
 package ai.langstream.kafka;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.client.WireMock.okForContentType;
-import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
@@ -87,6 +85,8 @@ class WebCrawlerSourceIT extends AbstractKafkaApplicationRunner {
                                 topics:
                                   - name: "${globals.output-topic}"
                                     creation-mode: create-if-not-exists
+                                  - name: "deleted-documents"
+                                    creation-mode: create-if-not-exists
                                 pipeline:
                                   - type: "webcrawler-source"
                                     id: "step1"
@@ -96,6 +96,7 @@ class WebCrawlerSourceIT extends AbstractKafkaApplicationRunner {
                                         allow-non-html-contents: true
                                         allowed-domains: ["%s"]
                                         state-storage: disk
+                                        deleted-documents-topic: "deleted-documents"
                                 """
                                 .formatted(
                                         wireMockRuntimeInfo.getHttpBaseUrl(),
@@ -104,7 +105,11 @@ class WebCrawlerSourceIT extends AbstractKafkaApplicationRunner {
                 deployApplication(
                         tenant, appId, application, buildInstanceYaml(), expectedAgents)) {
 
-            try (KafkaConsumer<String, String> consumer =
+
+
+            try (KafkaConsumer<String, String> deletedDocumentsConsumer =
+                         createConsumer("deleted-documents");
+                 KafkaConsumer<String, String> consumer =
                     createConsumer(applicationRuntime.getGlobal("output-topic")); ) {
 
                 executeAgentRunners(applicationRuntime);
@@ -139,6 +144,17 @@ class WebCrawlerSourceIT extends AbstractKafkaApplicationRunner {
                                 .resolve("step1")
                                 .resolve("%s-%s.webcrawler.status.json".formatted(appId, "step1"));
                 assertTrue(Files.exists(statusFile));
+
+                stubFor(
+                        get("/thirdPage.html")
+                                .willReturn(notFound()));
+
+                executeAgentRunners(applicationRuntime);
+
+                waitForMessages(
+                        deletedDocumentsConsumer,
+                        List.of("%s/thirdPage.html".formatted(wireMockRuntimeInfo.getHttpBaseUrl())));
+
             }
         }
     }


### PR DESCRIPTION
- new option `deleted-documents-topic` which is a topic name where the url is written as value (no key, value schema string) when the url is not available anymore (undeployed from the website)
- new header `content_diff` when emitting the documents with: `new` (first time I see the document from this url), `content_changed` (the document has changed since last time), `content_unchanged` (the document didn't change since last time but a re-index occurred)