### PR TITLE
s3/azure sources: add source activity summary notification

### DIFF
--- a/langstream-agents/langstream-agent-azure-blob-storage-source/src/main/java/ai/langstream/agents/azureblobstorage/AzureBlobStorageSource.java
+++ b/langstream-agents/langstream-agent-azure-blob-storage-source/src/main/java/ai/langstream/agents/azureblobstorage/AzureBlobStorageSource.java
@@ -15,8 +15,6 @@
  */
 package ai.langstream.agents.azureblobstorage;
 
-import static ai.langstream.api.util.ConfigurationUtils.getString;
-
 import ai.langstream.ai.agents.commons.storage.provider.StorageProviderObjectReference;
 import ai.langstream.ai.agents.commons.storage.provider.StorageProviderSource;
 import ai.langstream.ai.agents.commons.storage.provider.StorageProviderSourceState;
@@ -29,6 +27,9 @@ import com.azure.storage.common.StorageSharedKeyCredential;
 import java.util.*;
 import lombok.extern.slf4j.Slf4j;
 
+import static ai.langstream.api.util.ConfigurationUtils.*;
+import static ai.langstream.api.util.ConfigurationUtils.getInt;
+
 @Slf4j
 public class AzureBlobStorageSource
         extends StorageProviderSource<AzureBlobStorageSource.AzureBlobStorageSourceState> {
@@ -39,6 +40,14 @@ public class AzureBlobStorageSource
     private int idleTime;
 
     private String deletedObjectsTopic;
+
+    private String sourceActivitySummaryTopic;
+
+    private List<String> sourceActivitySummaryEvents;
+
+    private int sourceActivitySummaryNumEventsThreshold;
+    private int sourceActivitySummaryTimeSecondsThreshold;
+
     private boolean deleteObjects;
     public static final String ALL_FILES = "*";
     public static final String DEFAULT_EXTENSIONS_FILTER = "pdf,docx,html,htm,md,txt";
@@ -113,6 +122,15 @@ public class AzureBlobStorageSource
         idleTime = Integer.parseInt(configuration.getOrDefault("idle-time", 5).toString());
         deletedObjectsTopic = getString("deleted-objects-topic", null, configuration);
         deleteObjects = ConfigurationUtils.getBoolean("delete-objects", true, configuration);
+        sourceActivitySummaryTopic = getString("source-activity-summary-topic", null, configuration);
+        sourceActivitySummaryEvents = getList("source-activity-summary-events", configuration);
+        sourceActivitySummaryNumEventsThreshold = getInt("source-activity-summary-events-threshold", 0, configuration);
+        sourceActivitySummaryTimeSecondsThreshold =
+                getInt("source-activity-summary-time-seconds-threshold", 30, configuration);
+        if (sourceActivitySummaryTimeSecondsThreshold < 0) {
+            throw new IllegalArgumentException(
+                    "source-activity-summary-time-seconds-threshold must be > 0");
+        }
         extensions =
                 Set.of(
                         configuration
@@ -141,6 +159,26 @@ public class AzureBlobStorageSource
     @Override
     public String getDeletedObjectsTopic() {
         return deletedObjectsTopic;
+    }
+
+    @Override
+    public String getSourceActivitySummaryTopic() {
+        return sourceActivitySummaryTopic;
+    }
+
+    @Override
+    public List<String> getSourceActivitySummaryEvents() {
+        return sourceActivitySummaryEvents;
+    }
+
+    @Override
+    public int getSourceActivitySummaryNumEventsThreshold() {
+        return sourceActivitySummaryNumEventsThreshold;
+    }
+
+    @Override
+    public int getSourceActivitySummaryTimeSecondsThreshold() {
+        return sourceActivitySummaryTimeSecondsThreshold;
     }
 
     @Override

--- a/langstream-agents/langstream-agent-azure-blob-storage-source/src/main/java/ai/langstream/agents/azureblobstorage/AzureBlobStorageSource.java
+++ b/langstream-agents/langstream-agent-azure-blob-storage-source/src/main/java/ai/langstream/agents/azureblobstorage/AzureBlobStorageSource.java
@@ -15,6 +15,9 @@
  */
 package ai.langstream.agents.azureblobstorage;
 
+import static ai.langstream.api.util.ConfigurationUtils.*;
+import static ai.langstream.api.util.ConfigurationUtils.getInt;
+
 import ai.langstream.ai.agents.commons.storage.provider.StorageProviderObjectReference;
 import ai.langstream.ai.agents.commons.storage.provider.StorageProviderSource;
 import ai.langstream.ai.agents.commons.storage.provider.StorageProviderSourceState;
@@ -26,9 +29,6 @@ import com.azure.storage.blob.models.BlobItem;
 import com.azure.storage.common.StorageSharedKeyCredential;
 import java.util.*;
 import lombok.extern.slf4j.Slf4j;
-
-import static ai.langstream.api.util.ConfigurationUtils.*;
-import static ai.langstream.api.util.ConfigurationUtils.getInt;
 
 @Slf4j
 public class AzureBlobStorageSource
@@ -122,9 +122,11 @@ public class AzureBlobStorageSource
         idleTime = Integer.parseInt(configuration.getOrDefault("idle-time", 5).toString());
         deletedObjectsTopic = getString("deleted-objects-topic", null, configuration);
         deleteObjects = ConfigurationUtils.getBoolean("delete-objects", true, configuration);
-        sourceActivitySummaryTopic = getString("source-activity-summary-topic", null, configuration);
+        sourceActivitySummaryTopic =
+                getString("source-activity-summary-topic", null, configuration);
         sourceActivitySummaryEvents = getList("source-activity-summary-events", configuration);
-        sourceActivitySummaryNumEventsThreshold = getInt("source-activity-summary-events-threshold", 0, configuration);
+        sourceActivitySummaryNumEventsThreshold =
+                getInt("source-activity-summary-events-threshold", 0, configuration);
         sourceActivitySummaryTimeSecondsThreshold =
                 getInt("source-activity-summary-time-seconds-threshold", 30, configuration);
         if (sourceActivitySummaryTimeSecondsThreshold < 0) {

--- a/langstream-agents/langstream-agent-google-cloud-storage-source/src/main/java/ai/langstream/agents/gcs/GoogleCloudStorageSource.java
+++ b/langstream-agents/langstream-agent-google-cloud-storage-source/src/main/java/ai/langstream/agents/gcs/GoogleCloudStorageSource.java
@@ -46,6 +46,13 @@ public class GoogleCloudStorageSource
 
     private String deletedObjectsTopic;
     private boolean deleteObjects;
+    private String sourceActivitySummaryTopic;
+
+    private List<String> sourceActivitySummaryEvents;
+
+    private int sourceActivitySummaryNumEventsThreshold;
+    private int sourceActivitySummaryTimeSecondsThreshold;
+
     public static final String ALL_FILES = "*";
     public static final String DEFAULT_EXTENSIONS_FILTER = "pdf,docx,html,htm,md,txt";
     private Set<String> extensions = Set.of();
@@ -138,6 +145,26 @@ public class GoogleCloudStorageSource
     @Override
     public String getDeletedObjectsTopic() {
         return deletedObjectsTopic;
+    }
+
+    @Override
+    public String getSourceActivitySummaryTopic() {
+        return sourceActivitySummaryTopic;
+    }
+
+    @Override
+    public List<String> getSourceActivitySummaryEvents() {
+        return sourceActivitySummaryEvents;
+    }
+
+    @Override
+    public int getSourceActivitySummaryNumEventsThreshold() {
+        return sourceActivitySummaryNumEventsThreshold;
+    }
+
+    @Override
+    public int getSourceActivitySummaryTimeSecondsThreshold() {
+        return sourceActivitySummaryTimeSecondsThreshold;
     }
 
     @Override

--- a/langstream-agents/langstream-agent-s3/src/main/java/ai/langstream/agents/s3/S3Source.java
+++ b/langstream-agents/langstream-agent-s3/src/main/java/ai/langstream/agents/s3/S3Source.java
@@ -15,6 +15,8 @@
  */
 package ai.langstream.agents.s3;
 
+import static ai.langstream.api.util.ConfigurationUtils.*;
+
 import ai.langstream.ai.agents.commons.storage.provider.StorageProviderObjectReference;
 import ai.langstream.ai.agents.commons.storage.provider.StorageProviderSource;
 import ai.langstream.ai.agents.commons.storage.provider.StorageProviderSourceState;
@@ -31,8 +33,6 @@ import io.minio.messages.Item;
 import java.util.*;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-
-import static ai.langstream.api.util.ConfigurationUtils.*;
 
 @Slf4j
 public class S3Source extends StorageProviderSource<S3Source.S3SourceState> {
@@ -74,9 +74,11 @@ public class S3Source extends StorageProviderSource<S3Source.S3SourceState> {
         String region = configuration.getOrDefault("region", "").toString();
         idleTime = Integer.parseInt(configuration.getOrDefault("idle-time", 5).toString());
         deletedObjectsTopic = getString("deleted-objects-topic", null, configuration);
-        sourceActivitySummaryTopic = getString("source-activity-summary-topic", null, configuration);
+        sourceActivitySummaryTopic =
+                getString("source-activity-summary-topic", null, configuration);
         sourceActivitySummaryEvents = getList("source-activity-summary-events", configuration);
-        sourceActivitySummaryNumEventsThreshold = getInt("source-activity-summary-events-threshold", 0, configuration);
+        sourceActivitySummaryNumEventsThreshold =
+                getInt("source-activity-summary-events-threshold", 0, configuration);
         sourceActivitySummaryTimeSecondsThreshold =
                 getInt("source-activity-summary-time-seconds-threshold", 30, configuration);
         if (sourceActivitySummaryTimeSecondsThreshold < 0) {

--- a/langstream-agents/langstream-agent-s3/src/main/java/ai/langstream/agents/s3/S3Source.java
+++ b/langstream-agents/langstream-agent-s3/src/main/java/ai/langstream/agents/s3/S3Source.java
@@ -15,8 +15,6 @@
  */
 package ai.langstream.agents.s3;
 
-import static ai.langstream.api.util.ConfigurationUtils.getString;
-
 import ai.langstream.ai.agents.commons.storage.provider.StorageProviderObjectReference;
 import ai.langstream.ai.agents.commons.storage.provider.StorageProviderSource;
 import ai.langstream.ai.agents.commons.storage.provider.StorageProviderSourceState;
@@ -34,6 +32,8 @@ import java.util.*;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 
+import static ai.langstream.api.util.ConfigurationUtils.*;
+
 @Slf4j
 public class S3Source extends StorageProviderSource<S3Source.S3SourceState> {
 
@@ -43,6 +43,12 @@ public class S3Source extends StorageProviderSource<S3Source.S3SourceState> {
     private MinioClient minioClient;
     private int idleTime;
     private String deletedObjectsTopic;
+    private String sourceActivitySummaryTopic;
+
+    private List<String> sourceActivitySummaryEvents;
+
+    private int sourceActivitySummaryNumEventsThreshold;
+    private int sourceActivitySummaryTimeSecondsThreshold;
 
     public static final String ALL_FILES = "*";
     public static final String DEFAULT_EXTENSIONS_FILTER = "pdf,docx,html,htm,md,txt";
@@ -68,6 +74,16 @@ public class S3Source extends StorageProviderSource<S3Source.S3SourceState> {
         String region = configuration.getOrDefault("region", "").toString();
         idleTime = Integer.parseInt(configuration.getOrDefault("idle-time", 5).toString());
         deletedObjectsTopic = getString("deleted-objects-topic", null, configuration);
+        sourceActivitySummaryTopic = getString("source-activity-summary-topic", null, configuration);
+        sourceActivitySummaryEvents = getList("source-activity-summary-events", configuration);
+        sourceActivitySummaryNumEventsThreshold = getInt("source-activity-summary-events-threshold", 0, configuration);
+        sourceActivitySummaryTimeSecondsThreshold =
+                getInt("source-activity-summary-time-seconds-threshold", 30, configuration);
+        if (sourceActivitySummaryTimeSecondsThreshold < 0) {
+            throw new IllegalArgumentException(
+                    "source-activity-summary-time-seconds-threshold must be > 0");
+        }
+
         extensions =
                 Set.of(
                         configuration
@@ -111,6 +127,26 @@ public class S3Source extends StorageProviderSource<S3Source.S3SourceState> {
     @Override
     public String getDeletedObjectsTopic() {
         return deletedObjectsTopic;
+    }
+
+    @Override
+    public String getSourceActivitySummaryTopic() {
+        return sourceActivitySummaryTopic;
+    }
+
+    @Override
+    public List<String> getSourceActivitySummaryEvents() {
+        return sourceActivitySummaryEvents;
+    }
+
+    @Override
+    public int getSourceActivitySummaryNumEventsThreshold() {
+        return sourceActivitySummaryNumEventsThreshold;
+    }
+
+    @Override
+    public int getSourceActivitySummaryTimeSecondsThreshold() {
+        return sourceActivitySummaryTimeSecondsThreshold;
     }
 
     @Override

--- a/langstream-agents/langstream-agents-commons-storage-provider/src/main/java/ai/langstream/ai/agents/commons/storage/provider/StorageProviderSource.java
+++ b/langstream-agents/langstream-agents-commons-storage-provider/src/main/java/ai/langstream/ai/agents/commons/storage/provider/StorageProviderSource.java
@@ -22,6 +22,8 @@ import ai.langstream.api.runner.code.Record;
 import ai.langstream.api.runner.topics.TopicProducer;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -29,11 +31,13 @@ import lombok.extern.slf4j.Slf4j;
 public abstract class StorageProviderSource<T extends StorageProviderSourceState>
         extends AbstractAgentCode implements AgentSource {
 
+    public static final ObjectMapper MAPPER = new ObjectMapper();
     private Map<String, Object> agentConfiguration;
     private final Set<String> objectsToCommit = ConcurrentHashMap.newKeySet();
     @Getter private StateStorage<T> stateStorage;
 
     private TopicProducer deletedObjectsProducer;
+    private TopicProducer sourceActivitySummaryProducer;
 
     public abstract Class<T> getStateClass();
 
@@ -46,6 +50,14 @@ public abstract class StorageProviderSource<T extends StorageProviderSourceState
     public abstract int getIdleTime();
 
     public abstract String getDeletedObjectsTopic();
+
+    public abstract String getSourceActivitySummaryTopic();
+
+    public abstract List<String> getSourceActivitySummaryEvents();
+
+    public abstract int getSourceActivitySummaryNumEventsThreshold();
+
+    public abstract int getSourceActivitySummaryTimeSecondsThreshold();
 
     public abstract List<StorageProviderObjectReference> listObjects() throws Exception;
 
@@ -80,43 +92,28 @@ public abstract class StorageProviderSource<T extends StorageProviderSourceState
                                     agentContext.getGlobalAgentId(), deletedObjectsTopic, Map.of());
             deletedObjectsProducer.start();
         }
+        String sourceActivitySummaryTopic = getSourceActivitySummaryTopic();
+        if (sourceActivitySummaryTopic != null) {
+            sourceActivitySummaryProducer =
+                    agentContext
+                            .getTopicConnectionProvider()
+                            .createProducer(
+                                    agentContext.getGlobalAgentId(),
+                                    sourceActivitySummaryTopic,
+                                    Map.of());
+            sourceActivitySummaryProducer.start();
+        }
     }
 
     @Override
     public List<Record> read() throws Exception {
         final String bucketName = getBucketName();
+        sendSourceActivitySummaryIfNeeded();
         final List<StorageProviderObjectReference> objects = listObjects();
         final StorageProviderObjectReference object = getNextObject(objects);
         if (object == null) {
             log.info("No objects to emit");
-            if (stateStorage != null) {
-                log.info("Checking for deleted objects");
-                T state = getOrInitState();
-
-                final Set<String> allNames = new HashSet<>();
-                for (StorageProviderObjectReference o : objects) {
-                    allNames.add(formatAllTimeObjectsKey(o.name()));
-                }
-                Set<String> toRemove = new HashSet<>();
-                for (String allTimeKey : state.getAllTimeObjects().keySet()) {
-                    if (!allNames.contains(allTimeKey)) {
-                        log.info("Object {} was deleted", allTimeKey);
-                        toRemove.add(allTimeKey);
-                    }
-                }
-                for (String allTimeKey : toRemove) {
-                    state.getAllTimeObjects().remove(allTimeKey);
-                    if (deletedObjectsProducer != null) {
-                        SimpleRecord simpleRecord =
-                                SimpleRecord.of(
-                                        bucketName, allTimeKey.replace(bucketName + "@", ""));
-                        deletedObjectsProducer.write(simpleRecord).get();
-                    }
-                }
-                if (!toRemove.isEmpty()) {
-                    stateStorage.store(state);
-                }
-            }
+            checkDeletedObjects(objects, bucketName);
             final int idleTime = getIdleTime();
             log.info("sleeping for {} seconds", idleTime);
             Thread.sleep(idleTime * 1000L);
@@ -141,7 +138,20 @@ public abstract class StorageProviderSource<T extends StorageProviderSourceState
                 T state = getOrInitState();
                 final String key = formatAllTimeObjectsKey(name);
                 String oldValue = state.getAllTimeObjects().put(key, object.contentDigest());
-                contentDiff = oldValue == null ? "new" : "content_changed";
+                StorageProviderSourceState.ObjectDetail e = new StorageProviderSourceState.ObjectDetail(
+                        bucketName, object.name(), System.currentTimeMillis()
+                );
+                if (oldValue == null) {
+                    contentDiff = "new";
+                    state.getCurrentSourceActivitySummary()
+                            .newObjects()
+                            .add(e);
+                } else {
+                    contentDiff = "content_changed";
+                    state.getCurrentSourceActivitySummary()
+                            .updatedObjects()
+                            .add(e);
+                }
                 stateStorage.store(state);
             } else {
                 contentDiff = "no_state_storage";
@@ -162,6 +172,104 @@ public abstract class StorageProviderSource<T extends StorageProviderSourceState
         } catch (Exception e) {
             log.error("Error reading object {}", name, e);
             throw e;
+        }
+    }
+
+    private void sendSourceActivitySummaryIfNeeded() throws Exception {
+        if (stateStorage == null) {
+            return;
+        }
+        T state = getOrInitState();
+        StorageProviderSourceState.SourceActivitySummary currentSourceActivitySummary = state.getCurrentSourceActivitySummary();
+        if (currentSourceActivitySummary == null) {
+            return;
+        }
+        List<String> sourceActivitySummaryEvents = getSourceActivitySummaryEvents();
+        int countEvents = 0;
+        long firstEventTs = Long.MAX_VALUE;
+        if (sourceActivitySummaryEvents.contains("new")) {
+            countEvents += currentSourceActivitySummary.newObjects().size();
+            firstEventTs = currentSourceActivitySummary.newObjects().stream().mapToLong(StorageProviderSourceState.ObjectDetail::detectedAt).min().orElse(Long.MAX_VALUE);
+        }
+        if (sourceActivitySummaryEvents.contains("updated")) {
+            countEvents += currentSourceActivitySummary.updatedObjects().size();
+            firstEventTs = Math.min(firstEventTs, currentSourceActivitySummary.updatedObjects().stream().mapToLong(StorageProviderSourceState.ObjectDetail::detectedAt).min().orElse(Long.MAX_VALUE));
+        }
+        if (sourceActivitySummaryEvents.contains("deleted")) {
+            countEvents += currentSourceActivitySummary.deletedObjects().size();
+            firstEventTs = Math.min(firstEventTs, currentSourceActivitySummary.deletedObjects().stream().mapToLong(StorageProviderSourceState.ObjectDetail::detectedAt).min().orElse(Long.MAX_VALUE));
+        }
+        if (countEvents == 0) {
+            return;
+        }
+        long now = System.currentTimeMillis();
+
+        boolean emit = false;
+        int sourceActivitySummaryTimeSecondsThreshold = getSourceActivitySummaryTimeSecondsThreshold();
+        boolean isTimeForStartSummaryOver = now >= firstEventTs + sourceActivitySummaryTimeSecondsThreshold * 1000L;
+        if (!isTimeForStartSummaryOver) {
+            // no time yet, but we have enough events to send
+            int sourceActivitySummaryNumThreshold = getSourceActivitySummaryNumEventsThreshold();
+            if (sourceActivitySummaryNumThreshold > 0 && countEvents >= sourceActivitySummaryNumThreshold) {
+                log.info("Emitting source activity summary, events {} with threshold of {}", countEvents, sourceActivitySummaryNumThreshold);
+                emit = true;
+            }
+        } else {
+            log.info("Emitting source activity summary due to time threshold (first event was {} seconds ago)", (now - firstEventTs) / 1000);
+            // time is over, we should send summary
+            emit = true;
+        }
+        if (emit) {
+            if (sourceActivitySummaryProducer != null) {
+                log.info("Emitting source activity summary to topic {}", getSourceActivitySummaryTopic());
+                String value = MAPPER.writeValueAsString(currentSourceActivitySummary);
+                SimpleRecord simpleRecord =
+                        SimpleRecord.of(
+                                getBucketName(), value);
+                sourceActivitySummaryProducer.write(simpleRecord).get();
+            } else {
+                log.warn("No source activity summary producer configured, event will be lost");
+            }
+            state.setCurrentSourceActivitySummary(
+                    new StorageProviderSourceState.SourceActivitySummary(new ArrayList<>(), new ArrayList<>(), new ArrayList<>()));
+            stateStorage.store(state);
+        }
+    }
+
+    private void checkDeletedObjects(List<StorageProviderObjectReference> objects, String bucketName) throws Exception {
+        if (stateStorage != null) {
+            log.info("Checking for deleted objects");
+            T state = getOrInitState();
+
+            final Set<String> allNames = new HashSet<>();
+            for (StorageProviderObjectReference o : objects) {
+                allNames.add(formatAllTimeObjectsKey(o.name()));
+            }
+            Set<String> toRemove = new HashSet<>();
+            for (String allTimeKey : state.getAllTimeObjects().keySet()) {
+                if (!allNames.contains(allTimeKey)) {
+                    log.info("Object {} was deleted", allTimeKey);
+                    toRemove.add(allTimeKey);
+                }
+            }
+            for (String allTimeKey : toRemove) {
+                state.getAllTimeObjects().remove(allTimeKey);
+                String objectName = allTimeKey.replace(bucketName + "@", "");
+                state.getCurrentSourceActivitySummary()
+                        .deletedObjects()
+                        .add(
+                                new StorageProviderSourceState.ObjectDetail(
+                                        bucketName, objectName, System.currentTimeMillis()));
+                if (deletedObjectsProducer != null) {
+                    SimpleRecord simpleRecord =
+                            SimpleRecord.of(
+                                    bucketName, objectName);
+                    deletedObjectsProducer.write(simpleRecord).get();
+                }
+            }
+            if (!toRemove.isEmpty()) {
+                stateStorage.store(state);
+            }
         }
     }
 
@@ -220,6 +328,17 @@ public abstract class StorageProviderSource<T extends StorageProviderSourceState
             log.info("Removing object {}", objectName);
             deleteObject(objectName);
             objectsToCommit.remove(objectName);
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        super.close();
+        if (deletedObjectsProducer != null) {
+            deletedObjectsProducer.close();
+        }
+        if (sourceActivitySummaryProducer != null) {
+            sourceActivitySummaryProducer.close();
         }
     }
 }

--- a/langstream-agents/langstream-agents-commons-storage-provider/src/main/java/ai/langstream/ai/agents/commons/storage/provider/StorageProviderSourceState.java
+++ b/langstream-agents/langstream-agents-commons-storage-provider/src/main/java/ai/langstream/ai/agents/commons/storage/provider/StorageProviderSourceState.java
@@ -19,7 +19,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -27,19 +26,14 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class StorageProviderSourceState {
 
-    public record ObjectDetail(String bucket, String object, long detectedAt) {
-    }
+    public record ObjectDetail(String bucket, String object, long detectedAt) {}
 
     public record SourceActivitySummary(
             List<ObjectDetail> newObjects,
             List<ObjectDetail> updatedObjects,
-            List<ObjectDetail> deletedObjects
-
-    ) {
-    }
+            List<ObjectDetail> deletedObjects) {}
 
     private Map<String, String> allTimeObjects = new HashMap<>();
-    private SourceActivitySummary currentSourceActivitySummary = new SourceActivitySummary(new ArrayList<>(),
-            new ArrayList<>(),
-            new ArrayList<>());
+    private SourceActivitySummary currentSourceActivitySummary =
+            new SourceActivitySummary(new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
 }

--- a/langstream-agents/langstream-agents-commons-storage-provider/src/main/java/ai/langstream/ai/agents/commons/storage/provider/StorageProviderSourceState.java
+++ b/langstream-agents/langstream-agents-commons-storage-provider/src/main/java/ai/langstream/ai/agents/commons/storage/provider/StorageProviderSourceState.java
@@ -15,8 +15,11 @@
  */
 package ai.langstream.ai.agents.commons.storage.provider;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -24,5 +27,19 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class StorageProviderSourceState {
 
+    public record ObjectDetail(String bucket, String object, long detectedAt) {
+    }
+
+    public record SourceActivitySummary(
+            List<ObjectDetail> newObjects,
+            List<ObjectDetail> updatedObjects,
+            List<ObjectDetail> deletedObjects
+
+    ) {
+    }
+
     private Map<String, String> allTimeObjects = new HashMap<>();
+    private SourceActivitySummary currentSourceActivitySummary = new SourceActivitySummary(new ArrayList<>(),
+            new ArrayList<>(),
+            new ArrayList<>());
 }

--- a/langstream-api/src/main/java/ai/langstream/api/util/ConfigurationUtils.java
+++ b/langstream-api/src/main/java/ai/langstream/api/util/ConfigurationUtils.java
@@ -47,7 +47,6 @@ public class ConfigurationUtils {
         return DEVELOPMENT_MODE;
     }
 
-
     /**
      * Decode a configuration map into a list of strings. Nulls are removed
      *

--- a/langstream-api/src/main/java/ai/langstream/api/util/ConfigurationUtils.java
+++ b/langstream-api/src/main/java/ai/langstream/api/util/ConfigurationUtils.java
@@ -47,6 +47,7 @@ public class ConfigurationUtils {
         return DEVELOPMENT_MODE;
     }
 
+
     /**
      * Decode a configuration map into a list of strings. Nulls are removed
      *

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/StorageProviderSourceAgentProvider.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/StorageProviderSourceAgentProvider.java
@@ -142,13 +142,46 @@ public class StorageProviderSourceAgentProvider extends AbstractComposableAgentP
         private boolean deleteObjects;
 
         @ConfigProperty(
-                defaultValue = "true",
                 description =
                         """
                        Write a message to this topic when an object has been detected as deleted for any reason.
                                 """)
         @JsonProperty("deleted-objects-topic")
         private String deletedObjectsTopic;
+
+        @ConfigProperty(
+                description =
+                        """
+                       Write a message to this topic periodically with a summary of the activity in the source. 
+                                """)
+        @JsonProperty("source-activity-summary-topic")
+        private String sourceActivitySummaryTopic;
+
+        @ConfigProperty(
+                description =
+                        """
+                       List of events (comma separated) to include in the source activity summary. ('new', 'updated', 'deleted')
+                       To include all: 'new,updated,deleted'.
+                       Use this property to disable the source activity summary (by leaving default to empty).
+                                """)
+        @JsonProperty("source-activity-summary-events")
+        private String sourceActivitySummaryEvents;
+        @ConfigProperty(
+                defaultValue = "60",
+                description =
+                        """
+                        Trigger source activity summary emission when this number of events have been detected, even if the time threshold has not been reached yet.
+                                """)
+        @JsonProperty("source-activity-summary-events-threshold")
+        private int sourceActivitySummaryNumEventsThreshold;
+
+        @ConfigProperty(
+                description =
+                        """
+                        Trigger source activity summary emission every time this time threshold has been reached.
+                                """)
+        @JsonProperty("source-activity-summary-time-seconds-threshold")
+        private int sourceActivitySummaryTimeSecondsThreshold;
     }
 
     @AgentConfig(
@@ -240,13 +273,47 @@ public class StorageProviderSourceAgentProvider extends AbstractComposableAgentP
         private boolean deleteObjects;
 
         @ConfigProperty(
-                defaultValue = "true",
                 description =
                         """
                        Write a message to this topic when an object has been detected as deleted for any reason.
                                 """)
         @JsonProperty("deleted-objects-topic")
         private String deletedObjectsTopic;
+
+
+        @ConfigProperty(
+                description =
+                        """
+                       Write a message to this topic periodically with a summary of the activity in the source. 
+                                """)
+        @JsonProperty("source-activity-summary-topic")
+        private String sourceActivitySummaryTopic;
+
+        @ConfigProperty(
+                description =
+                        """
+                       List of events (comma separated) to include in the source activity summary. ('new', 'updated', 'deleted')
+                       To include all: 'new,updated,deleted'.
+                       Use this property to disable the source activity summary (by leaving default to empty).
+                                """)
+        @JsonProperty("source-activity-summary-events")
+        private String sourceActivitySummaryEvents;
+        @ConfigProperty(
+                defaultValue = "60",
+                description =
+                        """
+                        Trigger source activity summary emission when this number of events have been detected, even if the time threshold has not been reached yet.
+                                """)
+        @JsonProperty("source-activity-summary-events-threshold")
+        private int sourceActivitySummaryNumEventsThreshold;
+
+        @ConfigProperty(
+                description =
+                        """
+                        Trigger source activity summary emission every time this time threshold has been reached.
+                                """)
+        @JsonProperty("source-activity-summary-time-seconds-threshold")
+        private int sourceActivitySummaryTimeSecondsThreshold;
     }
 
     @AgentConfig(

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/StorageProviderSourceAgentProvider.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/StorageProviderSourceAgentProvider.java
@@ -152,7 +152,7 @@ public class StorageProviderSourceAgentProvider extends AbstractComposableAgentP
         @ConfigProperty(
                 description =
                         """
-                       Write a message to this topic periodically with a summary of the activity in the source. 
+                       Write a message to this topic periodically with a summary of the activity in the source.
                                 """)
         @JsonProperty("source-activity-summary-topic")
         private String sourceActivitySummaryTopic;
@@ -166,6 +166,7 @@ public class StorageProviderSourceAgentProvider extends AbstractComposableAgentP
                                 """)
         @JsonProperty("source-activity-summary-events")
         private String sourceActivitySummaryEvents;
+
         @ConfigProperty(
                 defaultValue = "60",
                 description =
@@ -280,11 +281,10 @@ public class StorageProviderSourceAgentProvider extends AbstractComposableAgentP
         @JsonProperty("deleted-objects-topic")
         private String deletedObjectsTopic;
 
-
         @ConfigProperty(
                 description =
                         """
-                       Write a message to this topic periodically with a summary of the activity in the source. 
+                       Write a message to this topic periodically with a summary of the activity in the source.
                                 """)
         @JsonProperty("source-activity-summary-topic")
         private String sourceActivitySummaryTopic;
@@ -298,6 +298,7 @@ public class StorageProviderSourceAgentProvider extends AbstractComposableAgentP
                                 """)
         @JsonProperty("source-activity-summary-events")
         private String sourceActivitySummaryEvents;
+
         @ConfigProperty(
                 defaultValue = "60",
                 description =

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/StorageProviderSourceAgentProvider.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/StorageProviderSourceAgentProvider.java
@@ -380,5 +380,41 @@ public class StorageProviderSourceAgentProvider extends AbstractComposableAgentP
                                 """)
         @JsonProperty("deleted-objects-topic")
         private String deletedObjectsTopic;
+
+
+        @ConfigProperty(
+                description =
+                        """
+                       Write a message to this topic periodically with a summary of the activity in the source.
+                                """)
+        @JsonProperty("source-activity-summary-topic")
+        private String sourceActivitySummaryTopic;
+
+        @ConfigProperty(
+                description =
+                        """
+                       List of events (comma separated) to include in the source activity summary. ('new', 'updated', 'deleted')
+                       To include all: 'new,updated,deleted'.
+                       Use this property to disable the source activity summary (by leaving default to empty).
+                                """)
+        @JsonProperty("source-activity-summary-events")
+        private String sourceActivitySummaryEvents;
+
+        @ConfigProperty(
+                defaultValue = "60",
+                description =
+                        """
+                        Trigger source activity summary emission when this number of events have been detected, even if the time threshold has not been reached yet.
+                                """)
+        @JsonProperty("source-activity-summary-events-threshold")
+        private int sourceActivitySummaryNumEventsThreshold;
+
+        @ConfigProperty(
+                description =
+                        """
+                        Trigger source activity summary emission every time this time threshold has been reached.
+                                """)
+        @JsonProperty("source-activity-summary-time-seconds-threshold")
+        private int sourceActivitySummaryTimeSecondsThreshold;
     }
 }

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/StorageProviderSourceAgentProvider.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/StorageProviderSourceAgentProvider.java
@@ -381,7 +381,6 @@ public class StorageProviderSourceAgentProvider extends AbstractComposableAgentP
         @JsonProperty("deleted-objects-topic")
         private String deletedObjectsTopic;
 
-
         @ConfigProperty(
                 description =
                         """

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/test/java/ai/langstream/runtime/impl/k8s/agents/S3SourceAgentProviderTest.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/test/java/ai/langstream/runtime/impl/k8s/agents/S3SourceAgentProviderTest.java
@@ -121,8 +121,7 @@ class S3SourceAgentProviderTest {
                               "deleted-objects-topic" : {
                                 "description" : "Write a message to this topic when an object has been detected as deleted for any reason.",
                                 "required" : false,
-                                "type" : "string",
-                                "defaultValue" : "true"
+                                "type" : "string"
                               },
                               "endpoint" : {
                                 "description" : "Endpoint to connect to. Usually it's https://<storage-account>.blob.core.windows.net.",
@@ -143,6 +142,27 @@ class S3SourceAgentProviderTest {
                               },
                               "sas-token" : {
                                 "description" : "Azure SAS token. If not provided, storage account name and key must be provided.",
+                                "required" : false,
+                                "type" : "string"
+                              },
+                              "source-activity-summary-events" : {
+                                "description" : "List of events (comma separated) to include in the source activity summary. ('new', 'updated', 'deleted')\\nTo include all: 'new,updated,deleted'.\\nUse this property to disable the source activity summary (by leaving default to empty).",
+                                "required" : false,
+                                "type" : "string"
+                              },
+                              "source-activity-summary-events-threshold" : {
+                                "description" : "Trigger source activity summary emission when this number of events have been detected, even if the time threshold has not been reached yet.",
+                                "required" : false,
+                                "type" : "integer",
+                                "defaultValue" : "60"
+                              },
+                              "source-activity-summary-time-seconds-threshold" : {
+                                "description" : "Trigger source activity summary emission every time this time threshold has been reached.",
+                                "required" : false,
+                                "type" : "integer"
+                              },
+                              "source-activity-summary-topic" : {
+                                "description" : "Write a message to this topic periodically with a summary of the activity in the source.",
                                 "required" : false,
                                 "type" : "string"
                               },
@@ -203,6 +223,108 @@ class S3SourceAgentProviderTest {
                               }
                             }
                           },
+                          "google-cloud-storage-source" : {
+                            "name" : "Google Cloud Storage Source",
+                            "description" : "Reads data from Google Cloud Storage. The only authentication supported is via service account JSON.",
+                            "properties" : {
+                              "bucket-name" : {
+                                "description" : "The name of the bucket.",
+                                "required" : false,
+                                "type" : "string",
+                                "defaultValue" : "langstream-gcs-source"
+                              },
+                              "delete-objects" : {
+                                "description" : "Whether to delete objects after processing.",
+                                "required" : false,
+                                "type" : "boolean",
+                                "defaultValue" : "true"
+                              },
+                              "deleted-objects-topic" : {
+                                "description" : "Write a message to this topic when an object has been detected as deleted for any reason.",
+                                "required" : false,
+                                "type" : "string",
+                                "defaultValue" : "true"
+                              },
+                              "file-extensions" : {
+                                "description" : "Comma separated list of file extensions to filter by.",
+                                "required" : false,
+                                "type" : "string",
+                                "defaultValue" : "pdf,docx,html,htm,md,txt"
+                              },
+                              "idle-time" : {
+                                "description" : "Time in seconds to sleep after polling for new files.",
+                                "required" : false,
+                                "type" : "integer",
+                                "defaultValue" : "5"
+                              },
+                              "service-account-json" : {
+                                "description" : "Textual Service Account JSON to authenticate with.",
+                                "required" : true,
+                                "type" : "string"
+                              },
+                              "source-activity-summary-events" : {
+                                "description" : "List of events (comma separated) to include in the source activity summary. ('new', 'updated', 'deleted')\\nTo include all: 'new,updated,deleted'.\\nUse this property to disable the source activity summary (by leaving default to empty).",
+                                "required" : false,
+                                "type" : "string"
+                              },
+                              "source-activity-summary-events-threshold" : {
+                                "description" : "Trigger source activity summary emission when this number of events have been detected, even if the time threshold has not been reached yet.",
+                                "required" : false,
+                                "type" : "integer",
+                                "defaultValue" : "60"
+                              },
+                              "source-activity-summary-time-seconds-threshold" : {
+                                "description" : "Trigger source activity summary emission every time this time threshold has been reached.",
+                                "required" : false,
+                                "type" : "integer"
+                              },
+                              "source-activity-summary-topic" : {
+                                "description" : "Write a message to this topic periodically with a summary of the activity in the source.",
+                                "required" : false,
+                                "type" : "string"
+                              },
+                              "state-storage" : {
+                                "description" : "State storage type (s3, disk).",
+                                "required" : false,
+                                "type" : "string"
+                              },
+                              "state-storage-file-prefix" : {
+                                "description" : "Prepend a prefix to the state storage file. (valid for all types)",
+                                "required" : false,
+                                "type" : "string"
+                              },
+                              "state-storage-file-prepend-tenant" : {
+                                "description" : "Prepend tenant to the state storage file. (valid for all types)",
+                                "required" : false,
+                                "type" : "string"
+                              },
+                              "state-storage-s3-access-key" : {
+                                "description" : "State storage S3 access key.",
+                                "required" : false,
+                                "type" : "string"
+                              },
+                              "state-storage-s3-bucket" : {
+                                "description" : "State storage S3 bucket.",
+                                "required" : false,
+                                "type" : "string"
+                              },
+                              "state-storage-s3-endpoint" : {
+                                "description" : "State storage S3 endpoint.",
+                                "required" : false,
+                                "type" : "string"
+                              },
+                              "state-storage-s3-region" : {
+                                "description" : "State storage S3 region.",
+                                "required" : false,
+                                "type" : "string"
+                              },
+                              "state-storage-s3-secret-key" : {
+                                "description" : "State storage S3 secret key.",
+                                "required" : false,
+                                "type" : "string"
+                              }
+                            }
+                          },
                           "s3-source" : {
                             "name" : "S3 Source",
                             "description" : "Reads data from S3 bucket",
@@ -228,8 +350,7 @@ class S3SourceAgentProviderTest {
                               "deleted-objects-topic" : {
                                 "description" : "Write a message to this topic when an object has been detected as deleted for any reason.",
                                 "required" : false,
-                                "type" : "string",
-                                "defaultValue" : "true"
+                                "type" : "string"
                               },
                               "endpoint" : {
                                 "description" : "The endpoint of the S3 server.",
@@ -259,6 +380,27 @@ class S3SourceAgentProviderTest {
                                 "required" : false,
                                 "type" : "string",
                                 "defaultValue" : "minioadmin"
+                              },
+                              "source-activity-summary-events" : {
+                                "description" : "List of events (comma separated) to include in the source activity summary. ('new', 'updated', 'deleted')\\nTo include all: 'new,updated,deleted'.\\nUse this property to disable the source activity summary (by leaving default to empty).",
+                                "required" : false,
+                                "type" : "string"
+                              },
+                              "source-activity-summary-events-threshold" : {
+                                "description" : "Trigger source activity summary emission when this number of events have been detected, even if the time threshold has not been reached yet.",
+                                "required" : false,
+                                "type" : "integer",
+                                "defaultValue" : "60"
+                              },
+                              "source-activity-summary-time-seconds-threshold" : {
+                                "description" : "Trigger source activity summary emission every time this time threshold has been reached.",
+                                "required" : false,
+                                "type" : "integer"
+                              },
+                              "source-activity-summary-topic" : {
+                                "description" : "Write a message to this topic periodically with a summary of the activity in the source.",
+                                "required" : false,
+                                "type" : "string"
                               },
                               "state-storage" : {
                                 "description" : "State storage type (s3, disk).",

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/S3SourceIT.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/S3SourceIT.java
@@ -15,17 +15,22 @@
  */
 package ai.langstream.kafka;
 
+import static org.junit.jupiter.api.Assertions.*;
 import static org.testcontainers.containers.localstack.LocalStackContainer.Service.S3;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.minio.MakeBucketArgs;
 import io.minio.MinioClient;
 import io.minio.PutObjectArgs;
 import io.minio.RemoveObjectArgs;
+
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+
+import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.junit.jupiter.api.Test;
@@ -50,7 +55,7 @@ class S3SourceIT extends AbstractKafkaApplicationRunner {
 
         String tenant = "tenant";
 
-        String[] expectedAgents = new String[] {appId + "-step1"};
+        String[] expectedAgents = new String[]{appId + "-step1"};
         String endpoint = localstack.getEndpointOverride(S3).toString();
         Map<String, String> application =
                 Map.of(
@@ -97,13 +102,13 @@ class S3SourceIT extends AbstractKafkaApplicationRunner {
         }
 
         try (ApplicationRuntime applicationRuntime =
-                deployApplication(
-                        tenant, appId, application, buildInstanceYaml(), expectedAgents)) {
+                     deployApplication(
+                             tenant, appId, application, buildInstanceYaml(), expectedAgents)) {
 
             try (KafkaConsumer<String, String> deletedDocumentsConsumer =
-                            createConsumer("deleted-objects");
-                    KafkaConsumer<String, String> consumer =
-                            createConsumer(applicationRuntime.getGlobal("output-topic")); ) {
+                         createConsumer("deleted-objects");
+                 KafkaConsumer<String, String> consumer =
+                         createConsumer(applicationRuntime.getGlobal("output-topic"));) {
 
                 executeAgentRunners(applicationRuntime);
 
@@ -118,6 +123,141 @@ class S3SourceIT extends AbstractKafkaApplicationRunner {
                 executeAgentRunners(applicationRuntime);
 
                 waitForMessages(deletedDocumentsConsumer, List.of("test-0.txt"));
+            }
+        }
+    }
+
+    @Test
+    public void testSourceActivitySummary() throws Exception {
+
+        final String appId = "app-" + UUID.randomUUID().toString().substring(0, 4);
+
+        String tenant = "tenant";
+
+        String[] expectedAgents = new String[]{appId + "-step1"};
+        String endpoint = localstack.getEndpointOverride(S3).toString();
+        Map<String, String> application =
+                Map.of(
+                        "module.yaml",
+                        """
+                                module: "module-1"
+                                id: "pipeline-1"
+                                topics:
+                                  - name: "${globals.output-topic}"
+                                    creation-mode: create-if-not-exists
+                                  - name: "deleted-documents"
+                                    creation-mode: create-if-not-exists
+                                pipeline:
+                                  - type: "s3-source"
+                                    id: "step1"
+                                    output: "${globals.output-topic}"
+                                    configuration:\s
+                                        bucketName: "test-bucket"
+                                        endpoint: "%s"
+                                        state-storage: s3
+                                        state-storage-s3-bucket: "test-state-bucket"
+                                        state-storage-s3-endpoint: "%s"
+                                        deleted-objects-topic: "deleted-objects"
+                                        delete-objects: false
+                                        source-activity-summary-topic: "s3-bucket-activity"
+                                        source-activity-summary-events: "new,updated,deleted"
+                                        source-activity-summary-events-threshold: 2
+                                        source-activity-summary-time-seconds-threshold: 5
+                                        idle-time: 1
+                                """
+                                .formatted(endpoint, endpoint));
+
+        MinioClient minioClient = MinioClient.builder().endpoint(endpoint).build();
+
+        minioClient.makeBucket(MakeBucketArgs.builder().bucket("test-bucket").build());
+
+        for (int i = 0; i < 2; i++) {
+            final String s = "content" + i;
+            minioClient.putObject(
+                    PutObjectArgs.builder()
+                            .bucket("test-bucket")
+                            .object("test-" + i + ".txt")
+                            .stream(
+                                    new ByteArrayInputStream(s.getBytes(StandardCharsets.UTF_8)),
+                                    s.length(),
+                                    -1)
+                            .build());
+        }
+
+        try (ApplicationRuntime applicationRuntime =
+                     deployApplication(
+                             tenant, appId, application, buildInstanceYaml(), expectedAgents)) {
+
+            try (KafkaConsumer<String, String> deletedDocumentsConsumer =
+                         createConsumer("deleted-objects");
+                 KafkaConsumer<String, String> activitiesConsumer =
+                         createConsumer("s3-bucket-activity");
+                 KafkaConsumer<String, String> consumer =
+                         createConsumer(applicationRuntime.getGlobal("output-topic"));) {
+
+                executeAgentRunners(applicationRuntime);
+
+                waitForMessages(consumer, List.of("content0", "content1"));
+
+                minioClient.putObject(
+                        PutObjectArgs.builder()
+                                .bucket("test-bucket")
+                                .object("test-0.txt")
+                                .stream(
+                                        new ByteArrayInputStream("another".getBytes(StandardCharsets.UTF_8)),
+                                        "another".length(),
+                                        -1)
+                                .build());
+
+                minioClient.removeObject(
+                        RemoveObjectArgs.builder()
+                                .bucket("test-bucket")
+                                .object("test-1.txt")
+                                .build());
+
+                executeAgentRunners(applicationRuntime);
+
+                waitForMessages(deletedDocumentsConsumer, List.of("test-1.txt"));
+
+
+                waitForMessages(activitiesConsumer, List.of(new java.util.function.Consumer<Object>() {
+                    @Override
+                    @SneakyThrows
+                    public void accept(Object o) {
+                        Map map = new ObjectMapper().readValue((String) o, Map.class);
+
+                        List<Map<String, Object>> newObjects = (List<Map<String, Object>>) map.get("newObjects");
+                        List<Map<String, Object>> updatedObjects = (List<Map<String, Object>>) map.get("updatedObjects");
+                        List<Map<String, Object>> deletedObjects = (List<Map<String, Object>>) map.get("deletedObjects");
+                        assertTrue(updatedObjects.isEmpty());
+                        assertTrue(deletedObjects.isEmpty());
+                        assertEquals(2, newObjects.size());
+                        assertEquals("test-bucket", newObjects.get(0).get("bucket"));
+                        assertEquals("test-0.txt", newObjects.get(0).get("object"));
+                        assertNotNull(newObjects.get(0).get("detectedAt"));
+                        assertEquals("test-bucket", newObjects.get(1).get("bucket"));
+                        assertEquals("test-1.txt", newObjects.get(1).get("object"));
+                        assertNotNull(newObjects.get(1).get("detectedAt"));
+                    }
+                }, new java.util.function.Consumer<Object>() {
+                    @Override
+                    @SneakyThrows
+                    public void accept(Object o) {
+                        Map map = new ObjectMapper().readValue((String) o, Map.class);
+                        List<Map<String, Object>> newObjects = (List<Map<String, Object>>) map.get("newObjects");
+                        List<Map<String, Object>> updatedObjects = (List<Map<String, Object>>) map.get("updatedObjects");
+                        List<Map<String, Object>> deletedObjects = (List<Map<String, Object>>) map.get("deletedObjects");
+                        assertTrue(newObjects.isEmpty());
+                        assertEquals(1, updatedObjects.size());
+                        assertEquals(1, deletedObjects.size());
+                        assertEquals("test-bucket", updatedObjects.get(0).get("bucket"));
+                        assertEquals("test-0.txt", updatedObjects.get(0).get("object"));
+                        assertNotNull(updatedObjects.get(0).get("detectedAt"));
+                        assertEquals("test-bucket", deletedObjects.get(0).get("bucket"));
+                        assertEquals("test-1.txt", deletedObjects.get(0).get("object"));
+                        assertNotNull(deletedObjects.get(0).get("detectedAt"));
+                    }
+                }));
             }
         }
     }

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/S3SourceIT.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/S3SourceIT.java
@@ -160,7 +160,7 @@ class S3SourceIT extends AbstractKafkaApplicationRunner {
                                         source-activity-summary-topic: "s3-bucket-activity"
                                         source-activity-summary-events: "new,updated,deleted"
                                         source-activity-summary-events-threshold: 2
-                                        source-activity-summary-time-seconds-threshold: 5
+                                        source-activity-summary-time-seconds-threshold: 500
                                         idle-time: 1
                                 """
                                 .formatted(endpoint, endpoint));

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/S3SourceIT.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/S3SourceIT.java
@@ -155,7 +155,6 @@ class S3SourceIT extends AbstractKafkaApplicationRunner {
                                         state-storage: s3
                                         state-storage-s3-bucket: "test-state-bucket"
                                         state-storage-s3-endpoint: "%s"
-                                        deleted-objects-topic: "deleted-objects"
                                         delete-objects: false
                                         source-activity-summary-topic: "s3-bucket-activity"
                                         source-activity-summary-events: "new,updated,deleted"
@@ -186,9 +185,7 @@ class S3SourceIT extends AbstractKafkaApplicationRunner {
                 deployApplication(
                         tenant, appId, application, buildInstanceYaml(), expectedAgents)) {
 
-            try (KafkaConsumer<String, String> deletedDocumentsConsumer =
-                            createConsumer("deleted-objects");
-                    KafkaConsumer<String, String> activitiesConsumer =
+            try (KafkaConsumer<String, String> activitiesConsumer =
                             createConsumer("s3-bucket-activity");
                     KafkaConsumer<String, String> consumer =
                             createConsumer(applicationRuntime.getGlobal("output-topic")); ) {
@@ -212,8 +209,6 @@ class S3SourceIT extends AbstractKafkaApplicationRunner {
                                 .build());
 
                 executeAgentRunners(applicationRuntime);
-
-                waitForMessages(deletedDocumentsConsumer, List.of("test-1.txt"));
 
                 waitForMessages(
                         activitiesConsumer,


### PR DESCRIPTION
To enable the new notification, these are the configs:
```
source-activity-summary-topic: "s3-bucket-activity"
source-activity-summary-events: "new,updated,deleted" # type of events to include, if empty or default this feature is disabled
source-activity-summary-events-threshold: 0 # number of events to force the notification to be sent out, even if time is not passed yet 
source-activity-summary-time-seconds-threshold: 5 # seconds between the first event detected to trigger the notification, if no events, no notification will be sent 
```