### PR TITLE
abstract out state storage management in agents

### DIFF
--- a/langstream-agents/langstream-agent-webcrawler/pom.xml
+++ b/langstream-agents/langstream-agent-webcrawler/pom.xml
@@ -43,6 +43,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>langstream-agents-commons-state-storage</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>com.github.crawler-commons</groupId>
       <artifactId>crawler-commons</artifactId>
       <version>1.4</version>

--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/WebCrawlerSource.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/WebCrawlerSource.java
@@ -37,7 +37,6 @@ import ai.langstream.api.runner.code.Record;
 import ai.langstream.api.runner.code.SimpleRecord;
 import ai.langstream.api.runner.topics.TopicProducer;
 import io.minio.*;
-
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Collection;
@@ -49,10 +48,8 @@ import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicInteger;
-
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -184,7 +181,10 @@ public class WebCrawlerSource extends AbstractAgentCode implements AgentSource {
             }
             log.info("Using local disk storage");
 
-            statusFileName = LocalDiskStateStorage.computePath(context.getTenant(), globalAgentId, agentConfiguration, "webcrawler");;
+            statusFileName =
+                    LocalDiskStateStorage.computePath(
+                            context.getTenant(), globalAgentId, agentConfiguration, "webcrawler");
+            ;
 
             this.stateStorage = new LocalDiskStateStorage<>(Path.of(stateStorage));
         } else {
@@ -209,7 +209,10 @@ public class WebCrawlerSource extends AbstractAgentCode implements AgentSource {
                 builder.region(region);
             }
             minioClient = builder.build();
-            statusFileName = S3StateStorage.computeObjectName(context.getTenant(), globalAgentId, agentConfiguration, "webcrawler");;
+            statusFileName =
+                    S3StateStorage.computeObjectName(
+                            context.getTenant(), globalAgentId, agentConfiguration, "webcrawler");
+            ;
             this.stateStorage = new S3StateStorage<>(minioClient, bucketName, statusFileName);
         }
         log.info("Status file is {}", statusFileName);
@@ -408,7 +411,6 @@ public class WebCrawlerSource extends AbstractAgentCode implements AgentSource {
             return "WebCrawlerSourceRecord{" + "url='" + url + '\'' + '}';
         }
     }
-
 
     @Override
     public void close() throws Exception {

--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/StatusStorage.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/StatusStorage.java
@@ -15,8 +15,6 @@
  */
 package ai.langstream.agents.webcrawler.crawler;
 
-import ai.langstream.ai.agents.commons.state.StateStorage;
-
 import java.util.List;
 import java.util.Map;
 

--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/StatusStorage.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/StatusStorage.java
@@ -15,23 +15,22 @@
  */
 package ai.langstream.agents.webcrawler.crawler;
 
+import ai.langstream.ai.agents.commons.state.StateStorage;
+
 import java.util.List;
 import java.util.Map;
 
-public interface StatusStorage {
-    void storeStatus(Status metadata) throws Exception;
+public class StatusStorage {
 
-    record StoreUrlReference(String url, String type, int depth) {}
+    public record StoreUrlReference(String url, String type, int depth) {}
 
-    record RobotsFile(String content, String contentType) {}
+    public record RobotsFile(String content, String contentType) {}
 
-    record Status(
+    public record Status(
             List<String> remainingUrls,
             List<StoreUrlReference> urls,
             Long lastIndexEndTimestamp,
             Long lastIndexStartTimestamp,
             Map<String, RobotsFile> robotFiles,
             Map<String, String> allTimeDocuments) {}
-
-    Status getCurrentStatus() throws Exception;
 }

--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/WebCrawler.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/WebCrawler.java
@@ -15,6 +15,7 @@
  */
 package ai.langstream.agents.webcrawler.crawler;
 
+import ai.langstream.ai.agents.commons.state.StateStorage;
 import crawlercommons.robots.SimpleRobotRules;
 import crawlercommons.robots.SimpleRobotRulesParser;
 import crawlercommons.sitemaps.AbstractSiteMap;
@@ -543,8 +544,8 @@ public class WebCrawler {
         status.setLastIndexEndTimestamp(0);
     }
 
-    public void reloadStatus(StatusStorage statusStorage) throws Exception {
-        status.reloadFrom(statusStorage);
+    public void reloadStatus(StateStorage<StatusStorage.Status> stateStorage) throws Exception {
+        status.reloadFrom(stateStorage);
 
         // while reloading we need only to rebuild in memory the robots rules
         // these rules have been already parsed with success the first time

--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerStatus.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerStatus.java
@@ -24,6 +24,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+
+import ai.langstream.ai.agents.commons.state.StateStorage;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -70,8 +72,8 @@ public class WebCrawlerStatus {
 
     private final Map<String, String> allTimeDocuments = new HashMap<>();
 
-    public void reloadFrom(StatusStorage statusStorage) throws Exception {
-        StatusStorage.Status currentStatus = statusStorage.getCurrentStatus();
+    public void reloadFrom(StateStorage<StatusStorage.Status> statusStorage) throws Exception {
+        StatusStorage.Status currentStatus = statusStorage.get(StatusStorage.Status.class);
         if (currentStatus != null) {
             log.info("Found a saved status, reloading");
             pendingUrls.clear();
@@ -151,7 +153,7 @@ public class WebCrawlerStatus {
         this.lastIndexStartTimestamp = lastIndexStartTimestamp;
     }
 
-    public void persist(StatusStorage statusStorage) throws Exception {
+    public void persist(StateStorage<StatusStorage.Status> stateStorage) throws Exception {
         List<StatusStorage.StoreUrlReference> urlReferencesForStore =
                 urls.values().stream()
                         .map(
@@ -159,7 +161,7 @@ public class WebCrawlerStatus {
                                         new StatusStorage.StoreUrlReference(
                                                 ref.url(), ref.type().name(), ref.depth()))
                         .collect(Collectors.toList());
-        statusStorage.storeStatus(
+        stateStorage.store(
                 new StatusStorage.Status(
                         new ArrayList<>(remainingUrls),
                         urlReferencesForStore,

--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerStatus.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerStatus.java
@@ -15,6 +15,7 @@
  */
 package ai.langstream.agents.webcrawler.crawler;
 
+import ai.langstream.ai.agents.commons.state.StateStorage;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayDeque;
@@ -24,8 +25,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-
-import ai.langstream.ai.agents.commons.state.StateStorage;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 

--- a/langstream-agents/langstream-agent-webcrawler/src/test/java/ai/langstream/agents/webcrawler/WebCrawlerSourceTest.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/test/java/ai/langstream/agents/webcrawler/WebCrawlerSourceTest.java
@@ -35,7 +35,6 @@ import ai.langstream.api.runner.topics.TopicProducer;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import io.minio.*;
-import io.minio.errors.*;
 import io.minio.messages.Item;
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
@@ -390,7 +389,7 @@ public class WebCrawlerSourceTest {
                              </body>
                             </html>""",
                     pages.get("thirdPage.html"));
-            StatusStorage.Status statusOnS3 = agentSource.getStatusStorage().getCurrentStatus();
+            StatusStorage.Status statusOnS3 = agentSource.getStateStorage().get(StatusStorage.Status.class);
             assertEquals(3, statusOnS3.allTimeDocuments().size());
 
             stubFor(get("/index.html").willReturn(notFound()));
@@ -399,7 +398,7 @@ public class WebCrawlerSourceTest {
                 agentSource.read();
             }
 
-            statusOnS3 = agentSource.getStatusStorage().getCurrentStatus();
+            statusOnS3 = agentSource.getStateStorage().get(StatusStorage.Status.class);
             assertEquals(2, statusOnS3.allTimeDocuments().size());
         }
     }

--- a/langstream-agents/langstream-agent-webcrawler/src/test/java/ai/langstream/agents/webcrawler/WebCrawlerSourceTest.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/test/java/ai/langstream/agents/webcrawler/WebCrawlerSourceTest.java
@@ -389,7 +389,8 @@ public class WebCrawlerSourceTest {
                              </body>
                             </html>""",
                     pages.get("thirdPage.html"));
-            StatusStorage.Status statusOnS3 = agentSource.getStateStorage().get(StatusStorage.Status.class);
+            StatusStorage.Status statusOnS3 =
+                    agentSource.getStateStorage().get(StatusStorage.Status.class);
             assertEquals(3, statusOnS3.allTimeDocuments().size());
 
             stubFor(get("/index.html").willReturn(notFound()));

--- a/langstream-agents/langstream-agent-webcrawler/src/test/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerStatusTest.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/test/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerStatusTest.java
@@ -17,9 +17,6 @@ package ai.langstream.agents.webcrawler.crawler;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.util.List;
-import java.util.Map;
-
 import ai.langstream.ai.agents.commons.state.MemoryStateStorage;
 import ai.langstream.ai.agents.commons.state.StateStorage;
 import org.junit.jupiter.api.Test;
@@ -159,5 +156,4 @@ class WebCrawlerStatusTest {
         assertEquals(visited, status.getUrls().size());
         assertEquals(remaining, status.getRemainingUrls().size());
     }
-
 }

--- a/langstream-agents/langstream-agent-webcrawler/src/test/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerStatusTest.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/test/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerStatusTest.java
@@ -19,6 +19,9 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.List;
 import java.util.Map;
+
+import ai.langstream.ai.agents.commons.state.MemoryStateStorage;
+import ai.langstream.ai.agents.commons.state.StateStorage;
 import org.junit.jupiter.api.Test;
 
 class WebCrawlerStatusTest {
@@ -107,7 +110,7 @@ class WebCrawlerStatusTest {
     @Test
     public void testReload() throws Exception {
 
-        DummyStorage storage = new DummyStorage();
+        StateStorage<StatusStorage.Status> storage = new MemoryStateStorage<>();
 
         WebCrawlerStatus status = new WebCrawlerStatus();
         status.addUrl(URL1, URLReference.Type.PAGE, 0, true);
@@ -157,20 +160,4 @@ class WebCrawlerStatusTest {
         assertEquals(remaining, status.getRemainingUrls().size());
     }
 
-    private static class DummyStorage implements StatusStorage {
-
-        private Status lastMetadata;
-
-        @Override
-        public void storeStatus(Status metadata) {
-            lastMetadata = metadata;
-        }
-
-        @Override
-        public Status getCurrentStatus() {
-            return lastMetadata != null
-                    ? lastMetadata
-                    : new Status(List.of(), List.of(), null, null, Map.of(), Map.of());
-        }
-    }
 }

--- a/langstream-agents/langstream-agents-commons-state-storage/pom.xml
+++ b/langstream-agents/langstream-agents-commons-state-storage/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright DataStax, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>ai.langstream</groupId>
+        <artifactId>langstream-agents</artifactId>
+        <version>0.11.7-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>langstream-agents-commons-state-storage</artifactId>
+    <packaging>jar</packaging>
+    <name>LangStream - State Storage for Agents</name>
+    <properties>
+        <build.dir>${project.build.directory}</build.dir>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>langstream-api</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.minio</groupId>
+            <artifactId>minio</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/LocalDiskStateStorage.java
+++ b/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/LocalDiskStateStorage.java
@@ -1,25 +1,16 @@
 package ai.langstream.ai.agents.commons.state;
 
+import static ai.langstream.api.util.ConfigurationUtils.getBoolean;
+import static ai.langstream.api.util.ConfigurationUtils.getString;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.minio.*;
-import io.minio.errors.ErrorResponseException;
-import io.minio.errors.MinioException;
-import lombok.AllArgsConstructor;
-import lombok.SneakyThrows;
-import lombok.extern.slf4j.Slf4j;
-
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Supplier;
-
-import static ai.langstream.api.util.ConfigurationUtils.getBoolean;
-import static ai.langstream.api.util.ConfigurationUtils.getString;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @AllArgsConstructor

--- a/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/LocalDiskStateStorage.java
+++ b/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/LocalDiskStateStorage.java
@@ -1,0 +1,70 @@
+package ai.langstream.ai.agents.commons.state;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.minio.*;
+import io.minio.errors.ErrorResponseException;
+import io.minio.errors.MinioException;
+import lombok.AllArgsConstructor;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import static ai.langstream.api.util.ConfigurationUtils.getBoolean;
+import static ai.langstream.api.util.ConfigurationUtils.getString;
+
+@Slf4j
+@AllArgsConstructor
+public class LocalDiskStateStorage<T> implements StateStorage<T> {
+
+    public static String computePath(
+            final String tenant,
+            final String globalAgentId,
+            final Map<String, Object> agentConfiguration,
+            final String suffix) {
+        final boolean prependTenant =
+                getBoolean("state-storage-file-prepend-tenant", false, agentConfiguration);
+        final String prefix = getString("state-storage-file-prefix", "", agentConfiguration);
+
+        final String pathPrefix;
+        if (prependTenant) {
+            pathPrefix = prefix + tenant + "-" + globalAgentId;
+        } else {
+            pathPrefix = prefix + globalAgentId;
+        }
+        return pathPrefix + "." + suffix + ".status.json";
+    }
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final Path path;
+
+    @Override
+    public void store(T status) throws Exception {
+        log.info("Storing state to the disk at path {}", path);
+        MAPPER.writeValue(path.toFile(), status);
+    }
+
+    @Override
+    public T get(Class<T> clazz) throws Exception {
+        if (Files.exists(path)) {
+            log.info("Restoring state from {}", path);
+            try {
+                return MAPPER.readValue(path.toFile(), clazz);
+            } catch (IOException e) {
+                log.error("Error parsing state file", e);
+                return null;
+            }
+        } else {
+            return null;
+        }
+    }
+}

--- a/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/MemoryStateStorage.java
+++ b/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/MemoryStateStorage.java
@@ -1,0 +1,31 @@
+package ai.langstream.ai.agents.commons.state;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static ai.langstream.api.util.ConfigurationUtils.getBoolean;
+import static ai.langstream.api.util.ConfigurationUtils.getString;
+
+@Slf4j
+public class MemoryStateStorage<T> implements StateStorage<T> {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private T value;
+
+    @Override
+    public void store(T status) throws Exception {
+        log.info("Storing state to memory");
+        value = status;
+    }
+
+    @Override
+    public T get(Class<T> clazz) throws Exception {
+        return value;
+    }
+}

--- a/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/MemoryStateStorage.java
+++ b/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/MemoryStateStorage.java
@@ -1,16 +1,7 @@
 package ai.langstream.ai.agents.commons.state;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Map;
-
-import static ai.langstream.api.util.ConfigurationUtils.getBoolean;
-import static ai.langstream.api.util.ConfigurationUtils.getString;
 
 @Slf4j
 public class MemoryStateStorage<T> implements StateStorage<T> {

--- a/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/S3StateStorage.java
+++ b/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/S3StateStorage.java
@@ -1,13 +1,12 @@
 package ai.langstream.ai.agents.commons.state;
 
+import static ai.langstream.api.util.ConfigurationUtils.getBoolean;
+import static ai.langstream.api.util.ConfigurationUtils.getString;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.minio.*;
 import io.minio.errors.ErrorResponseException;
 import io.minio.errors.MinioException;
-import lombok.AllArgsConstructor;
-import lombok.SneakyThrows;
-import lombok.extern.slf4j.Slf4j;
-
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.security.InvalidKeyException;
@@ -15,9 +14,8 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
-
-import static ai.langstream.api.util.ConfigurationUtils.getBoolean;
-import static ai.langstream.api.util.ConfigurationUtils.getString;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class S3StateStorage<T> implements StateStorage<T> {
@@ -63,7 +61,6 @@ public class S3StateStorage<T> implements StateStorage<T> {
         }
     }
 
-
     @Override
     public void store(T status) throws Exception {
         byte[] content = MAPPER.writeValueAsBytes(status);
@@ -90,8 +87,7 @@ public class S3StateStorage<T> implements StateStorage<T> {
                 return;
             } catch (IOException e) {
                 log.error("error putting object to s3", e);
-                if (e.getMessage() != null
-                        && e.getMessage().contains("unexpected end of stream")
+                if (e.getMessage() != null && e.getMessage().contains("unexpected end of stream")
                         || e.getMessage().contains("unexpected EOF")
                         || e.getMessage().contains("Broken pipe")) {
                     if (attempt == maxRetries) {
@@ -119,10 +115,7 @@ public class S3StateStorage<T> implements StateStorage<T> {
         try {
             GetObjectResponse result =
                     minioClient.getObject(
-                            GetObjectArgs.builder()
-                                    .bucket(bucketName)
-                                    .object(objectName)
-                                    .build());
+                            GetObjectArgs.builder().bucket(bucketName).object(objectName).build());
             byte[] content = result.readAllBytes();
             log.info("Restoring state from {}, {} bytes", objectName, content.length);
             try {

--- a/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/S3StateStorage.java
+++ b/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/S3StateStorage.java
@@ -1,0 +1,141 @@
+package ai.langstream.ai.agents.commons.state;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.minio.*;
+import io.minio.errors.ErrorResponseException;
+import io.minio.errors.MinioException;
+import lombok.AllArgsConstructor;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import static ai.langstream.api.util.ConfigurationUtils.getBoolean;
+import static ai.langstream.api.util.ConfigurationUtils.getString;
+
+@Slf4j
+public class S3StateStorage<T> implements StateStorage<T> {
+
+    public static String computeObjectName(
+            final String tenant,
+            final String globalAgentId,
+            final Map<String, Object> agentConfiguration,
+            final String suffix) {
+        final boolean prependTenant =
+                getBoolean("state-storage-file-prepend-tenant", false, agentConfiguration);
+        final String prefix = getString("state-storage-file-prefix", "", agentConfiguration);
+
+        final String pathPrefix;
+        if (prependTenant) {
+            pathPrefix = prefix + tenant + "/" + globalAgentId;
+        } else {
+            pathPrefix = prefix + globalAgentId;
+        }
+        return pathPrefix + "." + suffix + ".status.json";
+    }
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final MinioClient minioClient;
+    private final String bucketName;
+    private final String objectName;
+
+    public S3StateStorage(MinioClient minioClient, String bucketName, String objectName) {
+        this.minioClient = minioClient;
+        this.bucketName = bucketName;
+        this.objectName = objectName;
+        makeBucketIfNotExists();
+    }
+
+    @SneakyThrows
+    private void makeBucketIfNotExists() {
+        if (!minioClient.bucketExists(BucketExistsArgs.builder().bucket(bucketName).build())) {
+            log.info("Creating bucket {}", bucketName);
+            minioClient.makeBucket(MakeBucketArgs.builder().bucket(bucketName).build());
+        } else {
+            log.info("Bucket {} already exists", bucketName);
+        }
+    }
+
+
+    @Override
+    public void store(T status) throws Exception {
+        byte[] content = MAPPER.writeValueAsBytes(status);
+        log.info("Storing state in {}, {} bytes", objectName, content.length);
+        putWithRetries(
+                () ->
+                        PutObjectArgs.builder()
+                                .bucket(bucketName)
+                                .object(objectName)
+                                .contentType("text/json")
+                                .stream(new ByteArrayInputStream(content), content.length, -1)
+                                .build());
+    }
+
+    private void putWithRetries(Supplier<PutObjectArgs> args)
+            throws MinioException, NoSuchAlgorithmException, InvalidKeyException, IOException {
+        int attempt = 0;
+        int maxRetries = 5;
+        while (attempt < maxRetries) {
+            try {
+                attempt++;
+                log.info("attempting to put object to s3 {}/{}", attempt, maxRetries);
+                minioClient.putObject(args.get());
+                return;
+            } catch (IOException e) {
+                log.error("error putting object to s3", e);
+                if (e.getMessage() != null
+                        && e.getMessage().contains("unexpected end of stream")
+                        || e.getMessage().contains("unexpected EOF")
+                        || e.getMessage().contains("Broken pipe")) {
+                    if (attempt == maxRetries) {
+                        throw e;
+                    }
+                    long backoffTime = (long) Math.pow(2, attempt - 1) * 2000;
+                    log.info(
+                            "retrying put due to unexpected end of stream, retrying in {} ms",
+                            backoffTime);
+                    try {
+                        TimeUnit.MILLISECONDS.sleep(backoffTime);
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        throw new RuntimeException(ie);
+                    }
+                } else {
+                    throw e;
+                }
+            }
+        }
+    }
+
+    @Override
+    public T get(Class<T> clazz) throws Exception {
+        try {
+            GetObjectResponse result =
+                    minioClient.getObject(
+                            GetObjectArgs.builder()
+                                    .bucket(bucketName)
+                                    .object(objectName)
+                                    .build());
+            byte[] content = result.readAllBytes();
+            log.info("Restoring state from {}, {} bytes", objectName, content.length);
+            try {
+                return MAPPER.readValue(content, clazz);
+            } catch (IOException e) {
+                log.error("Error parsing state file", e);
+                return null;
+            }
+        } catch (ErrorResponseException e) {
+            if (e.errorResponse().code().equals("NoSuchKey")) {
+                return null;
+            }
+            throw e;
+        }
+    }
+}

--- a/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/StateStorage.java
+++ b/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/StateStorage.java
@@ -1,0 +1,10 @@
+package ai.langstream.ai.agents.commons.state;
+
+
+public interface StateStorage<T> {
+
+
+    void store(T state) throws Exception;
+
+    T get(Class<T> clazz) throws Exception;
+}

--- a/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/StateStorage.java
+++ b/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/StateStorage.java
@@ -1,8 +1,6 @@
 package ai.langstream.ai.agents.commons.state;
 
-
 public interface StateStorage<T> {
-
 
     void store(T state) throws Exception;
 

--- a/langstream-agents/pom.xml
+++ b/langstream-agents/pom.xml
@@ -33,6 +33,7 @@
     </properties>
     <modules>
         <module>langstream-agents-commons</module>
+        <module>langstream-agents-commons-state-storage</module>
         <module>langstream-agent-grpc</module>
         <module>langstream-agent-s3</module>
         <module>langstream-agent-camel</module>


### PR DESCRIPTION
preparatory work for adding the ability to use a state storage implementaton in other agents other than webcrawler.

note that this can't be provided by the runtime itself because it would mean to add minio dependency at runtime (which might conflicts with some other agents dependencies)