### PR TITLE
s3source: add state and updated/deleted events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
           sudo du -sh *
           docker images
           echo "Cleaning up docker images"
-          docker images | grep -v langstream | awk -F ' ' '{print $1,":",$2}' | tr -d ' ' | xargs -I {} docker rmi -f {}
+          (docker images | grep -v -e 'langstream' -e 'none' | tail -n +2 | awk -F ' ' '{print $1,":",$2}' | tr -d ' ' | xargs -I {} docker rmi -f {}) || echo "Failed to remove images"
           echo "After cleanup"
           docker images
           sudo du -sh *

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,7 @@ jobs:
           
           # cleanup intermediate layers to save space
           docker system prune -f
+          docker image prune -f
 
           echo "::group::Run integration tests"
           ./mvnw -ntp failsafe:integration-test failsafe:verify -pl ":langstream-runtime-impl" -PskipPython

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,9 +87,15 @@ jobs:
       - name: 'Test: Runtime (Integration Tests)'
         if: ${{ matrix.name == 'Runtime IT' }}
         run: |
+          echo "::group::Build runtime docker images"
           ./mvnw -ntp package -pl ":langstream-runtime-base-docker-image" -Pdocker -DskipTests -PskipPython
+          echo "::endgroup::"
+          echo "::group::Build module"
           ./mvnw -ntp package -pl ":langstream-runtime-impl" -Pdocker -DskipTests -PskipPython
+          echo "::endgroup::"
+          echo "::group::Run integration tests"
           ./mvnw -ntp failsafe:integration-test failsafe:verify -pl ":langstream-runtime-impl" -PskipPython
+          echo "::endgroup::"
 
       - name: 'Test: Api Gateway'
         if: ${{ matrix.name == 'Api Gateway' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,15 +97,15 @@ jobs:
           # cleanup intermediate layers to save space
           docker system prune -f
           docker image prune -f
-          du -sh /*
-          du -sh *
+          sudo du -sh *
           docker images
           echo "Cleaning up docker images"
           docker images | grep -v langstream | awk -F ' ' '{print $1,":",$2}' | tr -d ' ' | xargs -I {} docker rmi -f {}
           echo "After cleanup"
           docker images
-          du -sh /*
-          du -sh *
+          sudo du -sh *
+          
+
 
           echo "::group::Run integration tests"
           ./mvnw -ntp failsafe:integration-test failsafe:verify -pl ":langstream-runtime-impl" -PskipPython

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,10 @@ jobs:
           echo "::group::Build module"
           ./mvnw -ntp package -pl ":langstream-runtime-impl" -Pdocker -DskipTests -PskipPython
           echo "::endgroup::"
+          
+          # cleanup intermediate layers to save space
+          docker system prune -f
+
           echo "::group::Run integration tests"
           ./mvnw -ntp failsafe:integration-test failsafe:verify -pl ":langstream-runtime-impl" -PskipPython
           echo "::endgroup::"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,15 @@ jobs:
           # cleanup intermediate layers to save space
           docker system prune -f
           docker image prune -f
+          du -sh /*
+          du -sh *
+          docker images
+          echo "Cleaning up docker images"
+          docker images | grep -v langstream | awk -F ' ' '{print $1,":",$2}' | tr -d ' ' | xargs -I {} docker rmi -f {}
+          echo "After cleanup"
+          docker images
+          du -sh /*
+          du -sh *
 
           echo "::group::Run integration tests"
           ./mvnw -ntp failsafe:integration-test failsafe:verify -pl ":langstream-runtime-impl" -PskipPython

--- a/langstream-agents/langstream-agent-s3/pom.xml
+++ b/langstream-agents/langstream-agent-s3/pom.xml
@@ -38,6 +38,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>langstream-agents-commons-state-storage</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>io.minio</groupId>
       <artifactId>minio</artifactId>
     </dependency>
@@ -88,6 +93,7 @@
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
+
   </dependencies>
   <build>
     <plugins>

--- a/langstream-agents/langstream-agent-s3/src/test/java/ai/langstream/agents/s3/S3SourceTest.java
+++ b/langstream-agents/langstream-agent-s3/src/test/java/ai/langstream/agents/s3/S3SourceTest.java
@@ -15,7 +15,7 @@
  */
 package ai.langstream.agents.s3;
 
-import static org.junit.Assert.assertSame;
+import static org.junit.Assert.*;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testcontainers.containers.localstack.LocalStackContainer.Service.S3;
 
+import ai.langstream.ai.agents.commons.state.S3StateStorage;
 import ai.langstream.api.runner.code.AgentCodeRegistry;
 import ai.langstream.api.runner.code.AgentContext;
 import ai.langstream.api.runner.code.AgentProcessor;
@@ -32,12 +33,7 @@ import ai.langstream.api.runner.code.Header;
 import ai.langstream.api.runner.code.MetricsReporter;
 import ai.langstream.api.runner.code.Record;
 import ai.langstream.api.runner.code.SimpleRecord;
-import io.minio.ListObjectsArgs;
-import io.minio.MakeBucketArgs;
-import io.minio.MinioClient;
-import io.minio.PutObjectArgs;
-import io.minio.RemoveObjectArgs;
-import io.minio.Result;
+import io.minio.*;
 import io.minio.messages.Item;
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
@@ -83,90 +79,94 @@ public class S3SourceTest {
         // Add some objects to the bucket
         String bucket = "langstream-test-" + UUID.randomUUID();
         minioClient.makeBucket(MakeBucketArgs.builder().bucket(bucket).build());
-        AgentProcessor agentProcessor = buildAgentProcessor(bucket);
-        String content = "test-content-";
-        for (int i = 0; i < 2; i++) {
-            String s = content + i;
-            minioClient.putObject(
-                    PutObjectArgs.builder().bucket(bucket).object("test-" + i + ".txt").stream(
-                                    new ByteArrayInputStream(s.getBytes(StandardCharsets.UTF_8)),
-                                    s.length(),
-                                    -1)
-                            .build());
+        try (AgentProcessor agentProcessor = buildAgentProcessor(bucket); ) {
+            String content = "test-content-";
+            for (int i = 0; i < 2; i++) {
+                String s = content + i;
+                minioClient.putObject(
+                        PutObjectArgs.builder().bucket(bucket).object("test-" + i + ".txt").stream(
+                                        new ByteArrayInputStream(
+                                                s.getBytes(StandardCharsets.UTF_8)),
+                                        s.length(),
+                                        -1)
+                                .build());
+            }
+
+            // Create a input record that specifies the first file
+            String objectName = "test-0.txt";
+            SimpleRecord someRecord =
+                    SimpleRecord.builder()
+                            .value("{\"objectName\": \"" + objectName + "\"}")
+                            .headers(
+                                    List.of(
+                                            new SimpleRecord.SimpleHeader(
+                                                    "original", "Some session id")))
+                            .build();
+
+            // Process the record
+            List<AgentProcessor.SourceRecordAndResult> resultsForRecord = new ArrayList<>();
+            agentProcessor.process(List.of(someRecord), resultsForRecord::add);
+
+            // Should be a record for the file
+            assertEquals(1, resultsForRecord.size());
+
+            // the processor must pass downstream the original record
+            Record emittedToDownstream = resultsForRecord.get(0).sourceRecord();
+            assertSame(emittedToDownstream, someRecord);
+
+            // The resulting record should have the file content as the value
+            assertArrayEquals(
+                    "test-content-0".getBytes(StandardCharsets.UTF_8),
+                    (byte[]) resultsForRecord.get(0).resultRecords().get(0).value());
+            // The resulting record should have the file name as the key
+            assertEquals(objectName, resultsForRecord.get(0).resultRecords().get(0).key());
+
+            // Check headers
+            Collection<Header> headers = resultsForRecord.get(0).resultRecords().get(0).headers();
+
+            // Make sure the name header matches the object name
+            Optional<Header> foundNameHeader =
+                    headers.stream()
+                            .filter(
+                                    header ->
+                                            "name".equals(header.key())
+                                                    && objectName.equals(header.value()))
+                            .findFirst();
+
+            assertTrue(
+                    foundNameHeader
+                            .isPresent()); // Check that the object name is passed in the record
+
+            // Make sure the original header matches the passed in header
+            Optional<Header> foundOrigHeader =
+                    headers.stream()
+                            .filter(
+                                    header ->
+                                            "original".equals(header.key())
+                                                    && "Some session id".equals(header.value()))
+                            .findFirst();
+
+            assertTrue(
+                    foundOrigHeader
+                            .isPresent()); // Check that the object name is passed in the record
+
+            // Get the next file
+            String secondObjectName = "test-1.txt";
+            someRecord =
+                    SimpleRecord.builder()
+                            .value("{\"objectName\": \"" + secondObjectName + "\"}")
+                            .headers(
+                                    List.of(
+                                            new SimpleRecord.SimpleHeader(
+                                                    "original", "Some session id")))
+                            .build();
+
+            resultsForRecord = new ArrayList<>();
+            agentProcessor.process(List.of(someRecord), resultsForRecord::add);
+
+            // Make sure the second file is processed
+            assertEquals(1, resultsForRecord.size());
         }
-
-        // Create a input record that specifies the first file
-        String objectName = "test-0.txt";
-        SimpleRecord someRecord =
-                SimpleRecord.builder()
-                        .value("{\"objectName\": \"" + objectName + "\"}")
-                        .headers(
-                                List.of(
-                                        new SimpleRecord.SimpleHeader(
-                                                "original", "Some session id")))
-                        .build();
-
-        // Process the record
-        List<AgentProcessor.SourceRecordAndResult> resultsForRecord = new ArrayList<>();
-        agentProcessor.process(List.of(someRecord), resultsForRecord::add);
-
-        // Should be a record for the file
-        assertEquals(1, resultsForRecord.size());
-
-        // the processor must pass downstream the original record
-        Record emittedToDownstream = resultsForRecord.get(0).sourceRecord();
-        assertSame(emittedToDownstream, someRecord);
-
-        // The resulting record should have the file content as the value
-        assertArrayEquals(
-                "test-content-0".getBytes(StandardCharsets.UTF_8),
-                (byte[]) resultsForRecord.get(0).resultRecords().get(0).value());
-        // The resulting record should have the file name as the key
-        assertEquals(objectName, resultsForRecord.get(0).resultRecords().get(0).key());
-
-        // Check headers
-        Collection<Header> headers = resultsForRecord.get(0).resultRecords().get(0).headers();
-
-        // Make sure the name header matches the object name
-        Optional<Header> foundNameHeader =
-                headers.stream()
-                        .filter(
-                                header ->
-                                        "name".equals(header.key())
-                                                && objectName.equals(header.value()))
-                        .findFirst();
-
-        assertTrue(
-                foundNameHeader.isPresent()); // Check that the object name is passed in the record
-
-        // Make sure the original header matches the passed in header
-        Optional<Header> foundOrigHeader =
-                headers.stream()
-                        .filter(
-                                header ->
-                                        "original".equals(header.key())
-                                                && "Some session id".equals(header.value()))
-                        .findFirst();
-
-        assertTrue(
-                foundOrigHeader.isPresent()); // Check that the object name is passed in the record
-
-        // Get the next file
-        String secondObjectName = "test-1.txt";
-        someRecord =
-                SimpleRecord.builder()
-                        .value("{\"objectName\": \"" + secondObjectName + "\"}")
-                        .headers(
-                                List.of(
-                                        new SimpleRecord.SimpleHeader(
-                                                "original", "Some session id")))
-                        .build();
-
-        resultsForRecord = new ArrayList<>();
-        agentProcessor.process(List.of(someRecord), resultsForRecord::add);
-
-        // Make sure the second file is processed
-        assertEquals(1, resultsForRecord.size()); // assertEquals(
     }
 
     @Test
@@ -175,182 +175,191 @@ public class S3SourceTest {
         String bucket = "langstream-test-" + UUID.randomUUID();
         String directory = "test-dir/";
         minioClient.makeBucket(MakeBucketArgs.builder().bucket(bucket).build());
-        AgentProcessor agentProcessor = buildAgentProcessor(bucket);
-        String content = "test-content-";
-        for (int i = 0; i < 2; i++) {
-            String s = content + i;
-            minioClient.putObject(
-                    PutObjectArgs.builder()
-                            .bucket(bucket)
-                            .object(directory + "test-" + i + ".txt")
-                            .stream(
-                                    new ByteArrayInputStream(s.getBytes(StandardCharsets.UTF_8)),
-                                    s.length(),
-                                    -1)
-                            .build());
+        try (AgentProcessor agentProcessor = buildAgentProcessor(bucket); ) {
+            String content = "test-content-";
+            for (int i = 0; i < 2; i++) {
+                String s = content + i;
+                minioClient.putObject(
+                        PutObjectArgs.builder()
+                                .bucket(bucket)
+                                .object(directory + "test-" + i + ".txt")
+                                .stream(
+                                        new ByteArrayInputStream(
+                                                s.getBytes(StandardCharsets.UTF_8)),
+                                        s.length(),
+                                        -1)
+                                .build());
+            }
+
+            // Process the first file in the directory
+            String firstObjectName = directory + "test-0.txt";
+            SimpleRecord firstRecord =
+                    SimpleRecord.builder()
+                            .value("{\"objectName\": \"" + firstObjectName + "\"}")
+                            .headers(
+                                    List.of(
+                                            new SimpleRecord.SimpleHeader(
+                                                    "original", "Some session id")))
+                            .build();
+
+            List<AgentProcessor.SourceRecordAndResult> resultsForFirstRecord = new ArrayList<>();
+            agentProcessor.process(List.of(firstRecord), resultsForFirstRecord::add);
+            // Make sure the first file is processed and that the original record is passed
+            // downstream
+            assertEquals(1, resultsForFirstRecord.size());
+            assertSame(firstRecord, resultsForFirstRecord.get(0).sourceRecord());
+            // Check that the content of the first record is the content of the first file
+            assertArrayEquals(
+                    "test-content-0".getBytes(StandardCharsets.UTF_8),
+                    (byte[]) resultsForFirstRecord.get(0).resultRecords().get(0).value());
+            // Check that the key of the first record is the name of the first file
+            assertEquals(
+                    firstObjectName, resultsForFirstRecord.get(0).resultRecords().get(0).key());
+
+            // Check headers for first record
+            // The name header contains the file name
+            Collection<Header> firstRecordHeaders =
+                    resultsForFirstRecord.get(0).resultRecords().get(0).headers();
+            assertTrue(
+                    firstRecordHeaders.stream()
+                            .anyMatch(
+                                    header ->
+                                            "name".equals(header.key())
+                                                    && firstObjectName.equals(header.value())));
+            // The original header contains the original header from the record
+            assertTrue(
+                    firstRecordHeaders.stream()
+                            .anyMatch(
+                                    header ->
+                                            "original".equals(header.key())
+                                                    && "Some session id".equals(header.value())));
+
+            // Process the second file in the directory
+            String secondObjectName = directory + "test-1.txt";
+            SimpleRecord secondRecord =
+                    SimpleRecord.builder()
+                            .value("{\"objectName\": \"" + secondObjectName + "\"}")
+                            .headers(
+                                    List.of(
+                                            new SimpleRecord.SimpleHeader(
+                                                    "original", "Some session id")))
+                            .build();
+
+            List<AgentProcessor.SourceRecordAndResult> resultsForSecondRecord = new ArrayList<>();
+            agentProcessor.process(List.of(secondRecord), resultsForSecondRecord::add);
+
+            assertEquals(1, resultsForSecondRecord.size());
+            assertSame(secondRecord, resultsForSecondRecord.get(0).sourceRecord());
+
+            assertArrayEquals(
+                    "test-content-1".getBytes(StandardCharsets.UTF_8),
+                    (byte[]) resultsForSecondRecord.get(0).resultRecords().get(0).value());
+
+            // Check headers for second record
+            Collection<Header> secondRecordHeaders =
+                    resultsForSecondRecord.get(0).resultRecords().get(0).headers();
+            assertTrue(
+                    secondRecordHeaders.stream()
+                            .anyMatch(
+                                    header ->
+                                            "name".equals(header.key())
+                                                    && secondObjectName.equals(header.value())));
+            assertTrue(
+                    secondRecordHeaders.stream()
+                            .anyMatch(
+                                    header ->
+                                            "original".equals(header.key())
+                                                    && "Some session id".equals(header.value())));
         }
-
-        // Process the first file in the directory
-        String firstObjectName = directory + "test-0.txt";
-        SimpleRecord firstRecord =
-                SimpleRecord.builder()
-                        .value("{\"objectName\": \"" + firstObjectName + "\"}")
-                        .headers(
-                                List.of(
-                                        new SimpleRecord.SimpleHeader(
-                                                "original", "Some session id")))
-                        .build();
-
-        List<AgentProcessor.SourceRecordAndResult> resultsForFirstRecord = new ArrayList<>();
-        agentProcessor.process(List.of(firstRecord), resultsForFirstRecord::add);
-        // Make sure the first file is processed and that the original record is passed downstream
-        assertEquals(1, resultsForFirstRecord.size());
-        assertSame(firstRecord, resultsForFirstRecord.get(0).sourceRecord());
-        // Check that the content of the first record is the content of the first file
-        assertArrayEquals(
-                "test-content-0".getBytes(StandardCharsets.UTF_8),
-                (byte[]) resultsForFirstRecord.get(0).resultRecords().get(0).value());
-        // Check that the key of the first record is the name of the first file
-        assertEquals(firstObjectName, resultsForFirstRecord.get(0).resultRecords().get(0).key());
-
-        // Check headers for first record
-        // The name header contains the file name
-        Collection<Header> firstRecordHeaders =
-                resultsForFirstRecord.get(0).resultRecords().get(0).headers();
-        assertTrue(
-                firstRecordHeaders.stream()
-                        .anyMatch(
-                                header ->
-                                        "name".equals(header.key())
-                                                && firstObjectName.equals(header.value())));
-        // The original header contains the original header from the record
-        assertTrue(
-                firstRecordHeaders.stream()
-                        .anyMatch(
-                                header ->
-                                        "original".equals(header.key())
-                                                && "Some session id".equals(header.value())));
-
-        // Process the second file in the directory
-        String secondObjectName = directory + "test-1.txt";
-        SimpleRecord secondRecord =
-                SimpleRecord.builder()
-                        .value("{\"objectName\": \"" + secondObjectName + "\"}")
-                        .headers(
-                                List.of(
-                                        new SimpleRecord.SimpleHeader(
-                                                "original", "Some session id")))
-                        .build();
-
-        List<AgentProcessor.SourceRecordAndResult> resultsForSecondRecord = new ArrayList<>();
-        agentProcessor.process(List.of(secondRecord), resultsForSecondRecord::add);
-
-        assertEquals(1, resultsForSecondRecord.size());
-        assertSame(secondRecord, resultsForSecondRecord.get(0).sourceRecord());
-
-        assertArrayEquals(
-                "test-content-1".getBytes(StandardCharsets.UTF_8),
-                (byte[]) resultsForSecondRecord.get(0).resultRecords().get(0).value());
-
-        // Check headers for second record
-        Collection<Header> secondRecordHeaders =
-                resultsForSecondRecord.get(0).resultRecords().get(0).headers();
-        assertTrue(
-                secondRecordHeaders.stream()
-                        .anyMatch(
-                                header ->
-                                        "name".equals(header.key())
-                                                && secondObjectName.equals(header.value())));
-        assertTrue(
-                secondRecordHeaders.stream()
-                        .anyMatch(
-                                header ->
-                                        "original".equals(header.key())
-                                                && "Some session id".equals(header.value())));
     }
 
     @Test
     void testRead() throws Exception {
         String bucket = "langstream-test-" + UUID.randomUUID();
-        AgentSource agentSource = buildAgentSource(bucket);
-        String content = "test-content-";
-        for (int i = 0; i < 10; i++) {
-            String s = content + i;
-            minioClient.putObject(
-                    PutObjectArgs.builder().bucket(bucket).object("test-" + i + ".txt").stream(
-                                    new ByteArrayInputStream(s.getBytes(StandardCharsets.UTF_8)),
-                                    s.length(),
-                                    -1)
-                            .build());
+        try (AgentSource agentSource = buildAgentSource(bucket); ) {
+            String content = "test-content-";
+            for (int i = 0; i < 10; i++) {
+                String s = content + i;
+                minioClient.putObject(
+                        PutObjectArgs.builder().bucket(bucket).object("test-" + i + ".txt").stream(
+                                        new ByteArrayInputStream(
+                                                s.getBytes(StandardCharsets.UTF_8)),
+                                        s.length(),
+                                        -1)
+                                .build());
+            }
+
+            List<Record> read = agentSource.read();
+            assertEquals(1, read.size());
+            assertArrayEquals(
+                    "test-content-0".getBytes(StandardCharsets.UTF_8),
+                    (byte[]) read.get(0).value());
+
+            // DO NOT COMMIT, the source should not return the same objects
+
+            List<Record> read2 = agentSource.read();
+
+            assertEquals(1, read2.size());
+            assertArrayEquals(
+                    "test-content-1".getBytes(StandardCharsets.UTF_8),
+                    (byte[]) read2.get(0).value());
+
+            // COMMIT (out of order)
+            agentSource.commit(read2);
+            agentSource.commit(read);
+
+            Iterator<Result<Item>> results =
+                    minioClient
+                            .listObjects(ListObjectsArgs.builder().bucket(bucket).build())
+                            .iterator();
+            for (int i = 2; i < 10; i++) {
+                Result<Item> item = results.next();
+                assertEquals("test-" + i + ".txt", item.get().objectName());
+            }
+
+            List<Record> all = new ArrayList<>();
+            for (int i = 0; i < 8; i++) {
+                all.addAll(agentSource.read());
+            }
+
+            agentSource.commit(all);
+            all.clear();
+
+            results =
+                    minioClient
+                            .listObjects(ListObjectsArgs.builder().bucket(bucket).build())
+                            .iterator();
+            assertFalse(results.hasNext());
+
+            for (int i = 0; i < 10; i++) {
+                all.addAll(agentSource.read());
+            }
+            agentSource.commit(all);
+            agentSource.commit(List.of());
         }
-
-        List<Record> read = agentSource.read();
-        assertEquals(1, read.size());
-        assertArrayEquals(
-                "test-content-0".getBytes(StandardCharsets.UTF_8), (byte[]) read.get(0).value());
-
-        // DO NOT COMMIT, the source should not return the same objects
-
-        List<Record> read2 = agentSource.read();
-
-        assertEquals(1, read2.size());
-        assertArrayEquals(
-                "test-content-1".getBytes(StandardCharsets.UTF_8), (byte[]) read2.get(0).value());
-
-        // COMMIT (out of order)
-        agentSource.commit(read2);
-        agentSource.commit(read);
-
-        Iterator<Result<Item>> results =
-                minioClient
-                        .listObjects(ListObjectsArgs.builder().bucket(bucket).build())
-                        .iterator();
-        for (int i = 2; i < 10; i++) {
-            Result<Item> item = results.next();
-            assertEquals("test-" + i + ".txt", item.get().objectName());
-        }
-
-        List<Record> all = new ArrayList<>();
-        for (int i = 0; i < 8; i++) {
-            all.addAll(agentSource.read());
-        }
-
-        agentSource.commit(all);
-        all.clear();
-
-        results =
-                minioClient
-                        .listObjects(ListObjectsArgs.builder().bucket(bucket).build())
-                        .iterator();
-        assertFalse(results.hasNext());
-
-        for (int i = 0; i < 10; i++) {
-            all.addAll(agentSource.read());
-        }
-        agentSource.commit(all);
-        agentSource.commit(List.of());
     }
 
     @Test
     void emptyBucket() throws Exception {
         String bucket = "langstream-test-" + UUID.randomUUID();
-        AgentSource agentSource = buildAgentSource(bucket);
-        assertFalse(
-                minioClient
-                        .listObjects(ListObjectsArgs.builder().bucket(bucket).build())
-                        .iterator()
-                        .hasNext());
-        agentSource.commit(List.of());
-        List<Record> read = new ArrayList<>();
-        for (int i = 0; i < 10; i++) {
-            read.addAll(agentSource.read());
+        try (AgentSource agentSource = buildAgentSource(bucket); ) {
+            assertFalse(
+                    minioClient
+                            .listObjects(ListObjectsArgs.builder().bucket(bucket).build())
+                            .iterator()
+                            .hasNext());
+            agentSource.commit(List.of());
+            List<Record> read = new ArrayList<>();
+            for (int i = 0; i < 10; i++) {
+                read.addAll(agentSource.read());
+            }
+            assertFalse(
+                    minioClient
+                            .listObjects(ListObjectsArgs.builder().bucket(bucket).build())
+                            .iterator()
+                            .hasNext());
+            agentSource.commit(read);
         }
-        assertFalse(
-                minioClient
-                        .listObjects(ListObjectsArgs.builder().bucket(bucket).build())
-                        .iterator()
-                        .hasNext());
-        agentSource.commit(read);
     }
 
     @Test
@@ -370,15 +379,23 @@ public class S3SourceTest {
     }
 
     private AgentSource buildAgentSource(String bucket) throws Exception {
+        return buildAgentSource(bucket, Map.of());
+    }
+
+    private AgentSource buildAgentSource(String bucket, Map<String, Object> additionalConfigs)
+            throws Exception {
         AgentSource agentSource =
                 (AgentSource) AGENT_CODE_REGISTRY.getAgentCode("s3-source").agentCode();
-        Map<String, Object> configs = new HashMap<>();
         String endpoint = localstack.getEndpointOverride(S3).toString();
+        Map<String, Object> configs = new HashMap<>(additionalConfigs);
         configs.put("endpoint", endpoint);
         configs.put("bucketName", bucket);
         agentSource.init(configs);
+        agentSource.setMetadata("my-agent-id", "s3-source", System.currentTimeMillis());
         AgentContext context = mock(AgentContext.class);
         when(context.getMetricsReporter()).thenReturn(MetricsReporter.DISABLED);
+        when(context.getGlobalAgentId()).thenReturn("global-agent-id");
+        when(context.getTenant()).thenReturn("my-tenant");
         agentSource.setContext(context);
         agentSource.start();
         return agentSource;
@@ -393,6 +410,7 @@ public class S3SourceTest {
         configs.put("bucketName", bucket);
         configs.put("objectName", "{{ value.objectName }}");
         agent.init(configs);
+        agent.setMetadata("my-agent-id", "s3-processor", System.currentTimeMillis());
         AgentContext context = mock(AgentContext.class);
         when(context.getMetricsReporter()).thenReturn(MetricsReporter.DISABLED);
         agent.setContext(context);
@@ -416,5 +434,106 @@ public class S3SourceTest {
         assertFalse(S3Source.isExtensionAllowed("", Set.of("bbb")));
         assertFalse(S3Source.isExtensionAllowed(".aaa", Set.of("bbb")));
         assertFalse(S3Source.isExtensionAllowed("aaa.", Set.of("b")));
+    }
+
+    @Test
+    void testStateStoreWithNoDeletes() throws Exception {
+        String bucket = "langstream-test-" + UUID.randomUUID();
+        String stateBucket = "langstream-test-" + UUID.randomUUID();
+        try (AgentSource agentSource =
+                buildAgentSource(
+                        bucket,
+                        Map.of(
+                                "delete-objects",
+                                false,
+                                "state-storage",
+                                "s3",
+                                "state-storage-s3-bucket-name",
+                                stateBucket,
+                                "state-storage-s3-endpoint",
+                                localstack.getEndpointOverride(S3).toString())); ) {
+            String content = "test-content-";
+            for (int i = 0; i < 10; i++) {
+                String s = content + i;
+                minioClient.putObject(
+                        PutObjectArgs.builder().bucket(bucket).object("test-" + i + ".txt").stream(
+                                        new ByteArrayInputStream(
+                                                s.getBytes(StandardCharsets.UTF_8)),
+                                        s.length(),
+                                        -1)
+                                .build());
+            }
+            for (int i = 0; i < 10; i++) {
+                List<Record> read = agentSource.read();
+                assertEquals(1, read.size());
+                assertArrayEquals(
+                        ("test-content-" + i).getBytes(StandardCharsets.UTF_8),
+                        (byte[]) read.get(0).value());
+                assertEquals("test-" + i + ".txt", read.get(0).getHeader("name").valueAsString());
+                assertEquals(bucket, read.get(0).getHeader("bucket").valueAsString());
+                assertEquals("new", read.get(0).getHeader("content_diff").valueAsString());
+                agentSource.commit(read);
+            }
+
+            Iterator<Result<Item>> iterator =
+                    minioClient
+                            .listObjects(ListObjectsArgs.builder().bucket(bucket).build())
+                            .iterator();
+            for (int i = 0; i < 10; i++) {
+                Result<Item> item = iterator.next();
+                assertEquals("test-" + i + ".txt", item.get().objectName());
+            }
+            assertFalse(iterator.hasNext());
+            Item stateObject =
+                    minioClient
+                            .listObjects(ListObjectsArgs.builder().bucket(stateBucket).build())
+                            .iterator()
+                            .next()
+                            .get();
+            assertEquals("global-agent-id.my-agent-id.status.json", stateObject.objectName());
+            S3Source.S3SourceState state =
+                    ((S3Source) agentSource).getStateStorage().get(S3Source.S3SourceState.class);
+            assertEquals(10, state.allTimeObjects().size());
+            for (int i = 0; i < 10; i++) {
+                assertNotNull(state.allTimeObjects().get(bucket + "@test-" + i + ".txt"));
+            }
+            agentSource.read();
+            state = ((S3Source) agentSource).getStateStorage().get(S3Source.S3SourceState.class);
+            assertEquals(10, state.allTimeObjects().size());
+            String etag0 = null;
+            for (int i = 0; i < 10; i++) {
+                assertNotNull(state.allTimeObjects().get(bucket + "@test-" + i + ".txt"));
+                if (i == 0) {
+                    etag0 = state.allTimeObjects().get(bucket + "@test-" + i + ".txt");
+                }
+            }
+
+            final String s = "changed-contnet";
+            S3StateStorage.putWithRetries(
+                    minioClient,
+                    () ->
+                            PutObjectArgs.builder().bucket(bucket).object("test-0.txt").stream(
+                                            new ByteArrayInputStream(
+                                                    s.getBytes(StandardCharsets.UTF_8)),
+                                            s.length(),
+                                            -1)
+                                    .build());
+            List<Record> read = agentSource.read();
+            assertEquals(bucket, read.get(0).getHeader("bucket").valueAsString());
+            assertEquals("content_changed", read.get(0).getHeader("content_diff").valueAsString());
+
+            state = ((S3Source) agentSource).getStateStorage().get(S3Source.S3SourceState.class);
+            assertEquals(10, state.allTimeObjects().size());
+            assertNotEquals(etag0, state.allTimeObjects().get(bucket + "@test-0.txt"));
+
+            // ensure no emit it again
+            assertTrue(agentSource.read().isEmpty());
+
+            minioClient.removeObject(
+                    RemoveObjectArgs.builder().bucket(bucket).object("test-0.txt").build());
+            assertTrue(agentSource.read().isEmpty());
+            state = ((S3Source) agentSource).getStateStorage().get(S3Source.S3SourceState.class);
+            assertEquals(9, state.allTimeObjects().size());
+        }
     }
 }

--- a/langstream-agents/langstream-agent-s3/src/test/java/ai/langstream/agents/s3/S3SourceTest.java
+++ b/langstream-agents/langstream-agent-s3/src/test/java/ai/langstream/agents/s3/S3SourceTest.java
@@ -367,12 +367,15 @@ public class S3SourceTest {
         String bucket = "langstream-test-" + UUID.randomUUID();
         AgentSource agentSource = buildAgentSource(bucket);
         String content = "test-content";
-        minioClient.putObject(
-                PutObjectArgs.builder().bucket(bucket).object("test").stream(
-                                new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8)),
-                                content.length(),
-                                -1)
-                        .build());
+        S3StateStorage.putWithRetries(
+                minioClient,
+                () ->
+                        PutObjectArgs.builder().bucket(bucket).object("test").stream(
+                                        new ByteArrayInputStream(
+                                                content.getBytes(StandardCharsets.UTF_8)),
+                                        content.length(),
+                                        -1)
+                                .build());
         List<Record> read = agentSource.read();
         minioClient.removeObject(RemoveObjectArgs.builder().bucket(bucket).object("test").build());
         agentSource.commit(read);

--- a/langstream-agents/langstream-agent-webcrawler/pom.xml
+++ b/langstream-agents/langstream-agent-webcrawler/pom.xml
@@ -43,6 +43,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>langstream-agents-commons-state-storage</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>com.github.crawler-commons</groupId>
       <artifactId>crawler-commons</artifactId>
       <version>1.4</version>

--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/WebCrawlerSource.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/WebCrawlerSource.java
@@ -177,10 +177,14 @@ public class WebCrawlerSource extends AbstractAgentCode implements AgentSource {
                                 + " and state-storage was set to 'disk'");
             }
             log.info("Using local disk storage");
-            final String statusFilename =
+            final Path statusFilename =
                     LocalDiskStateStorage.computePath(
-                            context.getTenant(), globalAgentId, agentConfiguration, "webcrawler");
-            this.stateStorage = new LocalDiskStateStorage<>(Path.of(statusFilename));
+                            localDiskPath,
+                            context.getTenant(),
+                            globalAgentId,
+                            agentConfiguration,
+                            "webcrawler");
+            this.stateStorage = new LocalDiskStateStorage<>(statusFilename);
             log.info("Status file is {}", statusFilename);
         } else {
             log.info("Using S3 storage");

--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/WebCrawlerSource.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/WebCrawlerSource.java
@@ -177,7 +177,8 @@ public class WebCrawlerSource extends AbstractAgentCode implements AgentSource {
                                 + " and state-storage was set to 'disk'");
             }
             log.info("Using local disk storage");
-            final String statusFilename = LocalDiskStateStorage.computePath(
+            final String statusFilename =
+                    LocalDiskStateStorage.computePath(
                             context.getTenant(), globalAgentId, agentConfiguration, "webcrawler");
             this.stateStorage = new LocalDiskStateStorage<>(Path.of(statusFilename));
             log.info("Status file is {}", statusFilename);
@@ -211,7 +212,6 @@ public class WebCrawlerSource extends AbstractAgentCode implements AgentSource {
             this.stateStorage = new S3StateStorage<>(minioClient, bucketName, statusFileName);
             log.info("Status file is {}", statusFileName);
         }
-
 
         final String deletedDocumentsTopic =
                 getString("deleted-documents-topic", null, agentConfiguration);

--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/WebCrawlerSource.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/WebCrawlerSource.java
@@ -37,7 +37,6 @@ import ai.langstream.api.runner.code.Record;
 import ai.langstream.api.runner.code.SimpleRecord;
 import ai.langstream.api.runner.topics.TopicProducer;
 import io.minio.*;
-
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Collection;
@@ -49,10 +48,8 @@ import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicInteger;
-
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -184,7 +181,10 @@ public class WebCrawlerSource extends AbstractAgentCode implements AgentSource {
             }
             log.info("Using local disk storage");
 
-            statusFileName = LocalDiskStateStorage.computePath(context.getTenant(), globalAgentId, agentConfiguration, "webcrawler");;
+            statusFileName =
+                    LocalDiskStateStorage.computePath(
+                            context.getTenant(), globalAgentId, agentConfiguration, "webcrawler");
+            ;
 
             this.stateStorage = new LocalDiskStateStorage<>(Path.of(stateStorage));
         } else {
@@ -209,7 +209,10 @@ public class WebCrawlerSource extends AbstractAgentCode implements AgentSource {
                 builder.region(region);
             }
             minioClient = builder.build();
-            statusFileName = S3StateStorage.computeObjectName(context.getTenant(), globalAgentId, agentConfiguration, "webcrawler");;
+            statusFileName =
+                    S3StateStorage.computeObjectName(
+                            context.getTenant(), globalAgentId, agentConfiguration, "webcrawler");
+            ;
             this.stateStorage = new S3StateStorage<>(minioClient, bucketName, statusFileName);
         }
         log.info("Status file is {}", statusFileName);
@@ -408,7 +411,6 @@ public class WebCrawlerSource extends AbstractAgentCode implements AgentSource {
             return "WebCrawlerSourceRecord{" + "url='" + url + '\'' + '}';
         }
     }
-
 
     @Override
     public void close() throws Exception {

--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/StatusStorage.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/StatusStorage.java
@@ -15,8 +15,6 @@
  */
 package ai.langstream.agents.webcrawler.crawler;
 
-import ai.langstream.ai.agents.commons.state.StateStorage;
-
 import java.util.List;
 import java.util.Map;
 

--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/StatusStorage.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/StatusStorage.java
@@ -15,23 +15,22 @@
  */
 package ai.langstream.agents.webcrawler.crawler;
 
+import ai.langstream.ai.agents.commons.state.StateStorage;
+
 import java.util.List;
 import java.util.Map;
 
-public interface StatusStorage {
-    void storeStatus(Status metadata) throws Exception;
+public class StatusStorage {
 
-    record StoreUrlReference(String url, String type, int depth) {}
+    public record StoreUrlReference(String url, String type, int depth) {}
 
-    record RobotsFile(String content, String contentType) {}
+    public record RobotsFile(String content, String contentType) {}
 
-    record Status(
+    public record Status(
             List<String> remainingUrls,
             List<StoreUrlReference> urls,
             Long lastIndexEndTimestamp,
             Long lastIndexStartTimestamp,
             Map<String, RobotsFile> robotFiles,
             Map<String, String> allTimeDocuments) {}
-
-    Status getCurrentStatus() throws Exception;
 }

--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/WebCrawler.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/WebCrawler.java
@@ -15,6 +15,7 @@
  */
 package ai.langstream.agents.webcrawler.crawler;
 
+import ai.langstream.ai.agents.commons.state.StateStorage;
 import crawlercommons.robots.SimpleRobotRules;
 import crawlercommons.robots.SimpleRobotRulesParser;
 import crawlercommons.sitemaps.AbstractSiteMap;
@@ -543,8 +544,8 @@ public class WebCrawler {
         status.setLastIndexEndTimestamp(0);
     }
 
-    public void reloadStatus(StatusStorage statusStorage) throws Exception {
-        status.reloadFrom(statusStorage);
+    public void reloadStatus(StateStorage<StatusStorage.Status> stateStorage) throws Exception {
+        status.reloadFrom(stateStorage);
 
         // while reloading we need only to rebuild in memory the robots rules
         // these rules have been already parsed with success the first time

--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerStatus.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerStatus.java
@@ -24,6 +24,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+
+import ai.langstream.ai.agents.commons.state.StateStorage;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -70,8 +72,8 @@ public class WebCrawlerStatus {
 
     private final Map<String, String> allTimeDocuments = new HashMap<>();
 
-    public void reloadFrom(StatusStorage statusStorage) throws Exception {
-        StatusStorage.Status currentStatus = statusStorage.getCurrentStatus();
+    public void reloadFrom(StateStorage<StatusStorage.Status> statusStorage) throws Exception {
+        StatusStorage.Status currentStatus = statusStorage.get(StatusStorage.Status.class);
         if (currentStatus != null) {
             log.info("Found a saved status, reloading");
             pendingUrls.clear();
@@ -151,7 +153,7 @@ public class WebCrawlerStatus {
         this.lastIndexStartTimestamp = lastIndexStartTimestamp;
     }
 
-    public void persist(StatusStorage statusStorage) throws Exception {
+    public void persist(StateStorage<StatusStorage.Status> stateStorage) throws Exception {
         List<StatusStorage.StoreUrlReference> urlReferencesForStore =
                 urls.values().stream()
                         .map(
@@ -159,7 +161,7 @@ public class WebCrawlerStatus {
                                         new StatusStorage.StoreUrlReference(
                                                 ref.url(), ref.type().name(), ref.depth()))
                         .collect(Collectors.toList());
-        statusStorage.storeStatus(
+        stateStorage.store(
                 new StatusStorage.Status(
                         new ArrayList<>(remainingUrls),
                         urlReferencesForStore,

--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerStatus.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerStatus.java
@@ -15,6 +15,7 @@
  */
 package ai.langstream.agents.webcrawler.crawler;
 
+import ai.langstream.ai.agents.commons.state.StateStorage;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayDeque;
@@ -24,8 +25,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-
-import ai.langstream.ai.agents.commons.state.StateStorage;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 

--- a/langstream-agents/langstream-agent-webcrawler/src/test/java/ai/langstream/agents/webcrawler/WebCrawlerSourceTest.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/test/java/ai/langstream/agents/webcrawler/WebCrawlerSourceTest.java
@@ -589,7 +589,7 @@ public class WebCrawlerSourceTest {
                                 "false",
                                 "max-urls",
                                 10000));
-        assertEquals(objectName, agentSource.buildAdditionalInfo().get("reference"));
+        assertEquals(objectName, agentSource.buildAdditionalInfo().get("statusFileName"));
         agentSource.close();
     }
 }

--- a/langstream-agents/langstream-agent-webcrawler/src/test/java/ai/langstream/agents/webcrawler/WebCrawlerSourceTest.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/test/java/ai/langstream/agents/webcrawler/WebCrawlerSourceTest.java
@@ -35,7 +35,6 @@ import ai.langstream.api.runner.topics.TopicProducer;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import io.minio.*;
-import io.minio.errors.*;
 import io.minio.messages.Item;
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
@@ -390,7 +389,7 @@ public class WebCrawlerSourceTest {
                              </body>
                             </html>""",
                     pages.get("thirdPage.html"));
-            StatusStorage.Status statusOnS3 = agentSource.getStatusStorage().getCurrentStatus();
+            StatusStorage.Status statusOnS3 = agentSource.getStateStorage().get(StatusStorage.Status.class);
             assertEquals(3, statusOnS3.allTimeDocuments().size());
 
             stubFor(get("/index.html").willReturn(notFound()));
@@ -399,7 +398,7 @@ public class WebCrawlerSourceTest {
                 agentSource.read();
             }
 
-            statusOnS3 = agentSource.getStatusStorage().getCurrentStatus();
+            statusOnS3 = agentSource.getStateStorage().get(StatusStorage.Status.class);
             assertEquals(2, statusOnS3.allTimeDocuments().size());
         }
     }

--- a/langstream-agents/langstream-agent-webcrawler/src/test/java/ai/langstream/agents/webcrawler/WebCrawlerSourceTest.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/test/java/ai/langstream/agents/webcrawler/WebCrawlerSourceTest.java
@@ -589,7 +589,9 @@ public class WebCrawlerSourceTest {
                                 "false",
                                 "max-urls",
                                 10000));
-        assertEquals(objectName, agentSource.buildAdditionalInfo().get("statusFileName"));
+        assertEquals(
+                "s3://%s/%s".formatted(bucket, objectName),
+                agentSource.buildAdditionalInfo().get("statusFileName"));
         agentSource.close();
     }
 }

--- a/langstream-agents/langstream-agent-webcrawler/src/test/java/ai/langstream/agents/webcrawler/WebCrawlerSourceTest.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/test/java/ai/langstream/agents/webcrawler/WebCrawlerSourceTest.java
@@ -589,7 +589,7 @@ public class WebCrawlerSourceTest {
                                 "false",
                                 "max-urls",
                                 10000));
-        assertEquals(objectName, agentSource.getStatusFileName());
+        assertEquals(objectName, agentSource.buildAdditionalInfo().get("reference"));
         agentSource.close();
     }
 }

--- a/langstream-agents/langstream-agent-webcrawler/src/test/java/ai/langstream/agents/webcrawler/WebCrawlerSourceTest.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/test/java/ai/langstream/agents/webcrawler/WebCrawlerSourceTest.java
@@ -389,7 +389,8 @@ public class WebCrawlerSourceTest {
                              </body>
                             </html>""",
                     pages.get("thirdPage.html"));
-            StatusStorage.Status statusOnS3 = agentSource.getStateStorage().get(StatusStorage.Status.class);
+            StatusStorage.Status statusOnS3 =
+                    agentSource.getStateStorage().get(StatusStorage.Status.class);
             assertEquals(3, statusOnS3.allTimeDocuments().size());
 
             stubFor(get("/index.html").willReturn(notFound()));

--- a/langstream-agents/langstream-agent-webcrawler/src/test/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerStatusTest.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/test/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerStatusTest.java
@@ -17,9 +17,6 @@ package ai.langstream.agents.webcrawler.crawler;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.util.List;
-import java.util.Map;
-
 import ai.langstream.ai.agents.commons.state.MemoryStateStorage;
 import ai.langstream.ai.agents.commons.state.StateStorage;
 import org.junit.jupiter.api.Test;
@@ -159,5 +156,4 @@ class WebCrawlerStatusTest {
         assertEquals(visited, status.getUrls().size());
         assertEquals(remaining, status.getRemainingUrls().size());
     }
-
 }

--- a/langstream-agents/langstream-agent-webcrawler/src/test/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerStatusTest.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/test/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerStatusTest.java
@@ -19,6 +19,9 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.List;
 import java.util.Map;
+
+import ai.langstream.ai.agents.commons.state.MemoryStateStorage;
+import ai.langstream.ai.agents.commons.state.StateStorage;
 import org.junit.jupiter.api.Test;
 
 class WebCrawlerStatusTest {
@@ -107,7 +110,7 @@ class WebCrawlerStatusTest {
     @Test
     public void testReload() throws Exception {
 
-        DummyStorage storage = new DummyStorage();
+        StateStorage<StatusStorage.Status> storage = new MemoryStateStorage<>();
 
         WebCrawlerStatus status = new WebCrawlerStatus();
         status.addUrl(URL1, URLReference.Type.PAGE, 0, true);
@@ -157,20 +160,4 @@ class WebCrawlerStatusTest {
         assertEquals(remaining, status.getRemainingUrls().size());
     }
 
-    private static class DummyStorage implements StatusStorage {
-
-        private Status lastMetadata;
-
-        @Override
-        public void storeStatus(Status metadata) {
-            lastMetadata = metadata;
-        }
-
-        @Override
-        public Status getCurrentStatus() {
-            return lastMetadata != null
-                    ? lastMetadata
-                    : new Status(List.of(), List.of(), null, null, Map.of(), Map.of());
-        }
-    }
 }

--- a/langstream-agents/langstream-agents-commons-state-storage/pom.xml
+++ b/langstream-agents/langstream-agents-commons-state-storage/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>ai.langstream</groupId>
         <artifactId>langstream-agents</artifactId>
-        <version>0.11.7-SNAPSHOT</version>
+        <version>0.11.8-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>langstream-agents-commons-state-storage</artifactId>

--- a/langstream-agents/langstream-agents-commons-state-storage/pom.xml
+++ b/langstream-agents/langstream-agents-commons-state-storage/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright DataStax, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>ai.langstream</groupId>
+        <artifactId>langstream-agents</artifactId>
+        <version>0.11.7-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>langstream-agents-commons-state-storage</artifactId>
+    <packaging>jar</packaging>
+    <name>LangStream - State Storage for Agents</name>
+    <properties>
+        <build.dir>${project.build.directory}</build.dir>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>langstream-api</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.minio</groupId>
+            <artifactId>minio</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/langstream-agents/langstream-agents-commons-state-storage/pom.xml
+++ b/langstream-agents/langstream-agents-commons-state-storage/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>ai.langstream</groupId>
         <artifactId>langstream-agents</artifactId>
-        <version>0.11.8-SNAPSHOT</version>
+        <version>0.12.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>langstream-agents-commons-state-storage</artifactId>

--- a/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/LocalDiskStateStorage.java
+++ b/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/LocalDiskStateStorage.java
@@ -1,25 +1,16 @@
 package ai.langstream.ai.agents.commons.state;
 
+import static ai.langstream.api.util.ConfigurationUtils.getBoolean;
+import static ai.langstream.api.util.ConfigurationUtils.getString;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.minio.*;
-import io.minio.errors.ErrorResponseException;
-import io.minio.errors.MinioException;
-import lombok.AllArgsConstructor;
-import lombok.SneakyThrows;
-import lombok.extern.slf4j.Slf4j;
-
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Supplier;
-
-import static ai.langstream.api.util.ConfigurationUtils.getBoolean;
-import static ai.langstream.api.util.ConfigurationUtils.getString;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @AllArgsConstructor

--- a/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/LocalDiskStateStorage.java
+++ b/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/LocalDiskStateStorage.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ai.langstream.ai.agents.commons.state;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/LocalDiskStateStorage.java
+++ b/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/LocalDiskStateStorage.java
@@ -1,0 +1,70 @@
+package ai.langstream.ai.agents.commons.state;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.minio.*;
+import io.minio.errors.ErrorResponseException;
+import io.minio.errors.MinioException;
+import lombok.AllArgsConstructor;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import static ai.langstream.api.util.ConfigurationUtils.getBoolean;
+import static ai.langstream.api.util.ConfigurationUtils.getString;
+
+@Slf4j
+@AllArgsConstructor
+public class LocalDiskStateStorage<T> implements StateStorage<T> {
+
+    public static String computePath(
+            final String tenant,
+            final String globalAgentId,
+            final Map<String, Object> agentConfiguration,
+            final String suffix) {
+        final boolean prependTenant =
+                getBoolean("state-storage-file-prepend-tenant", false, agentConfiguration);
+        final String prefix = getString("state-storage-file-prefix", "", agentConfiguration);
+
+        final String pathPrefix;
+        if (prependTenant) {
+            pathPrefix = prefix + tenant + "-" + globalAgentId;
+        } else {
+            pathPrefix = prefix + globalAgentId;
+        }
+        return pathPrefix + "." + suffix + ".status.json";
+    }
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final Path path;
+
+    @Override
+    public void store(T status) throws Exception {
+        log.info("Storing state to the disk at path {}", path);
+        MAPPER.writeValue(path.toFile(), status);
+    }
+
+    @Override
+    public T get(Class<T> clazz) throws Exception {
+        if (Files.exists(path)) {
+            log.info("Restoring state from {}", path);
+            try {
+                return MAPPER.readValue(path.toFile(), clazz);
+            } catch (IOException e) {
+                log.error("Error parsing state file", e);
+                return null;
+            }
+        } else {
+            return null;
+        }
+    }
+}

--- a/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/LocalDiskStateStorage.java
+++ b/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/LocalDiskStateStorage.java
@@ -1,8 +1,5 @@
 package ai.langstream.ai.agents.commons.state;
 
-import static ai.langstream.api.util.ConfigurationUtils.getBoolean;
-import static ai.langstream.api.util.ConfigurationUtils.getString;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.minio.*;
 import java.io.IOException;
@@ -21,9 +18,8 @@ public class LocalDiskStateStorage<T> implements StateStorage<T> {
             final String globalAgentId,
             final Map<String, Object> agentConfiguration,
             final String suffix) {
-        final boolean prependTenant =
-                getBoolean("state-storage-file-prepend-tenant", false, agentConfiguration);
-        final String prefix = getString("state-storage-file-prefix", "", agentConfiguration);
+        final boolean prependTenant = StateStorage.isFilePrependTenant(agentConfiguration);
+        final String prefix = StateStorage.getFilePrefix(agentConfiguration);
 
         final String pathPrefix;
         if (prependTenant) {

--- a/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/LocalDiskStateStorage.java
+++ b/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/LocalDiskStateStorage.java
@@ -58,4 +58,9 @@ public class LocalDiskStateStorage<T> implements StateStorage<T> {
             return null;
         }
     }
+
+    @Override
+    public String getStateReference() {
+        return path.toString();
+    }
 }

--- a/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/MemoryStateStorage.java
+++ b/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/MemoryStateStorage.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ai.langstream.ai.agents.commons.state;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/MemoryStateStorage.java
+++ b/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/MemoryStateStorage.java
@@ -1,0 +1,31 @@
+package ai.langstream.ai.agents.commons.state;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static ai.langstream.api.util.ConfigurationUtils.getBoolean;
+import static ai.langstream.api.util.ConfigurationUtils.getString;
+
+@Slf4j
+public class MemoryStateStorage<T> implements StateStorage<T> {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private T value;
+
+    @Override
+    public void store(T status) throws Exception {
+        log.info("Storing state to memory");
+        value = status;
+    }
+
+    @Override
+    public T get(Class<T> clazz) throws Exception {
+        return value;
+    }
+}

--- a/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/MemoryStateStorage.java
+++ b/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/MemoryStateStorage.java
@@ -1,16 +1,7 @@
 package ai.langstream.ai.agents.commons.state;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Map;
-
-import static ai.langstream.api.util.ConfigurationUtils.getBoolean;
-import static ai.langstream.api.util.ConfigurationUtils.getString;
 
 @Slf4j
 public class MemoryStateStorage<T> implements StateStorage<T> {

--- a/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/MemoryStateStorage.java
+++ b/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/MemoryStateStorage.java
@@ -19,4 +19,9 @@ public class MemoryStateStorage<T> implements StateStorage<T> {
     public T get(Class<T> clazz) throws Exception {
         return value;
     }
+
+    @Override
+    public String getStateReference() {
+        return null;
+    }
 }

--- a/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/S3StateStorage.java
+++ b/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/S3StateStorage.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ai.langstream.ai.agents.commons.state;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/S3StateStorage.java
+++ b/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/S3StateStorage.java
@@ -131,4 +131,9 @@ public class S3StateStorage<T> implements StateStorage<T> {
             throw e;
         }
     }
+
+    @Override
+    public String getStateReference() {
+        return "s3://" + bucketName + "/" + objectName;
+    }
 }

--- a/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/S3StateStorage.java
+++ b/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/S3StateStorage.java
@@ -1,8 +1,5 @@
 package ai.langstream.ai.agents.commons.state;
 
-import static ai.langstream.api.util.ConfigurationUtils.getBoolean;
-import static ai.langstream.api.util.ConfigurationUtils.getString;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.minio.*;
 import io.minio.errors.ErrorResponseException;
@@ -25,9 +22,8 @@ public class S3StateStorage<T> implements StateStorage<T> {
             final String globalAgentId,
             final Map<String, Object> agentConfiguration,
             final String suffix) {
-        final boolean prependTenant =
-                getBoolean("state-storage-file-prepend-tenant", false, agentConfiguration);
-        final String prefix = getString("state-storage-file-prefix", "", agentConfiguration);
+        final boolean prependTenant = StateStorage.isFilePrependTenant(agentConfiguration);
+        final String prefix = StateStorage.getFilePrefix(agentConfiguration);
 
         final String pathPrefix;
         if (prependTenant) {
@@ -76,6 +72,11 @@ public class S3StateStorage<T> implements StateStorage<T> {
     }
 
     private void putWithRetries(Supplier<PutObjectArgs> args)
+            throws MinioException, NoSuchAlgorithmException, InvalidKeyException, IOException {
+        putWithRetries(minioClient, args);
+    }
+
+    public static void putWithRetries(MinioClient minioClient, Supplier<PutObjectArgs> args)
             throws MinioException, NoSuchAlgorithmException, InvalidKeyException, IOException {
         int attempt = 0;
         int maxRetries = 5;

--- a/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/S3StateStorage.java
+++ b/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/S3StateStorage.java
@@ -1,13 +1,12 @@
 package ai.langstream.ai.agents.commons.state;
 
+import static ai.langstream.api.util.ConfigurationUtils.getBoolean;
+import static ai.langstream.api.util.ConfigurationUtils.getString;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.minio.*;
 import io.minio.errors.ErrorResponseException;
 import io.minio.errors.MinioException;
-import lombok.AllArgsConstructor;
-import lombok.SneakyThrows;
-import lombok.extern.slf4j.Slf4j;
-
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.security.InvalidKeyException;
@@ -15,9 +14,8 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
-
-import static ai.langstream.api.util.ConfigurationUtils.getBoolean;
-import static ai.langstream.api.util.ConfigurationUtils.getString;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class S3StateStorage<T> implements StateStorage<T> {
@@ -63,7 +61,6 @@ public class S3StateStorage<T> implements StateStorage<T> {
         }
     }
 
-
     @Override
     public void store(T status) throws Exception {
         byte[] content = MAPPER.writeValueAsBytes(status);
@@ -90,8 +87,7 @@ public class S3StateStorage<T> implements StateStorage<T> {
                 return;
             } catch (IOException e) {
                 log.error("error putting object to s3", e);
-                if (e.getMessage() != null
-                        && e.getMessage().contains("unexpected end of stream")
+                if (e.getMessage() != null && e.getMessage().contains("unexpected end of stream")
                         || e.getMessage().contains("unexpected EOF")
                         || e.getMessage().contains("Broken pipe")) {
                     if (attempt == maxRetries) {
@@ -119,10 +115,7 @@ public class S3StateStorage<T> implements StateStorage<T> {
         try {
             GetObjectResponse result =
                     minioClient.getObject(
-                            GetObjectArgs.builder()
-                                    .bucket(bucketName)
-                                    .object(objectName)
-                                    .build());
+                            GetObjectArgs.builder().bucket(bucketName).object(objectName).build());
             byte[] content = result.readAllBytes();
             log.info("Restoring state from {}, {} bytes", objectName, content.length);
             try {

--- a/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/S3StateStorage.java
+++ b/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/S3StateStorage.java
@@ -1,0 +1,141 @@
+package ai.langstream.ai.agents.commons.state;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.minio.*;
+import io.minio.errors.ErrorResponseException;
+import io.minio.errors.MinioException;
+import lombok.AllArgsConstructor;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import static ai.langstream.api.util.ConfigurationUtils.getBoolean;
+import static ai.langstream.api.util.ConfigurationUtils.getString;
+
+@Slf4j
+public class S3StateStorage<T> implements StateStorage<T> {
+
+    public static String computeObjectName(
+            final String tenant,
+            final String globalAgentId,
+            final Map<String, Object> agentConfiguration,
+            final String suffix) {
+        final boolean prependTenant =
+                getBoolean("state-storage-file-prepend-tenant", false, agentConfiguration);
+        final String prefix = getString("state-storage-file-prefix", "", agentConfiguration);
+
+        final String pathPrefix;
+        if (prependTenant) {
+            pathPrefix = prefix + tenant + "/" + globalAgentId;
+        } else {
+            pathPrefix = prefix + globalAgentId;
+        }
+        return pathPrefix + "." + suffix + ".status.json";
+    }
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final MinioClient minioClient;
+    private final String bucketName;
+    private final String objectName;
+
+    public S3StateStorage(MinioClient minioClient, String bucketName, String objectName) {
+        this.minioClient = minioClient;
+        this.bucketName = bucketName;
+        this.objectName = objectName;
+        makeBucketIfNotExists();
+    }
+
+    @SneakyThrows
+    private void makeBucketIfNotExists() {
+        if (!minioClient.bucketExists(BucketExistsArgs.builder().bucket(bucketName).build())) {
+            log.info("Creating bucket {}", bucketName);
+            minioClient.makeBucket(MakeBucketArgs.builder().bucket(bucketName).build());
+        } else {
+            log.info("Bucket {} already exists", bucketName);
+        }
+    }
+
+
+    @Override
+    public void store(T status) throws Exception {
+        byte[] content = MAPPER.writeValueAsBytes(status);
+        log.info("Storing state in {}, {} bytes", objectName, content.length);
+        putWithRetries(
+                () ->
+                        PutObjectArgs.builder()
+                                .bucket(bucketName)
+                                .object(objectName)
+                                .contentType("text/json")
+                                .stream(new ByteArrayInputStream(content), content.length, -1)
+                                .build());
+    }
+
+    private void putWithRetries(Supplier<PutObjectArgs> args)
+            throws MinioException, NoSuchAlgorithmException, InvalidKeyException, IOException {
+        int attempt = 0;
+        int maxRetries = 5;
+        while (attempt < maxRetries) {
+            try {
+                attempt++;
+                log.info("attempting to put object to s3 {}/{}", attempt, maxRetries);
+                minioClient.putObject(args.get());
+                return;
+            } catch (IOException e) {
+                log.error("error putting object to s3", e);
+                if (e.getMessage() != null
+                        && e.getMessage().contains("unexpected end of stream")
+                        || e.getMessage().contains("unexpected EOF")
+                        || e.getMessage().contains("Broken pipe")) {
+                    if (attempt == maxRetries) {
+                        throw e;
+                    }
+                    long backoffTime = (long) Math.pow(2, attempt - 1) * 2000;
+                    log.info(
+                            "retrying put due to unexpected end of stream, retrying in {} ms",
+                            backoffTime);
+                    try {
+                        TimeUnit.MILLISECONDS.sleep(backoffTime);
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        throw new RuntimeException(ie);
+                    }
+                } else {
+                    throw e;
+                }
+            }
+        }
+    }
+
+    @Override
+    public T get(Class<T> clazz) throws Exception {
+        try {
+            GetObjectResponse result =
+                    minioClient.getObject(
+                            GetObjectArgs.builder()
+                                    .bucket(bucketName)
+                                    .object(objectName)
+                                    .build());
+            byte[] content = result.readAllBytes();
+            log.info("Restoring state from {}, {} bytes", objectName, content.length);
+            try {
+                return MAPPER.readValue(content, clazz);
+            } catch (IOException e) {
+                log.error("Error parsing state file", e);
+                return null;
+            }
+        } catch (ErrorResponseException e) {
+            if (e.errorResponse().code().equals("NoSuchKey")) {
+                return null;
+            }
+            throw e;
+        }
+    }
+}

--- a/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/StateStorage.java
+++ b/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/StateStorage.java
@@ -1,0 +1,10 @@
+package ai.langstream.ai.agents.commons.state;
+
+
+public interface StateStorage<T> {
+
+
+    void store(T state) throws Exception;
+
+    T get(Class<T> clazz) throws Exception;
+}

--- a/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/StateStorage.java
+++ b/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/StateStorage.java
@@ -7,6 +7,4 @@ public interface StateStorage<T> {
     T get(Class<T> clazz) throws Exception;
 
     String getStateReference();
-
 }
-

--- a/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/StateStorage.java
+++ b/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/StateStorage.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ai.langstream.ai.agents.commons.state;
 
 import static ai.langstream.api.util.ConfigurationUtils.getBoolean;

--- a/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/StateStorage.java
+++ b/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/StateStorage.java
@@ -1,8 +1,6 @@
 package ai.langstream.ai.agents.commons.state;
 
-
 public interface StateStorage<T> {
-
 
     void store(T state) throws Exception;
 

--- a/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/StateStorage.java
+++ b/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/StateStorage.java
@@ -1,6 +1,19 @@
 package ai.langstream.ai.agents.commons.state;
 
+import static ai.langstream.api.util.ConfigurationUtils.getBoolean;
+import static ai.langstream.api.util.ConfigurationUtils.getString;
+
+import java.util.Map;
+
 public interface StateStorage<T> {
+
+    static boolean isFilePrependTenant(Map<String, Object> agentConfiguration) {
+        return getBoolean("state-storage-file-prepend-tenant", false, agentConfiguration);
+    }
+
+    static String getFilePrefix(Map<String, Object> agentConfiguration) {
+        return getString("state-storage-file-prefix", "", agentConfiguration);
+    }
 
     void store(T state) throws Exception;
 

--- a/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/StateStorage.java
+++ b/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/StateStorage.java
@@ -5,4 +5,8 @@ public interface StateStorage<T> {
     void store(T state) throws Exception;
 
     T get(Class<T> clazz) throws Exception;
+
+    String getStateReference();
+
 }
+

--- a/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/StateStorageProvider.java
+++ b/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/StateStorageProvider.java
@@ -1,34 +1,40 @@
 package ai.langstream.ai.agents.commons.state;
 
-import io.minio.MinioClient;
-import lombok.extern.slf4j.Slf4j;
-import org.jetbrains.annotations.NotNull;
+import static ai.langstream.api.util.ConfigurationUtils.getString;
 
+import io.minio.MinioClient;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.Optional;
-
-import static ai.langstream.api.util.ConfigurationUtils.getString;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
 
 @Slf4j
 public class StateStorageProvider<T> {
 
-    public StateStorage<T> create(final String tenant,
-                                  final String agentId,
-                                  final String globalAgentId,
-                                  final Map<String, Object> agentConfiguration,
-                                  Optional<Path> localDiskPath) {
-        StateStorage<T> objectStateStorage = initStateStorage(tenant, agentId, globalAgentId, agentConfiguration, localDiskPath);
-        log.info("State storage initialized for agent {} - type {} - reference {}", agentId, objectStateStorage.getClass().getSimpleName(), objectStateStorage.getStateReference());
+    public StateStorage<T> create(
+            final String tenant,
+            final String agentId,
+            final String globalAgentId,
+            final Map<String, Object> agentConfiguration,
+            Optional<Path> localDiskPath) {
+        StateStorage<T> objectStateStorage =
+                initStateStorage(tenant, agentId, globalAgentId, agentConfiguration, localDiskPath);
+        log.info(
+                "State storage initialized for agent {} - type {} - reference {}",
+                agentId,
+                objectStateStorage.getClass().getSimpleName(),
+                objectStateStorage.getStateReference());
         return objectStateStorage;
     }
 
     @NotNull
-    private static <T> StateStorage<T> initStateStorage(String tenant,
-                                                        String agentId,
-                                                        String globalAgentId,
-                                                        Map<String, Object> agentConfiguration,
-                                                        Optional<Path> localDiskPath) {
+    private static <T> StateStorage<T> initStateStorage(
+            String tenant,
+            String agentId,
+            String globalAgentId,
+            Map<String, Object> agentConfiguration,
+            Optional<Path> localDiskPath) {
         final String stateStorage = getString("state-storage", "s3", agentConfiguration);
 
         if (stateStorage.equals("disk")) {
@@ -40,18 +46,27 @@ public class StateStorageProvider<T> {
             }
             log.info("Using local disk storage");
 
-            String stateFilename = LocalDiskStateStorage.computePath(
-                    tenant, globalAgentId, agentConfiguration, agentId);
+            String stateFilename =
+                    LocalDiskStateStorage.computePath(
+                            tenant, globalAgentId, agentConfiguration, agentId);
 
             return new LocalDiskStateStorage<>(Path.of(stateFilename));
         } else {
             log.info("Using S3 storage");
-            final String bucketName = getString("state-storage-s3-bucket-name", "langstream-s3-source-state", agentConfiguration);
+            final String bucketName =
+                    getString(
+                            "state-storage-s3-bucket-name",
+                            "langstream-s3-source-state",
+                            agentConfiguration);
             final String endpoint =
                     getString(
-                            "state-storage-s3-endpoint", "http://minio-endpoint.-not-set:9090", agentConfiguration);
-            final String username = getString("state-storage-s3-access-key", "minioadmin", agentConfiguration);
-            final String password = getString("state-storage-s3-secret-key", "minioadmin", agentConfiguration);
+                            "state-storage-s3-endpoint",
+                            "http://minio-endpoint.-not-set:9090",
+                            agentConfiguration);
+            final String username =
+                    getString("state-storage-s3-access-key", "minioadmin", agentConfiguration);
+            final String password =
+                    getString("state-storage-s3-secret-key", "minioadmin", agentConfiguration);
             final String region = getString("state-storage-s3-region", "", agentConfiguration);
 
             log.info(
@@ -66,8 +81,9 @@ public class StateStorageProvider<T> {
                 builder.region(region);
             }
             MinioClient minioClient = builder.build();
-            String stateFilename = LocalDiskStateStorage.computePath(
-                    tenant, globalAgentId, agentConfiguration, agentId);
+            String stateFilename =
+                    LocalDiskStateStorage.computePath(
+                            tenant, globalAgentId, agentConfiguration, agentId);
             return new S3StateStorage<>(minioClient, bucketName, stateFilename);
         }
     }

--- a/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/StateStorageProvider.java
+++ b/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/StateStorageProvider.java
@@ -60,19 +60,14 @@ public class StateStorageProvider<T> {
         }
 
         if (stateStorage.equals("disk")) {
-            if (!localDiskPath.isPresent()) {
-                throw new IllegalArgumentException(
-                        "No local disk path available for agent "
-                                + agentId
-                                + " and state-storage was set to 'disk'");
-            }
+
             log.info("Using local disk storage");
 
-            String stateFilename =
+            Path stateFilename =
                     LocalDiskStateStorage.computePath(
-                            tenant, globalAgentId, agentConfiguration, agentId);
+                            localDiskPath, tenant, globalAgentId, agentConfiguration, agentId);
 
-            return new LocalDiskStateStorage<>(Path.of(stateFilename));
+            return new LocalDiskStateStorage<>(stateFilename);
         } else {
             log.info("Using S3 storage");
             final String bucketName =
@@ -104,7 +99,7 @@ public class StateStorageProvider<T> {
             }
             MinioClient minioClient = builder.build();
             String stateFilename =
-                    LocalDiskStateStorage.computePath(
+                    S3StateStorage.computeObjectName(
                             tenant, globalAgentId, agentConfiguration, agentId);
             return new S3StateStorage<>(minioClient, bucketName, stateFilename);
         }

--- a/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/StateStorageProvider.java
+++ b/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/StateStorageProvider.java
@@ -7,10 +7,11 @@ import java.nio.file.Path;
 import java.util.Map;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
-import org.jetbrains.annotations.NotNull;
 
 @Slf4j
 public class StateStorageProvider<T> {
+
+    public static final String CONFIGURATION_KEY_STATE_STORAGE = "state-storage";
 
     public StateStorage<T> create(
             final String tenant,
@@ -20,6 +21,9 @@ public class StateStorageProvider<T> {
             Optional<Path> localDiskPath) {
         StateStorage<T> objectStateStorage =
                 initStateStorage(tenant, agentId, globalAgentId, agentConfiguration, localDiskPath);
+        if (objectStateStorage == null) {
+            return null;
+        }
         log.info(
                 "State storage initialized for agent {} - type {} - reference {}",
                 agentId,
@@ -28,14 +32,17 @@ public class StateStorageProvider<T> {
         return objectStateStorage;
     }
 
-    @NotNull
     private static <T> StateStorage<T> initStateStorage(
             String tenant,
             String agentId,
             String globalAgentId,
             Map<String, Object> agentConfiguration,
             Optional<Path> localDiskPath) {
-        final String stateStorage = getString("state-storage", "s3", agentConfiguration);
+        final String stateStorage =
+                getString(CONFIGURATION_KEY_STATE_STORAGE, "", agentConfiguration);
+        if (stateStorage.isEmpty()) {
+            return null;
+        }
 
         if (stateStorage.equals("disk")) {
             if (!localDiskPath.isPresent()) {

--- a/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/StateStorageProvider.java
+++ b/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/StateStorageProvider.java
@@ -1,0 +1,74 @@
+package ai.langstream.ai.agents.commons.state;
+
+import io.minio.MinioClient;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
+
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Optional;
+
+import static ai.langstream.api.util.ConfigurationUtils.getString;
+
+@Slf4j
+public class StateStorageProvider<T> {
+
+    public StateStorage<T> create(final String tenant,
+                                  final String agentId,
+                                  final String globalAgentId,
+                                  final Map<String, Object> agentConfiguration,
+                                  Optional<Path> localDiskPath) {
+        StateStorage<T> objectStateStorage = initStateStorage(tenant, agentId, globalAgentId, agentConfiguration, localDiskPath);
+        log.info("State storage initialized for agent {} - type {} - reference {}", agentId, objectStateStorage.getClass().getSimpleName(), objectStateStorage.getStateReference());
+        return objectStateStorage;
+    }
+
+    @NotNull
+    private static <T> StateStorage<T> initStateStorage(String tenant,
+                                                        String agentId,
+                                                        String globalAgentId,
+                                                        Map<String, Object> agentConfiguration,
+                                                        Optional<Path> localDiskPath) {
+        final String stateStorage = getString("state-storage", "s3", agentConfiguration);
+
+        if (stateStorage.equals("disk")) {
+            if (!localDiskPath.isPresent()) {
+                throw new IllegalArgumentException(
+                        "No local disk path available for agent "
+                                + agentId
+                                + " and state-storage was set to 'disk'");
+            }
+            log.info("Using local disk storage");
+
+            String stateFilename = LocalDiskStateStorage.computePath(
+                    tenant, globalAgentId, agentConfiguration, agentId);
+
+            return new LocalDiskStateStorage<>(Path.of(stateFilename));
+        } else {
+            log.info("Using S3 storage");
+            final String bucketName = getString("state-storage-s3-bucket-name", "langstream-s3-source-state", agentConfiguration);
+            final String endpoint =
+                    getString(
+                            "state-storage-s3-endpoint", "http://minio-endpoint.-not-set:9090", agentConfiguration);
+            final String username = getString("state-storage-s3-access-key", "minioadmin", agentConfiguration);
+            final String password = getString("state-storage-s3-secret-key", "minioadmin", agentConfiguration);
+            final String region = getString("state-storage-s3-region", "", agentConfiguration);
+
+            log.info(
+                    "Connecting to S3 Bucket at {} in region {} with user {}",
+                    endpoint,
+                    region,
+                    username);
+
+            MinioClient.Builder builder =
+                    MinioClient.builder().endpoint(endpoint).credentials(username, password);
+            if (!region.isBlank()) {
+                builder.region(region);
+            }
+            MinioClient minioClient = builder.build();
+            String stateFilename = LocalDiskStateStorage.computePath(
+                    tenant, globalAgentId, agentConfiguration, agentId);
+            return new S3StateStorage<>(minioClient, bucketName, stateFilename);
+        }
+    }
+}

--- a/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/StateStorageProvider.java
+++ b/langstream-agents/langstream-agents-commons-state-storage/src/main/java/ai/langstream/ai/agents/commons/state/StateStorageProvider.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ai.langstream.ai.agents.commons.state;
 
 import static ai.langstream.api.util.ConfigurationUtils.getString;

--- a/langstream-agents/pom.xml
+++ b/langstream-agents/pom.xml
@@ -33,6 +33,7 @@
     </properties>
     <modules>
         <module>langstream-agents-commons</module>
+        <module>langstream-agents-commons-state-storage</module>
         <module>langstream-agent-grpc</module>
         <module>langstream-agent-s3</module>
         <module>langstream-agent-camel</module>

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/ObjectStorageSourceAgentProvider.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/ObjectStorageSourceAgentProvider.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 import java.util.Set;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.extern.slf4j.Slf4j;
 
 /** Implements support for S3/Azure Source Agents. */
@@ -57,9 +58,10 @@ public class ObjectStorageSourceAgentProvider extends AbstractComposableAgentPro
         }
     }
 
+    @EqualsAndHashCode(callSuper = true)
     @AgentConfig(name = "S3 Source", description = "Reads data from S3 bucket")
     @Data
-    public static class S3SourceConfiguration {
+    public static class S3SourceConfiguration extends StateStorageBasedConfiguration {
 
         protected static final String DEFAULT_BUCKET_NAME = "langstream-source";
         protected static final String DEFAULT_ENDPOINT = "http://minio-endpoint.-not-set:9090";
@@ -126,6 +128,24 @@ public class ObjectStorageSourceAgentProvider extends AbstractComposableAgentPro
                                 """)
         @JsonProperty("file-extensions")
         private String fileExtensions = DEFAULT_FILE_EXTENSIONS;
+
+        @ConfigProperty(
+                defaultValue = "true",
+                description =
+                        """
+                       Whether to delete objects after processing.
+                                """)
+        @JsonProperty("delete-objects")
+        private boolean deleteObjects;
+
+        @ConfigProperty(
+                defaultValue = "true",
+                description =
+                        """
+                       Write a message to this topic when an object has been detected as deleted for any reason.
+                                """)
+        @JsonProperty("deleted-objects-topic")
+        private String deletedObjectsTopic;
     }
 
     @AgentConfig(

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/StateStorageBasedConfiguration.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/StateStorageBasedConfiguration.java
@@ -1,0 +1,70 @@
+package ai.langstream.runtime.impl.k8s.agents;
+
+import ai.langstream.api.doc.ConfigProperty;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@Data
+public class StateStorageBasedConfiguration {
+    @ConfigProperty(
+            description =
+                    """
+                    State storage type (s3, disk).
+                    """)
+    @JsonProperty("state-storage")
+    private String stateStorage;
+
+    @ConfigProperty(
+            description =
+                    """
+                    Prepend tenant to the state storage file. (valid for all types)
+                    """)
+    @JsonProperty("state-storage-file-prepend-tenant")
+    private String stateStorageFilePrependTenant;
+
+    @ConfigProperty(
+            description =
+                    """
+                    Prepend a prefix to the state storage file. (valid for all types)
+                    """)
+    @JsonProperty("state-storage-file-prefix")
+    private String stateStorageFilePrefix;
+
+    @ConfigProperty(
+            description = """
+                    State storage S3 bucket.
+                    """)
+    @JsonProperty("state-storage-s3-bucket")
+    private String stateStorageS3Bucket;
+
+    @ConfigProperty(
+            description =
+                    """
+                    State storage S3 endpoint.
+                    """)
+    @JsonProperty("state-storage-s3-endpoint")
+    private String stateStorageS3Endpoint;
+
+    @ConfigProperty(
+            description =
+                    """
+                    State storage S3 access key.
+                    """)
+    @JsonProperty("state-storage-s3-access-key")
+    private String stateStorageS3AKey;
+
+    @ConfigProperty(
+            description =
+                    """
+                    State storage S3 secret key.
+                    """)
+    @JsonProperty("state-storage-s3-secret-key")
+    private String stateStorageS3SecretKey;
+
+    @ConfigProperty(
+            description = """
+                    State storage S3 region.
+                    """)
+    @JsonProperty("state-storage-s3-region")
+    private String stateStorageS3Region;
+}

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/StateStorageBasedConfiguration.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/StateStorageBasedConfiguration.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ai.langstream.runtime.impl.k8s.agents;
 
 import ai.langstream.api.doc.ConfigProperty;

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/test/java/ai/langstream/runtime/impl/k8s/agents/S3SourceAgentProviderTest.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/test/java/ai/langstream/runtime/impl/k8s/agents/S3SourceAgentProviderTest.java
@@ -15,8 +15,6 @@
  */
 package ai.langstream.runtime.impl.k8s.agents;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 import ai.langstream.api.doc.AgentConfigurationModel;
 import ai.langstream.api.runtime.PluginsRegistry;
 import ai.langstream.deployer.k8s.util.SerializationUtil;

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/test/java/ai/langstream/runtime/impl/k8s/agents/S3SourceAgentProviderTest.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/test/java/ai/langstream/runtime/impl/k8s/agents/S3SourceAgentProviderTest.java
@@ -169,6 +169,18 @@ class S3SourceAgentProviderTest {
                                 "type" : "string",
                                 "defaultValue" : "langstream-source"
                               },
+                              "delete-objects" : {
+                                "description" : "Whether to delete objects after processing.",
+                                "required" : false,
+                                "type" : "boolean",
+                                "defaultValue" : "true"
+                              },
+                              "deleted-objects-topic" : {
+                                "description" : "Write a message to this topic when an object has been detected as deleted for any reason.",
+                                "required" : false,
+                                "type" : "string",
+                                "defaultValue" : "true"
+                              },
                               "endpoint" : {
                                 "description" : "The endpoint of the S3 server.",
                                 "required" : false,
@@ -197,6 +209,46 @@ class S3SourceAgentProviderTest {
                                 "required" : false,
                                 "type" : "string",
                                 "defaultValue" : "minioadmin"
+                              },
+                              "state-storage" : {
+                                "description" : "State storage type (s3, disk).",
+                                "required" : false,
+                                "type" : "string"
+                              },
+                              "state-storage-file-prefix" : {
+                                "description" : "Prepend a prefix to the state storage file. (valid for all types)",
+                                "required" : false,
+                                "type" : "string"
+                              },
+                              "state-storage-file-prepend-tenant" : {
+                                "description" : "Prepend tenant to the state storage file. (valid for all types)",
+                                "required" : false,
+                                "type" : "string"
+                              },
+                              "state-storage-s3-access-key" : {
+                                "description" : "State storage S3 access key.",
+                                "required" : false,
+                                "type" : "string"
+                              },
+                              "state-storage-s3-bucket" : {
+                                "description" : "State storage S3 bucket.",
+                                "required" : false,
+                                "type" : "string"
+                              },
+                              "state-storage-s3-endpoint" : {
+                                "description" : "State storage S3 endpoint.",
+                                "required" : false,
+                                "type" : "string"
+                              },
+                              "state-storage-s3-region" : {
+                                "description" : "State storage S3 region.",
+                                "required" : false,
+                                "type" : "string"
+                              },
+                              "state-storage-s3-secret-key" : {
+                                "description" : "State storage S3 secret key.",
+                                "required" : false,
+                                "type" : "string"
                               }
                             }
                           }

--- a/langstream-runtime/langstream-runtime-impl/pom.xml
+++ b/langstream-runtime/langstream-runtime-impl/pom.xml
@@ -116,6 +116,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>localstack</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>langstream-codestorage-s3</artifactId>
       <version>${project.version}</version>

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/AbstractApplicationRunner.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/AbstractApplicationRunner.java
@@ -319,8 +319,7 @@ public abstract class AbstractApplicationRunner {
                 log.error("Error getting fs stats for {}", root, e);
             }
         }
-        List<Image> images =
-                DockerClientFactory.lazyClient().listImagesCmd().exec();
+        List<Image> images = DockerClientFactory.lazyClient().listImagesCmd().exec();
         for (Image image : images) {
             String size = FileUtils.byteCountToDisplaySize(image.getSize());
             if (image.getRepoTags() == null) {

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/AbstractApplicationRunner.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/AbstractApplicationRunner.java
@@ -35,7 +35,6 @@ import ai.langstream.runtime.agent.api.AgentAPIController;
 import ai.langstream.runtime.api.agent.RuntimePodConfiguration;
 import com.github.dockerjava.api.model.Image;
 import io.fabric8.kubernetes.api.model.Secret;
-
 import java.io.IOException;
 import java.nio.file.*;
 import java.util.*;
@@ -47,7 +46,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import lombok.Getter;
-import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterAll;
@@ -311,13 +309,17 @@ public abstract class AbstractApplicationRunner {
         for (Path root : FileSystems.getDefault().getRootDirectories()) {
             try {
                 FileStore store = Files.getFileStore(root);
-                log.info("fs stats {}: available {}, total {}", root, store.getUsableSpace(), store.getTotalSpace());
+                log.info(
+                        "fs stats {}: available {}, total {}",
+                        root,
+                        store.getUsableSpace(),
+                        store.getTotalSpace());
             } catch (IOException e) {
                 log.error("Error getting fs stats for {}", root, e);
             }
         }
-        List<Image> images = DockerClientFactory.lazyClient().listImagesCmd().withShowAll(true)
-                .exec();
+        List<Image> images =
+                DockerClientFactory.lazyClient().listImagesCmd().withShowAll(true).exec();
         for (Image image : images) {
             if (image.getRepoTags() == null) {
                 log.info("Docker dangling image size {}", image.getSize());

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/AbstractApplicationRunner.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/AbstractApplicationRunner.java
@@ -47,6 +47,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.FileUtils;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -312,19 +313,20 @@ public abstract class AbstractApplicationRunner {
                 log.info(
                         "fs stats {}: available {}, total {}",
                         root,
-                        store.getUsableSpace(),
-                        store.getTotalSpace());
+                        FileUtils.byteCountToDisplaySize(store.getUsableSpace()),
+                        FileUtils.byteCountToDisplaySize(store.getTotalSpace()));
             } catch (IOException e) {
                 log.error("Error getting fs stats for {}", root, e);
             }
         }
         List<Image> images =
-                DockerClientFactory.lazyClient().listImagesCmd().withShowAll(true).exec();
+                DockerClientFactory.lazyClient().listImagesCmd().exec();
         for (Image image : images) {
+            String size = FileUtils.byteCountToDisplaySize(image.getSize());
             if (image.getRepoTags() == null) {
-                log.info("Docker dangling image size {}", image.getSize());
+                log.info("Docker dangling image size {}", size);
             } else {
-                log.info("Docker image {} size {}", image.getRepoTags()[0], image.getSize());
+                log.info("Docker image {} size {}", image.getRepoTags()[0], size);
             }
         }
     }

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/CassandraAssetQueryWriteIT.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/CassandraAssetQueryWriteIT.java
@@ -42,7 +42,8 @@ class CassandraAssetQueryWriteIT extends AbstractKafkaApplicationRunner {
 
     @Container
     private CassandraContainer cassandra =
-            new CassandraContainer(new DockerImageName("cassandra", "latest"));
+            new CassandraContainer(
+                    markAsDisposableImage(new DockerImageName("cassandra", "latest")));
 
     @Test
     public void testCassandra() throws Exception {
@@ -53,16 +54,16 @@ class CassandraAssetQueryWriteIT extends AbstractKafkaApplicationRunner {
                 Map.of(
                         "configuration.yaml",
                         """
-                        configuration:
-                          resources:
-                            - type: "datasource"
-                              name: "CassandraDatasource"
-                              configuration:
-                                service: "cassandra"
-                                contact-points: "%s"
-                                loadBalancing-localDc: "%s"
-                                port: %d
-                        """
+                                configuration:
+                                  resources:
+                                    - type: "datasource"
+                                      name: "CassandraDatasource"
+                                      configuration:
+                                        service: "cassandra"
+                                        contact-points: "%s"
+                                        loadBalancing-localDc: "%s"
+                                        port: %d
+                                """
                                 .formatted(
                                         cassandra.getContactPoint().getHostString(),
                                         cassandra.getLocalDatacenter(),
@@ -181,16 +182,16 @@ class CassandraAssetQueryWriteIT extends AbstractKafkaApplicationRunner {
                 Map.of(
                         "configuration.yaml",
                         """
-                        configuration:
-                          resources:
-                            - type: "vector-database"
-                              name: "CassandraDatasource"
-                              configuration:
-                                service: "cassandra"
-                                contact-points: "%s"
-                                loadBalancing-localDc: "%s"
-                                port: %d
-                        """
+                                configuration:
+                                  resources:
+                                    - type: "vector-database"
+                                      name: "CassandraDatasource"
+                                      configuration:
+                                        service: "cassandra"
+                                        contact-points: "%s"
+                                        loadBalancing-localDc: "%s"
+                                        port: %d
+                                """
                                 .formatted(
                                         cassandra.getContactPoint().getHostString(),
                                         cassandra.getLocalDatacenter(),

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/CassandraVectorAssetQueryWriteIT.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/CassandraVectorAssetQueryWriteIT.java
@@ -47,7 +47,9 @@ class CassandraVectorAssetQueryWriteIT extends AbstractKafkaApplicationRunner {
     @Container
     private CassandraContainer cassandra =
             new CassandraContainer(
-                    new DockerImageName("stargateio/dse-next", "4.0.7-0cf63a3d0b6d")
+                    markAsDisposableImage(
+                                    new DockerImageName(
+                                            "stargateio/dse-next", "4.0.7-0cf63a3d0b6d"))
                             .asCompatibleSubstituteFor("cassandra"));
 
     @Test

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/ComputeEmbeddingsIT.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/ComputeEmbeddingsIT.java
@@ -584,13 +584,6 @@ class ComputeEmbeddingsIT extends AbstractKafkaApplicationRunner {
         return Base64.getEncoder().encodeToString(bytes);
     }
 
-    public static void main(String[] args) {
-        // Example usage
-        List<Float> floatList = List.of(1.0f, 5.4f, 8.7f);
-        String base64String = convertFloatListToBase64(floatList);
-        System.out.println(base64String);
-    }
-
     @Test
     public void testLegacySyntax() throws Exception {
         wireMockRuntimeInfo

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/CouchbaseAssetQueryWriteIT.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/CouchbaseAssetQueryWriteIT.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
 
 @Slf4j
 @Testcontainers
@@ -39,7 +40,7 @@ class CouchbaseAssetQueryWriteIT extends AbstractKafkaApplicationRunner {
 
     @Container
     private GenericContainer couchbaseContainer =
-            new GenericContainer("couchbase:latest")
+            new GenericContainer(markAsDisposableImage(new DockerImageName("couchbase:latest")))
                     .withExposedPorts(8091)
                     .withEnv("COUCHBASE_SERVER_MEMORY_QUOTA", "300")
                     .withEnv("COUCHBASE_CLUSTER_RAMSIZE", "300")

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/ElasticSearchVectorIT.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/ElasticSearchVectorIT.java
@@ -34,8 +34,9 @@ class ElasticSearchVectorIT extends AbstractKafkaApplicationRunner {
     @Container
     static ElasticsearchContainer ELASTICSEARCH =
             new ElasticsearchContainer(
-                            DockerImageName.parse(
-                                    "docker.elastic.co/elasticsearch/elasticsearch:8.14.0"))
+                            markAsDisposableImage(
+                                    DockerImageName.parse(
+                                            "docker.elastic.co/elasticsearch/elasticsearch:8.14.0")))
                     .withEnv("discovery.type", "single-node")
                     .withEnv("xpack.security.enabled", "false")
                     .withEnv("xpack.security.http.ssl.enabled", "false")

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/FlareControllerAgentRunnerIT.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/FlareControllerAgentRunnerIT.java
@@ -46,7 +46,8 @@ class FlareControllerAgentRunnerIT extends AbstractKafkaApplicationRunner {
 
     @Container
     static GenericContainer database =
-            new GenericContainer(DockerImageName.parse("herddb/herddb:0.28.0"))
+            new GenericContainer(
+                            markAsDisposableImage(DockerImageName.parse("herddb/herddb:0.28.0")))
                     .withExposedPorts(7000);
 
     @BeforeAll

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/FlareControllerAgentRunnerIT.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/FlareControllerAgentRunnerIT.java
@@ -19,6 +19,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 
+import ai.langstream.utils.HerdDBExtension;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import java.math.BigDecimal;
@@ -31,34 +32,16 @@ import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.junit.jupiter.Container;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
 
 @Slf4j
 @Testcontainers
 @WireMockTest
 class FlareControllerAgentRunnerIT extends AbstractKafkaApplicationRunner {
 
-    @Container
-    static GenericContainer database =
-            new GenericContainer(
-                            markAsDisposableImage(DockerImageName.parse("herddb/herddb:0.28.0")))
-                    .withExposedPorts(7000);
-
-    @BeforeAll
-    public static void startDatabase() {
-        database.start();
-    }
-
-    @AfterAll
-    public static void stopDatabase() {
-        database.stop();
-    }
+    @RegisterExtension static HerdDBExtension herdDB = new HerdDBExtension();
 
     @Test
     public void testSimpleFlare(WireMockRuntimeInfo wireMockRuntimeInfo) throws Exception {
@@ -133,7 +116,7 @@ class FlareControllerAgentRunnerIT extends AbstractKafkaApplicationRunner {
                                   """)));
         String tenant = "tenant";
         String[] expectedAgents = {"app-step1"};
-        String jdbcUrl = "jdbc:herddb:server:localhost:" + database.getMappedPort(7000);
+        String jdbcUrl = herdDB.getJDBCUrl();
 
         Map<String, String> applicationWriter =
                 Map.of(

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/FlowControlRunnerIT.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/FlowControlRunnerIT.java
@@ -31,10 +31,8 @@ import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Slf4j
-@Testcontainers
 class FlowControlRunnerIT extends AbstractKafkaApplicationRunner {
 
     @Test

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/JdbcDatabaseIT.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/JdbcDatabaseIT.java
@@ -42,7 +42,8 @@ class JdbcDatabaseIT extends AbstractKafkaApplicationRunner {
 
     @Container
     static GenericContainer database =
-            new GenericContainer(DockerImageName.parse("herddb/herddb:0.28.0"))
+            new GenericContainer(
+                            markAsDisposableImage(DockerImageName.parse("herddb/herddb:0.28.0")))
                     .withExposedPorts(7000);
 
     @BeforeAll

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/JdbcDatabaseIT.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/JdbcDatabaseIT.java
@@ -17,6 +17,7 @@ package ai.langstream.kafka;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import ai.langstream.utils.HerdDBExtension;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
 import java.util.List;
@@ -26,13 +27,9 @@ import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.junit.jupiter.Container;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
 
 @Slf4j
 @Testcontainers
@@ -40,27 +37,13 @@ class JdbcDatabaseIT extends AbstractKafkaApplicationRunner {
 
     static final ObjectMapper MAPPER = new ObjectMapper();
 
-    @Container
-    static GenericContainer database =
-            new GenericContainer(
-                            markAsDisposableImage(DockerImageName.parse("herddb/herddb:0.28.0")))
-                    .withExposedPorts(7000);
-
-    @BeforeAll
-    public static void startDatabase() {
-        database.start();
-    }
-
-    @AfterAll
-    public static void stopDatabase() {
-        database.stop();
-    }
+    @RegisterExtension static HerdDBExtension herdDB = new HerdDBExtension();
 
     @Test
     public void testSimpleQueries() throws Exception {
         String tenant = "tenant";
         String[] expectedAgents = {"app-step1"};
-        String jdbcUrl = "jdbc:herddb:server:localhost:" + database.getMappedPort(7000);
+        String jdbcUrl = herdDB.getJDBCUrl();
 
         Map<String, String> applicationWriter =
                 Map.of(

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/OpenSearchVectorIT.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/OpenSearchVectorIT.java
@@ -31,7 +31,9 @@ import org.testcontainers.utility.DockerImageName;
 class OpenSearchVectorIT extends AbstractKafkaApplicationRunner {
     @Container
     static OpensearchContainer OPENSEARCH =
-            new OpensearchContainer(DockerImageName.parse("opensearchproject/opensearch:2"))
+            new OpensearchContainer(
+                            markAsDisposableImage(
+                                    DockerImageName.parse("opensearchproject/opensearch:2")))
                     .withEnv("discovery.type", "single-node");
 
     @Test

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/RerankAgentRunnerIT.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/RerankAgentRunnerIT.java
@@ -40,7 +40,8 @@ class RerankAgentRunnerIT extends AbstractKafkaApplicationRunner {
 
     @Container
     static GenericContainer database =
-            new GenericContainer(DockerImageName.parse("herddb/herddb:0.28.0"))
+            new GenericContainer(
+                            markAsDisposableImage(DockerImageName.parse("herddb/herddb:0.28.0")))
                     .withExposedPorts(7000);
 
     @BeforeAll

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/RerankAgentRunnerIT.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/RerankAgentRunnerIT.java
@@ -17,6 +17,7 @@ package ai.langstream.kafka;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import ai.langstream.utils.HerdDBExtension;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
@@ -26,33 +27,15 @@ import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.junit.jupiter.Container;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
 
 @Slf4j
 @Testcontainers
 class RerankAgentRunnerIT extends AbstractKafkaApplicationRunner {
 
-    @Container
-    static GenericContainer database =
-            new GenericContainer(
-                            markAsDisposableImage(DockerImageName.parse("herddb/herddb:0.28.0")))
-                    .withExposedPorts(7000);
-
-    @BeforeAll
-    public static void startDatabase() {
-        database.start();
-    }
-
-    @AfterAll
-    public static void stopDatabase() {
-        database.stop();
-    }
+    @RegisterExtension static HerdDBExtension herdDB = new HerdDBExtension();
 
     @SneakyThrows
     private static void validateResults(String message) {
@@ -97,23 +80,23 @@ class RerankAgentRunnerIT extends AbstractKafkaApplicationRunner {
     public void testSimpleRerank() throws Exception {
         String tenant = "tenant";
         String[] expectedAgents = {"app-step1"};
-        String jdbcUrl = "jdbc:herddb:server:localhost:" + database.getMappedPort(7000);
+        String jdbcUrl = herdDB.getJDBCUrl();
 
         Map<String, String> applicationWriter =
                 Map.of(
                         "configuration.yaml",
                         """
-                        configuration:
-                          resources:
-                            - type: "datasource"
-                              name: "JdbcDatasource"
-                              configuration:
-                                service: "jdbc"
-                                driverClass: "herddb.jdbc.Driver"
-                                url: "%s"
-                                user: "sa"
-                                password: "hdb"
-                                """
+                                configuration:
+                                  resources:
+                                    - type: "datasource"
+                                      name: "JdbcDatasource"
+                                      configuration:
+                                        service: "jdbc"
+                                        driverClass: "herddb.jdbc.Driver"
+                                        url: "%s"
+                                        user: "sa"
+                                        password: "hdb"
+                                        """
                                 .formatted(jdbcUrl),
                         "module.yaml",
                         """
@@ -166,17 +149,17 @@ class RerankAgentRunnerIT extends AbstractKafkaApplicationRunner {
                 Map.of(
                         "configuration.yaml",
                         """
-                        configuration:
-                          resources:
-                            - type: "datasource"
-                              name: "JdbcDatasource"
-                              configuration:
-                                service: "jdbc"
-                                driverClass: "herddb.jdbc.Driver"
-                                url: "%s"
-                                user: "sa"
-                                password: "hdb"
-                                """
+                                configuration:
+                                  resources:
+                                    - type: "datasource"
+                                      name: "JdbcDatasource"
+                                      configuration:
+                                        service: "jdbc"
+                                        driverClass: "herddb.jdbc.Driver"
+                                        url: "%s"
+                                        user: "sa"
+                                        password: "hdb"
+                                        """
                                 .formatted(jdbcUrl),
                         "module.yaml",
                         """

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/S3SourceIT.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/S3SourceIT.java
@@ -39,12 +39,12 @@ import org.testcontainers.utility.DockerImageName;
 @Testcontainers
 class S3SourceIT extends AbstractKafkaApplicationRunner {
 
-    private static final DockerImageName localstackImage =
-            DockerImageName.parse("localstack/localstack:2.2.0");
-
     @Container
     private static final LocalStackContainer localstack =
-            new LocalStackContainer(localstackImage).withServices(S3);
+            new LocalStackContainer(
+                            markAsDisposableImage(
+                                    DockerImageName.parse("localstack/localstack:2.2.0")))
+                    .withServices(S3);
 
     @Test
     public void test() throws Exception {

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/S3SourceIT.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/S3SourceIT.java
@@ -120,7 +120,7 @@ class S3SourceIT extends AbstractKafkaApplicationRunner {
 
                 executeAgentRunners(applicationRuntime);
 
-                waitForMessages(deletedDocumentsConsumer, List.of("mvtest-0.txt"));
+                waitForMessages(deletedDocumentsConsumer, List.of("test-0.txt"));
             }
         }
     }

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/S3SourceIT.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/S3SourceIT.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.kafka;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.testcontainers.containers.localstack.LocalStackContainer.Service.S3;
+
+import io.minio.MakeBucketArgs;
+import io.minio.MinioClient;
+import io.minio.PutObjectArgs;
+import io.minio.RemoveObjectArgs;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@Slf4j
+@Testcontainers
+class S3SourceIT extends AbstractKafkaApplicationRunner {
+
+    private static final DockerImageName localstackImage =
+            DockerImageName.parse("localstack/localstack:2.2.0");
+
+    @Container
+    private static final LocalStackContainer localstack =
+            new LocalStackContainer(localstackImage).withServices(S3);
+
+    @Test
+    public void test() throws Exception {
+
+        final String appId = "app-" + UUID.randomUUID().toString().substring(0, 4);
+
+        String tenant = "tenant";
+
+        String[] expectedAgents = new String[] {appId + "-step1"};
+        String endpoint = localstack.getEndpointOverride(S3).toString();
+        Map<String, String> application =
+                Map.of(
+                        "module.yaml",
+                        """
+                                module: "module-1"
+                                id: "pipeline-1"
+                                topics:
+                                  - name: "${globals.output-topic}"
+                                    creation-mode: create-if-not-exists
+                                  - name: "deleted-documents"
+                                    creation-mode: create-if-not-exists
+                                pipeline:
+                                  - type: "s3-source"
+                                    id: "step1"
+                                    output: "${globals.output-topic}"
+                                    configuration:\s
+                                        bucketName: "test-bucket"
+                                        endpoint: "%s"
+                                        state-storage: s3
+                                        state-storage-s3-bucket: "test-state-bucket"
+                                        state-storage-s3-endpoint: "%s"
+                                        deleted-objects-topic: "deleted-objects"
+                                        delete-objects: false
+                                        idle-time: 1
+                                """
+                                .formatted(endpoint, endpoint));
+
+        MinioClient minioClient = MinioClient.builder().endpoint(endpoint).build();
+
+        minioClient.makeBucket(MakeBucketArgs.builder().bucket("test-bucket").build());
+
+        for (int i = 0; i < 2; i++) {
+            final String s = "content" + i;
+            minioClient.putObject(
+                    PutObjectArgs.builder()
+                            .bucket("test-bucket")
+                            .object("test-" + i + ".txt")
+                            .stream(
+                                    new ByteArrayInputStream(s.getBytes(StandardCharsets.UTF_8)),
+                                    s.length(),
+                                    -1)
+                            .build());
+        }
+
+        try (ApplicationRuntime applicationRuntime =
+                deployApplication(
+                        tenant, appId, application, buildInstanceYaml(), expectedAgents)) {
+
+            try (KafkaConsumer<String, String> deletedDocumentsConsumer =
+                            createConsumer("deleted-objects");
+                    KafkaConsumer<String, String> consumer =
+                            createConsumer(applicationRuntime.getGlobal("output-topic")); ) {
+
+                executeAgentRunners(applicationRuntime);
+
+                waitForMessages(consumer, List.of("content0", "content1"));
+
+                minioClient.removeObject(
+                        RemoveObjectArgs.builder()
+                                .bucket("test-bucket")
+                                .object("test-0.txt")
+                                .build());
+
+                executeAgentRunners(applicationRuntime);
+
+                waitForMessages(deletedDocumentsConsumer, List.of("mvtest-0.txt"));
+            }
+        }
+    }
+}

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/SolrAssetQueryWriteIT.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/SolrAssetQueryWriteIT.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
 
 @Slf4j
 @Testcontainers
@@ -37,7 +38,7 @@ class SolrAssetQueryWriteIT extends AbstractKafkaApplicationRunner {
 
     @Container
     private GenericContainer solrCloudContainer =
-            new GenericContainer("solr:9.3.0")
+            new GenericContainer(markAsDisposableImage(new DockerImageName("solr:9.3.0")))
                     .withExposedPorts(8983)
                     .withCommand("-c"); // enable SolarCloud mode
 

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/WebCrawlerSourceIT.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/WebCrawlerSourceIT.java
@@ -137,10 +137,13 @@ class WebCrawlerSourceIT extends AbstractKafkaApplicationRunner {
                                  </body>
                                 </html>"""));
 
+                String expected = "%s-%s.webcrawler.status.json".formatted(appId, "step1");
                 final Path statusFile =
-                        getBasePersistenceDirectory()
-                                .resolve("step1")
-                                .resolve("%s-%s.webcrawler.status.json".formatted(appId, "step1"));
+                        getBasePersistenceDirectory().resolve("step1").resolve(expected);
+                System.out.println("here.. expected=" + expected);
+                Files.list(getBasePersistenceDirectory()).forEach(System.out::println);
+                Files.list(getBasePersistenceDirectory().resolve("step1"))
+                        .forEach(System.out::println);
                 assertTrue(Files.exists(statusFile));
 
                 stubFor(get("/thirdPage.html").willReturn(notFound()));

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/services/ServiceAgentIT.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/services/ServiceAgentIT.java
@@ -21,10 +21,8 @@ import ai.langstream.mockagents.MockProcessorAgentsCodeProvider;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Slf4j
-@Testcontainers
 class ServiceAgentIT extends AbstractStreamingLessApplicationRunner {
 
     @Test

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/utils/HerdDBExtension.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/utils/HerdDBExtension.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.utils;
+
+import java.util.function.Consumer;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.output.OutputFrame;
+import org.testcontainers.utility.DockerImageName;
+
+@Slf4j
+public class HerdDBExtension implements BeforeAllCallback, AfterAllCallback {
+    public static final DockerImageName DOCKER_IMAGE_NAME =
+            DockerImageName.parse("herddb/herddb:0.28.0");
+    private GenericContainer container;
+
+    @Override
+    public void afterAll(ExtensionContext extensionContext) throws Exception {
+
+        if (container != null) {
+            container.close();
+        }
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext extensionContext) throws Exception {
+        container =
+                new GenericContainer<>(DOCKER_IMAGE_NAME)
+                        .withExposedPorts(7000)
+                        .withLogConsumer(
+                                new Consumer<OutputFrame>() {
+                                    @Override
+                                    public void accept(OutputFrame outputFrame) {
+                                        log.debug("herddb> {}", outputFrame.getUtf8String().trim());
+                                    }
+                                });
+        ;
+        container.start();
+    }
+
+    public String getJDBCUrl() {
+        return "jdbc:herddb:server:localhost:" + container.getMappedPort(7000);
+    }
+}

--- a/langstream-runtime/langstream-runtime-impl/src/test/resources/logback-test.xml
+++ b/langstream-runtime/langstream-runtime-impl/src/test/resources/logback-test.xml
@@ -36,6 +36,6 @@
     <logger name="org.apache.kafka.common.metrics.Metrics" level="OFF"/>
     <logger name="org.apache.kafka.common.utils.AppInfoParser" level="ERROR" />
     <logger name="ai.langstream.api.runner.code" level="WARN" />
-    <logger name="ai.langstream.api.runner.agent" level="WARN" />
+    <logger name="ai.langstream.api.runtime.agent" level="WARN" />
 
 </configuration>

--- a/langstream-runtime/langstream-runtime-impl/src/test/resources/logback-test.xml
+++ b/langstream-runtime/langstream-runtime-impl/src/test/resources/logback-test.xml
@@ -36,6 +36,7 @@
     <logger name="org.apache.kafka.common.metrics.Metrics" level="OFF"/>
     <logger name="org.apache.kafka.common.utils.AppInfoParser" level="ERROR" />
     <logger name="ai.langstream.api.runner.code" level="WARN" />
-    <logger name="ai.langstream.api.runtime.agent" level="WARN" />
+    <logger name="ai.langstream.api.runner.topics" level="WARN" />
+    <logger name="ai.langstream.runtime.agent" level="WARN" />
 
 </configuration>

--- a/langstream-runtime/langstream-runtime-impl/src/test/resources/logback-test.xml
+++ b/langstream-runtime/langstream-runtime-impl/src/test/resources/logback-test.xml
@@ -31,4 +31,11 @@
     <root level="info">
         <appender-ref ref="STDOUT"/>
     </root>
+
+    <logger name="org.apache.kafka.clients" level="WARN"/>
+    <logger name="org.apache.kafka.common.metrics.Metrics" level="OFF"/>
+    <logger name="org.apache.kafka.common.utils.AppInfoParser" level="ERROR" />
+    <logger name="ai.langstream.api.runner.code" level="WARN" />
+    <logger name="ai.langstream.api.runner.agent" level="WARN" />
+
 </configuration>


### PR DESCRIPTION
New options on the s3 source:
- `delete-objects` default true, put false to not delete objects once processed
- `state-storage` (s3, disk) to store the objects and enable updated/deleted events (complete example [here](https://github.com/vectorize-io/langstream/pull/61/files#diff-133fd0f51181b2ea3753373f7312443bc86d8d854e5f79c4df1804c615cacec7R76-R78) 

in the message header we now set `content_diff` to:
- new -> first time processed
- content_changed -> object already processed but content changed
- no_state_storage -> no state storage configured so we don't know if it's the first time


