### PR TITLE
deployer: use configmaps instead of init containers

### DIFF
--- a/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/CRDConstants.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/CRDConstants.java
@@ -36,7 +36,6 @@ public class CRDConstants {
 
     public static final String SETUP_JOB_CONFIGMAP_PREFIX = "langstream-app-setup-";
 
-
     // The name of the secret containing the cluster configuration.
     // This secret cannot clash with application's secrets since this is an invalid application id
     // (more than 20 chars).

--- a/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/CRDConstants.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/CRDConstants.java
@@ -29,9 +29,13 @@ public class CRDConstants {
 
     public static final String DEPLOYER_JOB_PREFIX_CLEANUP = "langstream-runtime-deployer-cleanup-";
     public static final String DEPLOYER_JOB_PREFIX_DEPLOYER = "langstream-runtime-deployer-";
+    public static final String DEPLOYER_JOB_CONFIGMAP_PREFIX = "langstream-runtime-deployer-";
 
     public static final String SETUP_JOB_PREFIX_CLEANUP = "langstream-app-setup-cleanup-";
     public static final String SETUP_JOB_PREFIX_DEPLOYER = "langstream-app-setup-";
+
+    public static final String SETUP_JOB_CONFIGMAP_PREFIX = "langstream-app-setup-";
+
 
     // The name of the secret containing the cluster configuration.
     // This secret cannot clash with application's secrets since this is an invalid application id

--- a/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/apps/AppResourcesFactory.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/apps/AppResourcesFactory.java
@@ -33,21 +33,11 @@ import ai.langstream.runtime.api.application.ApplicationSetupConfiguration;
 import ai.langstream.runtime.api.application.ApplicationSetupConstants;
 import ai.langstream.runtime.api.deployer.RuntimeDeployerConfiguration;
 import ai.langstream.runtime.api.deployer.RuntimeDeployerConstants;
-import io.fabric8.kubernetes.api.model.Container;
-import io.fabric8.kubernetes.api.model.ContainerBuilder;
-import io.fabric8.kubernetes.api.model.EmptyDirVolumeSource;
-import io.fabric8.kubernetes.api.model.EnvVar;
-import io.fabric8.kubernetes.api.model.EnvVarBuilder;
-import io.fabric8.kubernetes.api.model.KeyToPathBuilder;
-import io.fabric8.kubernetes.api.model.Pod;
-import io.fabric8.kubernetes.api.model.Quantity;
-import io.fabric8.kubernetes.api.model.Volume;
-import io.fabric8.kubernetes.api.model.VolumeBuilder;
-import io.fabric8.kubernetes.api.model.VolumeMount;
-import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
+import io.fabric8.kubernetes.api.model.*;
 import io.fabric8.kubernetes.api.model.batch.v1.Job;
 import io.fabric8.kubernetes.api.model.batch.v1.JobBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -55,18 +45,23 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
+
 import lombok.Builder;
 import lombok.Getter;
 import lombok.SneakyThrows;
 
 public class AppResourcesFactory {
 
+    public static final String JOB_CONFIGMAP_KEY_CLUSTER_RUNTIME = "cluster-runtime-config";
+    public static final String JOB_CONFIGMAP_KEY_APP_CONFIG = "app-config";
+
     @Builder
     @Getter
     public static class GenerateJobParams {
         private ApplicationCustomResource applicationCustomResource;
         private boolean deleteJob;
-        @Builder.Default private Map<String, Object> clusterRuntimeConfiguration = Map.of();
+        @Builder.Default
+        private Map<String, Object> clusterRuntimeConfiguration = Map.of();
         private String image;
         private String imagePullPolicy;
         private PodTemplate podTemplate;
@@ -77,67 +72,38 @@ public class AppResourcesFactory {
         final ApplicationCustomResource applicationCustomResource =
                 Objects.requireNonNull(params.getApplicationCustomResource());
         final boolean isDeleteJob = params.isDeleteJob();
-        final Map<String, Object> clusterRuntimeConfiguration =
-                params.getClusterRuntimeConfiguration();
         final String image = params.getImage();
         final String imagePullPolicy = params.getImagePullPolicy();
 
         final String applicationId = applicationCustomResource.getMetadata().getName();
         final ApplicationSpec spec = applicationCustomResource.getSpec();
         final String tenant = spec.getTenant();
-        final ApplicationSpecOptions applicationSpecOptions =
-                ApplicationSpec.deserializeOptions(spec.getOptions());
 
-        final String clusterRuntimeConfigVolumeName = "cluster-runtime-config";
-        final String appConfigVolumeName = "app-config";
 
         final String containerImage = resolveContainerImage(image, spec);
         final String containerImagePullPolicy =
                 resolveContainerImagePullPolicy(imagePullPolicy, spec);
 
-        RuntimeDeployerConfiguration.DeployFlags deployFlags =
-                new RuntimeDeployerConfiguration.DeployFlags();
-        deployFlags.setRuntimeVersion(applicationSpecOptions.getRuntimeVersion());
-        deployFlags.setAutoUpgradeRuntimeImagePullPolicy(
-                applicationSpecOptions.isAutoUpgradeRuntimeImagePullPolicy());
-        deployFlags.setAutoUpgradeAgentResources(
-                applicationSpecOptions.isAutoUpgradeAgentResources());
-        deployFlags.setAutoUpgradeAgentPodTemplate(
-                applicationSpecOptions.isAutoUpgradeAgentPodTemplate());
-        deployFlags.setSeed(applicationSpecOptions.getSeed());
-        final RuntimeDeployerConfiguration config =
-                new RuntimeDeployerConfiguration(
-                        applicationId,
-                        tenant,
-                        spec.getApplication(),
-                        spec.getCodeArchiveId(),
-                        deployFlags);
 
-        Map<String, Object> initContainerConfigs = new LinkedHashMap<>();
-        initContainerConfigs.put(appConfigVolumeName, config);
-        initContainerConfigs.put(clusterRuntimeConfigVolumeName, clusterRuntimeConfiguration);
-        final Container initContainer =
-                createInitContainerInjectingConfig(
-                        "deployer-init-config",
-                        containerImage,
-                        containerImagePullPolicy,
-                        initContainerConfigs);
         final String command = isDeleteJob ? "delete" : "deploy";
         final String clusterConfigVolume = "cluster-config";
+        final String configMapVolumeName = "app-configs";
 
         final List<VolumeMount> volumeMounts =
                 List.of(
                         new VolumeMountBuilder()
-                                .withName(appConfigVolumeName)
-                                .withMountPath("/%s".formatted(appConfigVolumeName))
+                                .withName(configMapVolumeName)
+                                .withMountPath("/%s".formatted(JOB_CONFIGMAP_KEY_APP_CONFIG))
+                                .withSubPath(JOB_CONFIGMAP_KEY_APP_CONFIG)
+                                .build(),
+                        new VolumeMountBuilder()
+                                .withName(configMapVolumeName)
+                                .withMountPath("/%s".formatted(JOB_CONFIGMAP_KEY_CLUSTER_RUNTIME))
+                                .withSubPath(JOB_CONFIGMAP_KEY_CLUSTER_RUNTIME)
                                 .build(),
                         new VolumeMountBuilder()
                                 .withName("app-secrets")
                                 .withMountPath("/app-secrets")
-                                .build(),
-                        new VolumeMountBuilder()
-                                .withName(clusterRuntimeConfigVolumeName)
-                                .withMountPath("/%s".formatted(clusterRuntimeConfigVolumeName))
                                 .build(),
                         new VolumeMountBuilder()
                                 .withName(clusterConfigVolume)
@@ -147,11 +113,11 @@ public class AppResourcesFactory {
                 List.of(
                         new EnvVarBuilder()
                                 .withName(RuntimeDeployerConstants.APP_CONFIG_ENV)
-                                .withValue("/%s/config".formatted(appConfigVolumeName))
+                                .withValue("/%s".formatted(JOB_CONFIGMAP_KEY_APP_CONFIG))
                                 .build(),
                         new EnvVarBuilder()
                                 .withName(RuntimeDeployerConstants.CLUSTER_RUNTIME_CONFIG_ENV)
-                                .withValue("/%s/config".formatted(clusterRuntimeConfigVolumeName))
+                                .withValue("/%s".formatted(JOB_CONFIGMAP_KEY_CLUSTER_RUNTIME))
                                 .build(),
                         new EnvVarBuilder()
                                 .withName(RuntimeDeployerConstants.APP_SECRETS_ENV)
@@ -170,8 +136,8 @@ public class AppResourcesFactory {
                 List.of(
                         "deployer-runtime",
                         command,
-                        "/%s/config".formatted(clusterRuntimeConfigVolumeName),
-                        "/%s/config".formatted(appConfigVolumeName),
+                        "/%s".formatted(JOB_CONFIGMAP_KEY_CLUSTER_RUNTIME),
+                        "/%s".formatted(JOB_CONFIGMAP_KEY_APP_CONFIG),
                         "/app-secrets/secrets");
         final String containerName = "deployer";
         final Container container =
@@ -187,18 +153,16 @@ public class AppResourcesFactory {
         final List<Volume> volumes =
                 List.of(
                         new VolumeBuilder()
-                                .withName(appConfigVolumeName)
-                                .withEmptyDir(new EmptyDirVolumeSource())
+                                .withName(configMapVolumeName)
+                                .withNewConfigMap()
+                                .withName(getDeployerJobConfigMap(applicationId))
+                                .endConfigMap()
                                 .build(),
                         new VolumeBuilder()
                                 .withName("app-secrets")
                                 .withNewSecret()
                                 .withSecretName(applicationId)
                                 .endSecret()
-                                .build(),
-                        new VolumeBuilder()
-                                .withName(clusterRuntimeConfigVolumeName)
-                                .withEmptyDir(new EmptyDirVolumeSource())
                                 .build(),
                         new VolumeBuilder()
                                 .withName(clusterConfigVolume)
@@ -221,10 +185,66 @@ public class AppResourcesFactory {
                 params,
                 jobName,
                 labels,
-                List.of(initContainer),
                 container,
                 volumes,
                 serviceAccountName);
+    }
+
+    @SneakyThrows
+    public static ConfigMap generateJobConfigMap(GenerateJobParams params, boolean isSetup) {
+        final ApplicationCustomResource applicationCustomResource =
+                Objects.requireNonNull(params.getApplicationCustomResource());
+        final String applicationId = applicationCustomResource.getMetadata().getName();
+        final ApplicationSpec spec = applicationCustomResource.getSpec();
+        final String tenant = spec.getTenant();
+        final String serializedAppConfig;
+
+        if (isSetup) {
+            final ApplicationSetupConfiguration config =
+                    new ApplicationSetupConfiguration(
+                            applicationId, tenant, spec.getApplication(), spec.getCodeArchiveId());
+            serializedAppConfig = SerializationUtil.writeAsJson(config);
+        } else {
+            final ApplicationSpecOptions applicationSpecOptions =
+                    ApplicationSpec.deserializeOptions(spec.getOptions());
+            RuntimeDeployerConfiguration.DeployFlags deployFlags =
+                    new RuntimeDeployerConfiguration.DeployFlags();
+            deployFlags.setRuntimeVersion(applicationSpecOptions.getRuntimeVersion());
+            deployFlags.setAutoUpgradeRuntimeImagePullPolicy(
+                    applicationSpecOptions.isAutoUpgradeRuntimeImagePullPolicy());
+            deployFlags.setAutoUpgradeAgentResources(
+                    applicationSpecOptions.isAutoUpgradeAgentResources());
+            deployFlags.setAutoUpgradeAgentPodTemplate(
+                    applicationSpecOptions.isAutoUpgradeAgentPodTemplate());
+            deployFlags.setSeed(applicationSpecOptions.getSeed());
+            final RuntimeDeployerConfiguration config =
+                    new RuntimeDeployerConfiguration(
+                            applicationId,
+                            tenant,
+                            spec.getApplication(),
+                            spec.getCodeArchiveId(),
+                            deployFlags);
+            serializedAppConfig = SerializationUtil.writeAsJson(config);
+        }
+
+        final Map<String, String> labels = isSetup ? getLabelsForSetup(false, applicationId) : getLabelsForDeployer(false, applicationId);
+        final String name = isSetup ? getSetupJobConfigMap(applicationId) : getDeployerJobConfigMap(applicationId);
+        return new ConfigMapBuilder()
+                .withNewMetadata()
+                .withName(name)
+                .withNamespace(applicationCustomResource.getMetadata().getNamespace())
+                .withOwnerReferences(List.of(
+                        KubeUtil.getOwnerReferenceForResource(applicationCustomResource)
+                ))
+                .withLabels(labels)
+                .endMetadata()
+                .withData(
+                        Map.of(
+                                JOB_CONFIGMAP_KEY_APP_CONFIG, serializedAppConfig,
+                                JOB_CONFIGMAP_KEY_CLUSTER_RUNTIME, SerializationUtil.writeAsJson(params.getClusterRuntimeConfiguration())
+                        )
+                )
+                .build();
     }
 
     @SneakyThrows
@@ -232,8 +252,6 @@ public class AppResourcesFactory {
         final ApplicationCustomResource applicationCustomResource =
                 Objects.requireNonNull(params.getApplicationCustomResource());
         final boolean isDeleteJob = params.isDeleteJob();
-        final Map<String, Object> clusterRuntimeConfiguration =
-                params.getClusterRuntimeConfiguration();
         final String image = params.getImage();
         final String imagePullPolicy = params.getImagePullPolicy();
 
@@ -241,40 +259,29 @@ public class AppResourcesFactory {
         final ApplicationSpec spec = applicationCustomResource.getSpec();
         final String tenant = spec.getTenant();
 
-        final String clusterRuntimeConfigVolumeName = "cluster-runtime-config";
-        final String appConfigVolumeName = "app-config";
         final String clusterConfigVolume = "cluster-config";
 
         final String containerImage = resolveContainerImage(image, spec);
         final String containerImagePullPolicy =
                 resolveContainerImagePullPolicy(imagePullPolicy, spec);
 
-        final ApplicationSetupConfiguration config =
-                new ApplicationSetupConfiguration(
-                        applicationId, tenant, spec.getApplication(), spec.getCodeArchiveId());
 
-        Map<String, Object> initContainerConfigs = new LinkedHashMap<>();
-        initContainerConfigs.put(appConfigVolumeName, config);
-        initContainerConfigs.put(clusterRuntimeConfigVolumeName, clusterRuntimeConfiguration);
-        final Container initContainer =
-                createInitContainerInjectingConfig(
-                        "setup-init-config",
-                        containerImage,
-                        containerImagePullPolicy,
-                        initContainerConfigs);
+        String configMapVolumeName = "app-configs";
         final List<VolumeMount> volumeMounts =
                 List.of(
                         new VolumeMountBuilder()
-                                .withName(appConfigVolumeName)
-                                .withMountPath("/%s".formatted(appConfigVolumeName))
+                                .withName(configMapVolumeName)
+                                .withMountPath("/%s".formatted(JOB_CONFIGMAP_KEY_APP_CONFIG))
+                                .withSubPath(JOB_CONFIGMAP_KEY_APP_CONFIG)
+                                .build(),
+                        new VolumeMountBuilder()
+                                .withName(configMapVolumeName)
+                                .withMountPath("/%s".formatted(JOB_CONFIGMAP_KEY_CLUSTER_RUNTIME))
+                                .withSubPath(JOB_CONFIGMAP_KEY_CLUSTER_RUNTIME)
                                 .build(),
                         new VolumeMountBuilder()
                                 .withName("app-secrets")
                                 .withMountPath("/app-secrets")
-                                .build(),
-                        new VolumeMountBuilder()
-                                .withName(clusterRuntimeConfigVolumeName)
-                                .withMountPath("/%s".formatted(clusterRuntimeConfigVolumeName))
                                 .build(),
                         new VolumeMountBuilder()
                                 .withName(clusterConfigVolume)
@@ -284,11 +291,11 @@ public class AppResourcesFactory {
                 List.of(
                         new EnvVarBuilder()
                                 .withName(ApplicationSetupConstants.APP_CONFIG_ENV)
-                                .withValue("/%s/config".formatted(appConfigVolumeName))
+                                .withValue("/%s".formatted(JOB_CONFIGMAP_KEY_APP_CONFIG))
                                 .build(),
                         new EnvVarBuilder()
                                 .withName(ApplicationSetupConstants.CLUSTER_RUNTIME_CONFIG_ENV)
-                                .withValue("/%s/config".formatted(clusterRuntimeConfigVolumeName))
+                                .withValue("/%s".formatted(JOB_CONFIGMAP_KEY_CLUSTER_RUNTIME))
                                 .build(),
                         new EnvVarBuilder()
                                 .withName(ApplicationSetupConstants.APP_SECRETS_ENV)
@@ -319,18 +326,16 @@ public class AppResourcesFactory {
         final List<Volume> volumes =
                 List.of(
                         new VolumeBuilder()
-                                .withName(appConfigVolumeName)
-                                .withEmptyDir(new EmptyDirVolumeSource())
+                                .withName(configMapVolumeName)
+                                .withNewConfigMap()
+                                .withName(getSetupJobConfigMap(applicationId))
+                                .endConfigMap()
                                 .build(),
                         new VolumeBuilder()
                                 .withName("app-secrets")
                                 .withNewSecret()
                                 .withSecretName(applicationId)
                                 .endSecret()
-                                .build(),
-                        new VolumeBuilder()
-                                .withName(clusterRuntimeConfigVolumeName)
-                                .withEmptyDir(new EmptyDirVolumeSource())
                                 .build(),
                         new VolumeBuilder()
                                 .withName(clusterConfigVolume)
@@ -353,7 +358,6 @@ public class AppResourcesFactory {
                 params,
                 jobName,
                 labels,
-                List.of(initContainer),
                 container,
                 volumes,
                 serviceAccountName);
@@ -386,7 +390,6 @@ public class AppResourcesFactory {
             GenerateJobParams params,
             String jobName,
             final Map<String, String> labels,
-            List<Container> initContainers,
             Container container,
             List<Volume> volumes,
             String serviceAccountName) {
@@ -414,7 +417,6 @@ public class AppResourcesFactory {
                 .withNodeSelector(podTemplate != null ? podTemplate.nodeSelector() : null)
                 .withServiceAccountName(serviceAccountName)
                 .withVolumes(volumes)
-                .withInitContainers(initContainers)
                 .withContainers(List.of(container))
                 .withRestartPolicy("Never")
                 .endSpec()
@@ -447,33 +449,6 @@ public class AppResourcesFactory {
         return containerImage;
     }
 
-    private static Container createInitContainerInjectingConfig(
-            String containerName,
-            String containerImage,
-            String containerImagePullPolicy,
-            Map<String, Object> configs) {
-        final ContainerBuilder builder =
-                new ContainerBuilder()
-                        .withName(containerName)
-                        .withImage(containerImage)
-                        .withImagePullPolicy(containerImagePullPolicy)
-                        .withCommand("bash", "-c");
-
-        List<String> cmds = new ArrayList<>();
-        List<VolumeMount> volumeMounts = new ArrayList<>();
-        for (Map.Entry<String, Object> entry : configs.entrySet()) {
-            final String jsonValue = SerializationUtil.writeInlineBashJson(entry.getValue());
-            cmds.add("echo '%s' > /%s/config".formatted(jsonValue, entry.getKey()));
-            volumeMounts.add(
-                    new VolumeMountBuilder()
-                            .withName(entry.getKey())
-                            .withMountPath("/%s".formatted(entry.getKey()))
-                            .build());
-        }
-        return builder.withArgs(cmds.stream().collect(Collectors.joining(" && ")))
-                .withVolumeMounts(volumeMounts)
-                .build();
-    }
 
     private static Map<String, String> getPodAnnotations(PodTemplate podTemplate) {
         final Map<String, String> annotations = new HashMap<>();
@@ -517,6 +492,14 @@ public class AppResourcesFactory {
         } else {
             return SETUP_JOB_PREFIX_DEPLOYER + applicationId;
         }
+    }
+
+    public static String getSetupJobConfigMap(String applicationId) {
+        return CRDConstants.SETUP_JOB_CONFIGMAP_PREFIX + applicationId;
+    }
+
+    public static String getDeployerJobConfigMap(String applicationId) {
+        return CRDConstants.DEPLOYER_JOB_CONFIGMAP_PREFIX + applicationId;
     }
 
     public static ApplicationLifecycleStatus computeApplicationStatus(
@@ -594,7 +577,7 @@ public class AppResourcesFactory {
         if (!CRDConstants.RESOURCE_NAME_PATTERN.matcher(applicationId).matches()) {
             throw new IllegalArgumentException(
                     ("Application id '%s' contains illegal characters. Allowed characters are alphanumeric and "
-                                    + "dash.")
+                            + "dash.")
                             .formatted(applicationId));
         }
 

--- a/langstream-k8s-deployer/langstream-k8s-deployer-core/src/test/java/ai/langstream/deployer/k8s/apps/AppResourcesFactoryTest.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-core/src/test/java/ai/langstream/deployer/k8s/apps/AppResourcesFactoryTest.java
@@ -234,7 +234,7 @@ class AppResourcesFactoryTest {
                             app: langstream-deployer
                             langstream-application: test-'app
                             langstream-scope: deploy
-                          name: langstream-app-setup-test-'app
+                          name: langstream-runtime-deployer-test-'app
                           namespace: default
                           ownerReferences:
                           - apiVersion: langstream.ai/v1alpha1

--- a/langstream-k8s-deployer/langstream-k8s-deployer-core/src/test/java/ai/langstream/deployer/k8s/apps/AppResourcesFactoryTest.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-core/src/test/java/ai/langstream/deployer/k8s/apps/AppResourcesFactoryTest.java
@@ -251,7 +251,8 @@ class AppResourcesFactoryTest {
                                 AppResourcesFactory.GenerateJobParams.builder()
                                         .applicationCustomResource(resource)
                                         .clusterRuntimeConfiguration(Map.of("config1", "value"))
-                                        .build(), false)));
+                                        .build(),
+                                false)));
     }
 
     @Test
@@ -465,7 +466,8 @@ class AppResourcesFactoryTest {
                                 AppResourcesFactory.GenerateJobParams.builder()
                                         .applicationCustomResource(resource)
                                         .clusterRuntimeConfiguration(Map.of("config1", "value"))
-                                        .build(), true)));
+                                        .build(),
+                                true)));
     }
 
     @ParameterizedTest
@@ -571,11 +573,14 @@ class AppResourcesFactoryTest {
                                 .deleteJob(false)
                                 .image("busybox:v1")
                                 .imagePullPolicy("Never")
-                                .build(), false);
+                                .build(),
+                        false);
         System.out.println("config=" + configMap.getData().get("app-config"));
 
         assertTrue(
-                configMap.getData().get("app-config")
+                configMap
+                        .getData()
+                        .get("app-config")
                         .contains(
                                 "\"deployFlags\":{\"runtimeVersion\":null,\"autoUpgradeRuntimeImagePullPolicy\":false,\"autoUpgradeAgentResources\":false,\"autoUpgradeAgentPodTemplate\":false,\"seed\":0}"));
     }
@@ -604,10 +609,13 @@ class AppResourcesFactoryTest {
                                 .deleteJob(false)
                                 .image("busybox:v1")
                                 .imagePullPolicy("Never")
-                                .build(), false);
+                                .build(),
+                        false);
         System.out.println("config=" + configMap.getData().get("app-config"));
         assertTrue(
-                configMap.getData().get("app-config")
+                configMap
+                        .getData()
+                        .get("app-config")
                         .contains(
                                 "\"deployFlags\":{\"runtimeVersion\":\"auto-upgrade\",\"autoUpgradeRuntimeImagePullPolicy\":true,\"autoUpgradeAgentResources\":true,\"autoUpgradeAgentPodTemplate\":true,\"seed\":0}"));
     }

--- a/langstream-k8s-deployer/langstream-k8s-deployer-core/src/test/java/ai/langstream/deployer/k8s/apps/AppResourcesFactoryTest.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-core/src/test/java/ai/langstream/deployer/k8s/apps/AppResourcesFactoryTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import ai.langstream.deployer.k8s.PodTemplate;
 import ai.langstream.deployer.k8s.api.crds.apps.ApplicationCustomResource;
 import ai.langstream.deployer.k8s.util.SerializationUtil;
+import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.Toleration;
 import io.fabric8.kubernetes.api.model.TolerationBuilder;
@@ -82,14 +83,14 @@ class AppResourcesFactoryTest {
                               - args:
                                 - deployer-runtime
                                 - deploy
-                                - /cluster-runtime-config/config
-                                - /app-config/config
+                                - /cluster-runtime-config
+                                - /app-config
                                 - /app-secrets/secrets
                                 env:
                                 - name: LANGSTREAM_RUNTIME_DEPLOYER_APP_CONFIGURATION
-                                  value: /app-config/config
+                                  value: /app-config
                                 - name: LANGSTREAM_RUNTIME_DEPLOYER_CLUSTER_RUNTIME_CONFIGURATION
-                                  value: /cluster-runtime-config/config
+                                  value: /cluster-runtime-config
                                 - name: LANGSTREAM_RUNTIME_DEPLOYER_APP_SECRETS
                                   value: /app-secrets/secrets
                                 - name: LANGSTREAM_RUNTIME_DEPLOYER_CLUSTER_CONFIGURATION
@@ -106,37 +107,24 @@ class AppResourcesFactoryTest {
                                 terminationMessagePolicy: FallbackToLogsOnError
                                 volumeMounts:
                                 - mountPath: /app-config
-                                  name: app-config
+                                  name: app-configs
+                                  subPath: app-config
+                                - mountPath: /cluster-runtime-config
+                                  name: app-configs
+                                  subPath: cluster-runtime-config
                                 - mountPath: /app-secrets
                                   name: app-secrets
-                                - mountPath: /cluster-runtime-config
-                                  name: cluster-runtime-config
                                 - mountPath: /cluster-config
                                   name: cluster-config
-                              initContainers:
-                              - args:
-                                - "echo '{\\"applicationId\\":\\"test-'\\"'\\"'app\\",\\"tenant\\":\\"my-tenant\\",\\"application\\":\\"{app: true}\\",\\"codeStorageArchiveId\\":\\"iiii\\",\\"deployFlags\\":{\\"runtimeVersion\\":null,\\"autoUpgradeRuntimeImagePullPolicy\\":false,\\"autoUpgradeAgentResources\\":false,\\"autoUpgradeAgentPodTemplate\\":false,\\"seed\\":0}}' > /app-config/config && echo '{}' > /cluster-runtime-config/config"
-                                command:
-                                - bash
-                                - -c
-                                image: ubuntu
-                                imagePullPolicy: Always
-                                name: deployer-init-config
-                                volumeMounts:
-                                - mountPath: /app-config
-                                  name: app-config
-                                - mountPath: /cluster-runtime-config
-                                  name: cluster-runtime-config
                               restartPolicy: Never
                               serviceAccountName: my-tenant
                               volumes:
-                              - emptyDir: {}
-                                name: app-config
+                              - configMap:
+                                  name: langstream-runtime-deployer-test-'app
+                                name: app-configs
                               - name: app-secrets
                                 secret:
                                   secretName: test-'app
-                              - emptyDir: {}
-                                name: cluster-runtime-config
                               - name: cluster-config
                                 secret:
                                   items:
@@ -181,14 +169,14 @@ class AppResourcesFactoryTest {
                               - args:
                                 - deployer-runtime
                                 - delete
-                                - /cluster-runtime-config/config
-                                - /app-config/config
+                                - /cluster-runtime-config
+                                - /app-config
                                 - /app-secrets/secrets
                                 env:
                                 - name: LANGSTREAM_RUNTIME_DEPLOYER_APP_CONFIGURATION
-                                  value: /app-config/config
+                                  value: /app-config
                                 - name: LANGSTREAM_RUNTIME_DEPLOYER_CLUSTER_RUNTIME_CONFIGURATION
-                                  value: /cluster-runtime-config/config
+                                  value: /cluster-runtime-config
                                 - name: LANGSTREAM_RUNTIME_DEPLOYER_APP_SECRETS
                                   value: /app-secrets/secrets
                                 - name: LANGSTREAM_RUNTIME_DEPLOYER_CLUSTER_CONFIGURATION
@@ -205,37 +193,24 @@ class AppResourcesFactoryTest {
                                 terminationMessagePolicy: FallbackToLogsOnError
                                 volumeMounts:
                                 - mountPath: /app-config
-                                  name: app-config
+                                  name: app-configs
+                                  subPath: app-config
+                                - mountPath: /cluster-runtime-config
+                                  name: app-configs
+                                  subPath: cluster-runtime-config
                                 - mountPath: /app-secrets
                                   name: app-secrets
-                                - mountPath: /cluster-runtime-config
-                                  name: cluster-runtime-config
                                 - mountPath: /cluster-config
                                   name: cluster-config
-                              initContainers:
-                              - args:
-                                - "echo '{\\"applicationId\\":\\"test-'\\"'\\"'app\\",\\"tenant\\":\\"my-tenant\\",\\"application\\":\\"{app: true}\\",\\"codeStorageArchiveId\\":\\"iiii\\",\\"deployFlags\\":{\\"runtimeVersion\\":null,\\"autoUpgradeRuntimeImagePullPolicy\\":false,\\"autoUpgradeAgentResources\\":false,\\"autoUpgradeAgentPodTemplate\\":false,\\"seed\\":0}}' > /app-config/config && echo '{}' > /cluster-runtime-config/config"
-                                command:
-                                - bash
-                                - -c
-                                image: ubuntu
-                                imagePullPolicy: Always
-                                name: deployer-init-config
-                                volumeMounts:
-                                - mountPath: /app-config
-                                  name: app-config
-                                - mountPath: /cluster-runtime-config
-                                  name: cluster-runtime-config
                               restartPolicy: Never
                               serviceAccountName: my-tenant
                               volumes:
-                              - emptyDir: {}
-                                name: app-config
+                              - configMap:
+                                  name: langstream-runtime-deployer-test-'app
+                                name: app-configs
                               - name: app-secrets
                                 secret:
                                   secretName: test-'app
-                              - emptyDir: {}
-                                name: cluster-runtime-config
                               - name: cluster-config
                                 secret:
                                   items:
@@ -249,6 +224,34 @@ class AppResourcesFactoryTest {
                                         .applicationCustomResource(resource)
                                         .deleteJob(true)
                                         .build())));
+        assertEquals(
+                """
+                        ---
+                        apiVersion: v1
+                        kind: ConfigMap
+                        metadata:
+                          labels:
+                            app: langstream-deployer
+                            langstream-application: test-'app
+                            langstream-scope: deploy
+                          name: langstream-app-setup-test-'app
+                          namespace: default
+                          ownerReferences:
+                          - apiVersion: langstream.ai/v1alpha1
+                            kind: Application
+                            blockOwnerDeletion: true
+                            controller: true
+                            name: test-'app
+                        data:
+                          app-config: "{\\"applicationId\\":\\"test-'app\\",\\"tenant\\":\\"my-tenant\\",\\"application\\":\\"{app: true}\\",\\"codeStorageArchiveId\\":\\"iiii\\",\\"deployFlags\\":{\\"runtimeVersion\\":null,\\"autoUpgradeRuntimeImagePullPolicy\\":false,\\"autoUpgradeAgentResources\\":false,\\"autoUpgradeAgentPodTemplate\\":false,\\"seed\\":0}}"
+                          cluster-runtime-config: "{\\"config1\\":\\"value\\"}"
+                        """,
+                SerializationUtil.writeAsYaml(
+                        AppResourcesFactory.generateJobConfigMap(
+                                AppResourcesFactory.GenerateJobParams.builder()
+                                        .applicationCustomResource(resource)
+                                        .clusterRuntimeConfiguration(Map.of("config1", "value"))
+                                        .build(), false)));
     }
 
     @Test
@@ -302,9 +305,9 @@ class AppResourcesFactoryTest {
                                 - deploy
                                 env:
                                 - name: LANGSTREAM_APPLICATION_SETUP_APP_CONFIGURATION
-                                  value: /app-config/config
+                                  value: /app-config
                                 - name: LANGSTREAM_APPLICATION_SETUP_CLUSTER_RUNTIME_CONFIGURATION
-                                  value: /cluster-runtime-config/config
+                                  value: /cluster-runtime-config
                                 - name: LANGSTREAM_APPLICATION_SETUP_APP_SECRETS
                                   value: /app-secrets/secrets
                                 - name: LANGSTREAM_APPLICATION_SETUP_CLUSTER_CONFIGURATION
@@ -321,37 +324,24 @@ class AppResourcesFactoryTest {
                                 terminationMessagePolicy: FallbackToLogsOnError
                                 volumeMounts:
                                 - mountPath: /app-config
-                                  name: app-config
+                                  name: app-configs
+                                  subPath: app-config
+                                - mountPath: /cluster-runtime-config
+                                  name: app-configs
+                                  subPath: cluster-runtime-config
                                 - mountPath: /app-secrets
                                   name: app-secrets
-                                - mountPath: /cluster-runtime-config
-                                  name: cluster-runtime-config
                                 - mountPath: /cluster-config
                                   name: cluster-config
-                              initContainers:
-                              - args:
-                                - "echo '{\\"applicationId\\":\\"test-'\\"'\\"'app\\",\\"tenant\\":\\"my-tenant\\",\\"application\\":\\"{app: true}\\",\\"codeArchiveId\\":\\"iiii\\"}' > /app-config/config && echo '{}' > /cluster-runtime-config/config"
-                                command:
-                                - bash
-                                - -c
-                                image: ubuntu
-                                imagePullPolicy: Always
-                                name: setup-init-config
-                                volumeMounts:
-                                - mountPath: /app-config
-                                  name: app-config
-                                - mountPath: /cluster-runtime-config
-                                  name: cluster-runtime-config
                               restartPolicy: Never
                               serviceAccountName: runtime-my-tenant
                               volumes:
-                              - emptyDir: {}
-                                name: app-config
+                              - configMap:
+                                  name: langstream-app-setup-test-'app
+                                name: app-configs
                               - name: app-secrets
                                 secret:
                                   secretName: test-'app
-                              - emptyDir: {}
-                                name: cluster-runtime-config
                               - name: cluster-config
                                 secret:
                                   items:
@@ -398,9 +388,9 @@ class AppResourcesFactoryTest {
                                 - cleanup
                                 env:
                                 - name: LANGSTREAM_APPLICATION_SETUP_APP_CONFIGURATION
-                                  value: /app-config/config
+                                  value: /app-config
                                 - name: LANGSTREAM_APPLICATION_SETUP_CLUSTER_RUNTIME_CONFIGURATION
-                                  value: /cluster-runtime-config/config
+                                  value: /cluster-runtime-config
                                 - name: LANGSTREAM_APPLICATION_SETUP_APP_SECRETS
                                   value: /app-secrets/secrets
                                 - name: LANGSTREAM_APPLICATION_SETUP_CLUSTER_CONFIGURATION
@@ -417,37 +407,24 @@ class AppResourcesFactoryTest {
                                 terminationMessagePolicy: FallbackToLogsOnError
                                 volumeMounts:
                                 - mountPath: /app-config
-                                  name: app-config
+                                  name: app-configs
+                                  subPath: app-config
+                                - mountPath: /cluster-runtime-config
+                                  name: app-configs
+                                  subPath: cluster-runtime-config
                                 - mountPath: /app-secrets
                                   name: app-secrets
-                                - mountPath: /cluster-runtime-config
-                                  name: cluster-runtime-config
                                 - mountPath: /cluster-config
                                   name: cluster-config
-                              initContainers:
-                              - args:
-                                - "echo '{\\"applicationId\\":\\"test-'\\"'\\"'app\\",\\"tenant\\":\\"my-tenant\\",\\"application\\":\\"{app: true}\\",\\"codeArchiveId\\":\\"iiii\\"}' > /app-config/config && echo '{}' > /cluster-runtime-config/config"
-                                command:
-                                - bash
-                                - -c
-                                image: ubuntu
-                                imagePullPolicy: Always
-                                name: setup-init-config
-                                volumeMounts:
-                                - mountPath: /app-config
-                                  name: app-config
-                                - mountPath: /cluster-runtime-config
-                                  name: cluster-runtime-config
                               restartPolicy: Never
                               serviceAccountName: runtime-my-tenant
                               volumes:
-                              - emptyDir: {}
-                                name: app-config
+                              - configMap:
+                                  name: langstream-app-setup-test-'app
+                                name: app-configs
                               - name: app-secrets
                                 secret:
                                   secretName: test-'app
-                              - emptyDir: {}
-                                name: cluster-runtime-config
                               - name: cluster-config
                                 secret:
                                   items:
@@ -461,6 +438,34 @@ class AppResourcesFactoryTest {
                                         .applicationCustomResource(resource)
                                         .deleteJob(true)
                                         .build())));
+        assertEquals(
+                """
+                        ---
+                        apiVersion: v1
+                        kind: ConfigMap
+                        metadata:
+                          labels:
+                            app: langstream-setup
+                            langstream-application: test-'app
+                            langstream-scope: deploy
+                          name: langstream-app-setup-test-'app
+                          namespace: default
+                          ownerReferences:
+                          - apiVersion: langstream.ai/v1alpha1
+                            kind: Application
+                            blockOwnerDeletion: true
+                            controller: true
+                            name: test-'app
+                        data:
+                          app-config: "{\\"applicationId\\":\\"test-'app\\",\\"tenant\\":\\"my-tenant\\",\\"application\\":\\"{app: true}\\",\\"codeArchiveId\\":\\"iiii\\"}"
+                          cluster-runtime-config: "{\\"config1\\":\\"value\\"}"
+                        """,
+                SerializationUtil.writeAsYaml(
+                        AppResourcesFactory.generateJobConfigMap(
+                                AppResourcesFactory.GenerateJobParams.builder()
+                                        .applicationCustomResource(resource)
+                                        .clusterRuntimeConfiguration(Map.of("config1", "value"))
+                                        .build(), true)));
     }
 
     @ParameterizedTest
@@ -559,21 +564,18 @@ class AppResourcesFactoryTest {
                     options: '{"runtimeImage": null, "autoUpgradeRuntimeImagePullPolicy": false, "autoUpgradeAgentResources": false, "autoUpgradeAgentPodTemplate": false}'
                 """);
 
-        Job job =
-                AppResourcesFactory.generateDeployerJob(
+        ConfigMap configMap =
+                AppResourcesFactory.generateJobConfigMap(
                         AppResourcesFactory.GenerateJobParams.builder()
                                 .applicationCustomResource(resource)
                                 .deleteJob(false)
                                 .image("busybox:v1")
                                 .imagePullPolicy("Never")
-                                .build());
-        final Container container =
-                job.getSpec().getTemplate().getSpec().getInitContainers().get(0);
-        System.out.println("args=" + container.getArgs().get(0));
+                                .build(), false);
+        System.out.println("config=" + configMap.getData().get("app-config"));
+
         assertTrue(
-                container
-                        .getArgs()
-                        .get(0)
+                configMap.getData().get("app-config")
                         .contains(
                                 "\"deployFlags\":{\"runtimeVersion\":null,\"autoUpgradeRuntimeImagePullPolicy\":false,\"autoUpgradeAgentResources\":false,\"autoUpgradeAgentPodTemplate\":false,\"seed\":0}"));
     }
@@ -595,21 +597,17 @@ class AppResourcesFactoryTest {
                     options: '{"runtimeVersion": "auto-upgrade", "autoUpgradeRuntimeImagePullPolicy": true, "autoUpgradeAgentResources": true, "autoUpgradeAgentPodTemplate": true}'
                 """);
 
-        Job job =
-                AppResourcesFactory.generateDeployerJob(
+        ConfigMap configMap =
+                AppResourcesFactory.generateJobConfigMap(
                         AppResourcesFactory.GenerateJobParams.builder()
                                 .applicationCustomResource(resource)
                                 .deleteJob(false)
                                 .image("busybox:v1")
                                 .imagePullPolicy("Never")
-                                .build());
-        final Container container =
-                job.getSpec().getTemplate().getSpec().getInitContainers().get(0);
-        System.out.println("args=" + container.getArgs().get(0));
+                                .build(), false);
+        System.out.println("config=" + configMap.getData().get("app-config"));
         assertTrue(
-                container
-                        .getArgs()
-                        .get(0)
+                configMap.getData().get("app-config")
                         .contains(
                                 "\"deployFlags\":{\"runtimeVersion\":\"auto-upgrade\",\"autoUpgradeRuntimeImagePullPolicy\":true,\"autoUpgradeAgentResources\":true,\"autoUpgradeAgentPodTemplate\":true,\"seed\":0}"));
     }

--- a/langstream-k8s-deployer/langstream-k8s-deployer-core/src/test/java/ai/langstream/deployer/k8s/apps/ApplicationCustomResourceTest.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-core/src/test/java/ai/langstream/deployer/k8s/apps/ApplicationCustomResourceTest.java
@@ -218,7 +218,8 @@ class ApplicationCustomResourceTest {
                                 AppResourcesFactory.GenerateJobParams.builder()
                                         .applicationCustomResource(resource)
                                         .deleteJob(deleteJob)
-                                        .build(), false))
+                                        .build(),
+                                false))
                 .inNamespace(namespace)
                 .serverSideApply();
         k3s.getClient()
@@ -236,10 +237,10 @@ class ApplicationCustomResourceTest {
                                 AppResourcesFactory.GenerateJobParams.builder()
                                         .applicationCustomResource(resource)
                                         .deleteJob(deleteJob)
-                                        .build(), true))
+                                        .build(),
+                                true))
                 .inNamespace(namespace)
                 .serverSideApply();
-
 
         k3s.getClient()
                 .resource(

--- a/langstream-k8s-deployer/langstream-k8s-deployer-core/src/test/java/ai/langstream/deployer/k8s/apps/ApplicationCustomResourceTest.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-core/src/test/java/ai/langstream/deployer/k8s/apps/ApplicationCustomResourceTest.java
@@ -60,7 +60,7 @@ class ApplicationCustomResourceTest {
                                     status.getStatus());
                             assertEquals(
                                     "failed to create containerd task: failed to create shim task: OCI runtime create failed: "
-                                            + "runc create failed: unable to start container process: exec: \"bash\": executable file not "
+                                            + "runc create failed: unable to start container process: exec: \"deployer-runtime\": executable file not "
                                             + "found in $PATH: unknown",
                                     status.getReason());
                         });
@@ -84,7 +84,7 @@ class ApplicationCustomResourceTest {
                                     status.getStatus());
                             assertEquals(
                                     "failed to create containerd task: failed to create shim task: OCI runtime create failed: "
-                                            + "runc create failed: unable to start container process: exec: \"bash\": executable file not "
+                                            + "runc create failed: unable to start container process: exec: \"deployer-runtime\": executable file not "
                                             + "found in $PATH: unknown",
                                     status.getReason());
                         });
@@ -211,6 +211,16 @@ class ApplicationCustomResourceTest {
         }
         resource.setStatus(status);
         k3s.getClient().resource(resource).inNamespace(namespace).updateStatus();
+
+        k3s.getClient()
+                .resource(
+                        AppResourcesFactory.generateJobConfigMap(
+                                AppResourcesFactory.GenerateJobParams.builder()
+                                        .applicationCustomResource(resource)
+                                        .deleteJob(deleteJob)
+                                        .build(), false))
+                .inNamespace(namespace)
+                .serverSideApply();
         k3s.getClient()
                 .resource(
                         AppResourcesFactory.generateDeployerJob(
@@ -220,6 +230,16 @@ class ApplicationCustomResourceTest {
                                         .build()))
                 .inNamespace(namespace)
                 .serverSideApply();
+        k3s.getClient()
+                .resource(
+                        AppResourcesFactory.generateJobConfigMap(
+                                AppResourcesFactory.GenerateJobParams.builder()
+                                        .applicationCustomResource(resource)
+                                        .deleteJob(deleteJob)
+                                        .build(), true))
+                .inNamespace(namespace)
+                .serverSideApply();
+
 
         k3s.getClient()
                 .resource(

--- a/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/test/java/ai/langstream/deployer/k8s/controllers/AppControllerIT.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/test/java/ai/langstream/deployer/k8s/controllers/AppControllerIT.java
@@ -31,13 +31,11 @@ import io.fabric8.kubernetes.api.model.batch.v1.Job;
 import io.fabric8.kubernetes.api.model.batch.v1.JobBuilder;
 import io.fabric8.kubernetes.api.model.batch.v1.JobSpec;
 import io.fabric8.kubernetes.client.KubernetesClient;
-
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -387,30 +385,25 @@ public class AppControllerIT {
                         .orElseThrow()
                         .getValue());
 
-
-        List<Volume> volumes = spec.getTemplate()
-                .getSpec()
-                .getVolumes();
+        List<Volume> volumes = spec.getTemplate().getSpec().getVolumes();
         Volume appConfigsVolume = volumes.get(0);
         assertEquals("app-configs", appConfigsVolume.getName());
         assertEquals("langstream-app-setup-my-app", appConfigsVolume.getConfigMap().getName());
 
-        ConfigMap configMap = deployment.getClient()
-                .configMaps()
-                .inNamespace(job.getMetadata().getNamespace())
-                .withName(appConfigsVolume.getConfigMap().getName())
-                .get();
+        ConfigMap configMap =
+                deployment
+                        .getClient()
+                        .configMaps()
+                        .inNamespace(job.getMetadata().getNamespace())
+                        .withName(appConfigsVolume.getConfigMap().getName())
+                        .get();
 
         assertEquals(2, configMap.getData().size());
         assertEquals(
                 "{\"applicationId\":\"my-app\",\"tenant\":\"my-tenant\",\"application\":\"{\\\"modules\\\": {}}\",\"codeArchiveId\":null}",
                 configMap.getData().get("app-config"));
 
-        assertEquals(
-                "{}",
-                configMap.getData().get("cluster-runtime-config"));
-
-
+        assertEquals("{}", configMap.getData().get("cluster-runtime-config"));
     }
 
     private void checkDeployerJob(Job job, boolean cleanup) {
@@ -474,28 +467,26 @@ public class AppControllerIT {
                         .orElseThrow()
                         .getValue());
 
-        List<Volume> volumes = spec.getTemplate()
-                .getSpec()
-                .getVolumes();
+        List<Volume> volumes = spec.getTemplate().getSpec().getVolumes();
         Volume appConfigsVolume = volumes.get(0);
         assertEquals("app-configs", appConfigsVolume.getName());
         String configMapName = appConfigsVolume.getConfigMap().getName();
         assertEquals("langstream-runtime-deployer-my-app", configMapName);
 
-        ConfigMap configMap = deployment.getClient()
-                .configMaps()
-                .inNamespace(job.getMetadata().getNamespace())
-                .withName(configMapName)
-                .get();
+        ConfigMap configMap =
+                deployment
+                        .getClient()
+                        .configMaps()
+                        .inNamespace(job.getMetadata().getNamespace())
+                        .withName(configMapName)
+                        .get();
 
         assertEquals(2, configMap.getData().size());
         assertEquals(
                 "{\"applicationId\":\"my-app\",\"tenant\":\"my-tenant\",\"application\":\"{\\\"modules\\\": {}}\",\"codeStorageArchiveId\":null,\"deployFlags\":{\"runtimeVersion\":null,\"autoUpgradeRuntimeImagePullPolicy\":false,\"autoUpgradeAgentResources\":false,\"autoUpgradeAgentPodTemplate\":false,\"seed\":0}}",
                 configMap.getData().get("app-config"));
 
-        assertEquals(
-                "{}",
-                configMap.getData().get("cluster-runtime-config"));
+        assertEquals("{}", configMap.getData().get("cluster-runtime-config"));
     }
 
     private ApplicationCustomResource getCr(String yaml) {

--- a/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/test/java/ai/langstream/deployer/k8s/controllers/AppControllerIT.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/test/java/ai/langstream/deployer/k8s/controllers/AppControllerIT.java
@@ -26,22 +26,18 @@ import ai.langstream.deployer.k8s.api.crds.apps.ApplicationStatus;
 import ai.langstream.deployer.k8s.apps.AppResourcesFactory;
 import ai.langstream.deployer.k8s.controllers.apps.AppController;
 import ai.langstream.deployer.k8s.util.SerializationUtil;
-import io.fabric8.kubernetes.api.model.Container;
-import io.fabric8.kubernetes.api.model.ContainerBuilder;
-import io.fabric8.kubernetes.api.model.NamespaceBuilder;
-import io.fabric8.kubernetes.api.model.PodSpec;
-import io.fabric8.kubernetes.api.model.Quantity;
-import io.fabric8.kubernetes.api.model.SecretBuilder;
-import io.fabric8.kubernetes.api.model.ServiceAccountBuilder;
+import io.fabric8.kubernetes.api.model.*;
 import io.fabric8.kubernetes.api.model.batch.v1.Job;
 import io.fabric8.kubernetes.api.model.batch.v1.JobBuilder;
 import io.fabric8.kubernetes.api.model.batch.v1.JobSpec;
 import io.fabric8.kubernetes.client.KubernetesClient;
+
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -352,29 +348,69 @@ public class AppControllerIT {
         assertEquals(Quantity.parse("100m"), container.getResources().getRequests().get("cpu"));
         assertEquals(Quantity.parse("128Mi"), container.getResources().getRequests().get("memory"));
         assertEquals("/app-config", container.getVolumeMounts().get(0).getMountPath());
-        assertEquals("app-config", container.getVolumeMounts().get(0).getName());
-        assertEquals("/app-secrets", container.getVolumeMounts().get(1).getMountPath());
-        assertEquals("app-secrets", container.getVolumeMounts().get(1).getName());
+        assertEquals("app-configs", container.getVolumeMounts().get(0).getName());
+        assertEquals("/cluster-runtime-config", container.getVolumeMounts().get(1).getMountPath());
+        assertEquals("app-configs", container.getVolumeMounts().get(1).getName());
+        assertEquals("/app-secrets", container.getVolumeMounts().get(2).getMountPath());
+        assertEquals("app-secrets", container.getVolumeMounts().get(2).getName());
+        assertEquals("/cluster-config", container.getVolumeMounts().get(3).getMountPath());
+        assertEquals("cluster-config", container.getVolumeMounts().get(3).getName());
         assertEquals(0, container.getCommand().size());
         int args = 0;
         assertEquals("application-setup", container.getArgs().get(args++));
         assertEquals("deploy", container.getArgs().get(args++));
+        assertEquals(
+                "/app-config",
+                container.getEnv().stream()
+                        .filter(
+                                e ->
+                                        "LANGSTREAM_APPLICATION_SETUP_APP_CONFIGURATION"
+                                                .equals(e.getName()))
+                        .findFirst()
+                        .orElseThrow()
+                        .getValue());
+        assertEquals(
+                "/cluster-runtime-config",
+                container.getEnv().stream()
+                        .filter(
+                                e ->
+                                        "LANGSTREAM_APPLICATION_SETUP_CLUSTER_RUNTIME_CONFIGURATION"
+                                                .equals(e.getName()))
+                        .findFirst()
+                        .orElseThrow()
+                        .getValue());
+        assertEquals(
+                "/app-secrets/secrets",
+                container.getEnv().stream()
+                        .filter(e -> "LANGSTREAM_APPLICATION_SETUP_APP_SECRETS".equals(e.getName()))
+                        .findFirst()
+                        .orElseThrow()
+                        .getValue());
 
-        final Container initContainer = templateSpec.getInitContainers().get(0);
-        assertEquals("bash", initContainer.getImage());
-        assertEquals("IfNotPresent", initContainer.getImagePullPolicy());
-        assertEquals("setup-init-config", initContainer.getName());
-        assertEquals("/app-config", initContainer.getVolumeMounts().get(0).getMountPath());
-        assertEquals("app-config", initContainer.getVolumeMounts().get(0).getName());
+
+        List<Volume> volumes = spec.getTemplate()
+                .getSpec()
+                .getVolumes();
+        Volume appConfigsVolume = volumes.get(0);
+        assertEquals("app-configs", appConfigsVolume.getName());
+        assertEquals("langstream-app-setup-my-app", appConfigsVolume.getConfigMap().getName());
+
+        ConfigMap configMap = deployment.getClient()
+                .configMaps()
+                .inNamespace(job.getMetadata().getNamespace())
+                .withName(appConfigsVolume.getConfigMap().getName())
+                .get();
+
+        assertEquals(2, configMap.getData().size());
         assertEquals(
-                "/cluster-runtime-config", initContainer.getVolumeMounts().get(1).getMountPath());
-        assertEquals("cluster-runtime-config", initContainer.getVolumeMounts().get(1).getName());
-        assertEquals("bash", initContainer.getCommand().get(0));
-        assertEquals("-c", initContainer.getCommand().get(1));
+                "{\"applicationId\":\"my-app\",\"tenant\":\"my-tenant\",\"application\":\"{\\\"modules\\\": {}}\",\"codeArchiveId\":null}",
+                configMap.getData().get("app-config"));
+
         assertEquals(
-                "echo '{\"applicationId\":\"my-app\",\"tenant\":\"my-tenant\",\"application\":\"{\\\"modules\\\": "
-                        + "{}}\",\"codeArchiveId\":null}' > /app-config/config && echo '{}' > /cluster-runtime-config/config",
-                initContainer.getArgs().get(0));
+                "{}",
+                configMap.getData().get("cluster-runtime-config"));
+
+
     }
 
     private void checkDeployerJob(Job job, boolean cleanup) {
@@ -387,27 +423,31 @@ public class AppControllerIT {
         assertEquals(Quantity.parse("100m"), container.getResources().getRequests().get("cpu"));
         assertEquals(Quantity.parse("128Mi"), container.getResources().getRequests().get("memory"));
         assertEquals("/app-config", container.getVolumeMounts().get(0).getMountPath());
-        assertEquals("app-config", container.getVolumeMounts().get(0).getName());
-        assertEquals("/app-secrets", container.getVolumeMounts().get(1).getMountPath());
-        assertEquals("app-secrets", container.getVolumeMounts().get(1).getName());
+        assertEquals("app-configs", container.getVolumeMounts().get(0).getName());
+        assertEquals("/cluster-runtime-config", container.getVolumeMounts().get(1).getMountPath());
+        assertEquals("app-configs", container.getVolumeMounts().get(1).getName());
+        assertEquals("/app-secrets", container.getVolumeMounts().get(2).getMountPath());
+        assertEquals("app-secrets", container.getVolumeMounts().get(2).getName());
+        assertEquals("/cluster-config", container.getVolumeMounts().get(3).getMountPath());
+        assertEquals("cluster-config", container.getVolumeMounts().get(3).getName());
         assertEquals(0, container.getCommand().size());
         if (cleanup) {
             int args = 0;
             assertEquals("deployer-runtime", container.getArgs().get(args++));
             assertEquals("delete", container.getArgs().get(args++));
-            assertEquals("/cluster-runtime-config/config", container.getArgs().get(args++));
-            assertEquals("/app-config/config", container.getArgs().get(args++));
+            assertEquals("/cluster-runtime-config", container.getArgs().get(args++));
+            assertEquals("/app-config", container.getArgs().get(args++));
             assertEquals("/app-secrets/secrets", container.getArgs().get(args++));
         } else {
             int args = 0;
             assertEquals("deployer-runtime", container.getArgs().get(args++));
             assertEquals("deploy", container.getArgs().get(args++));
-            assertEquals("/cluster-runtime-config/config", container.getArgs().get(args++));
-            assertEquals("/app-config/config", container.getArgs().get(args++));
+            assertEquals("/cluster-runtime-config", container.getArgs().get(args++));
+            assertEquals("/app-config", container.getArgs().get(args++));
             assertEquals("/app-secrets/secrets", container.getArgs().get(args++));
         }
         assertEquals(
-                "/app-config/config",
+                "/app-config",
                 container.getEnv().stream()
                         .filter(
                                 e ->
@@ -417,7 +457,7 @@ public class AppControllerIT {
                         .orElseThrow()
                         .getValue());
         assertEquals(
-                "/cluster-runtime-config/config",
+                "/cluster-runtime-config",
                 container.getEnv().stream()
                         .filter(
                                 e ->
@@ -434,20 +474,28 @@ public class AppControllerIT {
                         .orElseThrow()
                         .getValue());
 
-        final Container initContainer = templateSpec.getInitContainers().get(0);
-        assertEquals("bash", initContainer.getImage());
-        assertEquals("IfNotPresent", initContainer.getImagePullPolicy());
-        assertEquals("deployer-init-config", initContainer.getName());
-        assertEquals("/app-config", initContainer.getVolumeMounts().get(0).getMountPath());
-        assertEquals("app-config", initContainer.getVolumeMounts().get(0).getName());
+        List<Volume> volumes = spec.getTemplate()
+                .getSpec()
+                .getVolumes();
+        Volume appConfigsVolume = volumes.get(0);
+        assertEquals("app-configs", appConfigsVolume.getName());
+        String configMapName = appConfigsVolume.getConfigMap().getName();
+        assertEquals("langstream-runtime-deployer-my-app", configMapName);
+
+        ConfigMap configMap = deployment.getClient()
+                .configMaps()
+                .inNamespace(job.getMetadata().getNamespace())
+                .withName(configMapName)
+                .get();
+
+        assertEquals(2, configMap.getData().size());
         assertEquals(
-                "/cluster-runtime-config", initContainer.getVolumeMounts().get(1).getMountPath());
-        assertEquals("cluster-runtime-config", initContainer.getVolumeMounts().get(1).getName());
-        assertEquals("bash", initContainer.getCommand().get(0));
-        assertEquals("-c", initContainer.getCommand().get(1));
+                "{\"applicationId\":\"my-app\",\"tenant\":\"my-tenant\",\"application\":\"{\\\"modules\\\": {}}\",\"codeStorageArchiveId\":null,\"deployFlags\":{\"runtimeVersion\":null,\"autoUpgradeRuntimeImagePullPolicy\":false,\"autoUpgradeAgentResources\":false,\"autoUpgradeAgentPodTemplate\":false,\"seed\":0}}",
+                configMap.getData().get("app-config"));
+
         assertEquals(
-                "echo '{\"applicationId\":\"my-app\",\"tenant\":\"my-tenant\",\"application\":\"{\\\"modules\\\": {}}\",\"codeStorageArchiveId\":null,\"deployFlags\":{\"runtimeVersion\":null,\"autoUpgradeRuntimeImagePullPolicy\":false,\"autoUpgradeAgentResources\":false,\"autoUpgradeAgentPodTemplate\":false,\"seed\":0}}' > /app-config/config && echo '{}' > /cluster-runtime-config/config",
-                initContainer.getArgs().get(0));
+                "{}",
+                configMap.getData().get("cluster-runtime-config"));
     }
 
     private ApplicationCustomResource getCr(String yaml) {


### PR DESCRIPTION
init container args (bash) has a very limited size of args ~10KB. with large applications configurations it's a huge problem making the application not deployable at all.

configmaps instead have 1MiB as size limit. 

This change is totally backwards compatible but it requires the operator service account to have this clusterRole: https://github.com/LangStream/charts/commit/c3da8cd32c74af4b94186a54327e406f791d8eb1