### PR TITLE
add source-record-headers to some sources

### DIFF
--- a/langstream-agents/langstream-agent-azure-blob-storage-source/src/main/java/ai/langstream/agents/azureblobstorage/AzureBlobStorageSource.java
+++ b/langstream-agents/langstream-agent-azure-blob-storage-source/src/main/java/ai/langstream/agents/azureblobstorage/AzureBlobStorageSource.java
@@ -31,7 +31,6 @@ import com.azure.storage.blob.models.BlobItem;
 import com.azure.storage.common.StorageSharedKeyCredential;
 import java.util.*;
 import java.util.stream.Collectors;
-
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -55,7 +54,6 @@ public class AzureBlobStorageSource
     private boolean deleteObjects;
 
     private Collection<Header> sourceRecordHeaders;
-
 
     public static final String ALL_FILES = "*";
     public static final String DEFAULT_EXTENSIONS_FILTER = "pdf,docx,html,htm,md,txt";
@@ -130,11 +128,13 @@ public class AzureBlobStorageSource
         idleTime = Integer.parseInt(configuration.getOrDefault("idle-time", 5).toString());
         deletedObjectsTopic = getString("deleted-objects-topic", null, configuration);
         deleteObjects = ConfigurationUtils.getBoolean("delete-objects", true, configuration);
-        sourceRecordHeaders = getMap("source-record-headers", Map.of(), configuration)
-                .entrySet()
-                .stream()
-                .map(entry -> SimpleRecord.SimpleHeader.of(entry.getKey(), entry.getValue()))
-                .collect(Collectors.toUnmodifiableList());
+        sourceRecordHeaders =
+                getMap("source-record-headers", Map.of(), configuration).entrySet().stream()
+                        .map(
+                                entry ->
+                                        SimpleRecord.SimpleHeader.of(
+                                                entry.getKey(), entry.getValue()))
+                        .collect(Collectors.toUnmodifiableList());
         sourceActivitySummaryTopic =
                 getString("source-activity-summary-topic", null, configuration);
         sourceActivitySummaryEvents = getList("source-activity-summary-events", configuration);

--- a/langstream-agents/langstream-agent-google-cloud-storage-source/src/main/java/ai/langstream/agents/gcs/GoogleCloudStorageSource.java
+++ b/langstream-agents/langstream-agent-google-cloud-storage-source/src/main/java/ai/langstream/agents/gcs/GoogleCloudStorageSource.java
@@ -15,6 +15,8 @@
  */
 package ai.langstream.agents.gcs;
 
+import static ai.langstream.api.util.ConfigurationUtils.*;
+
 import ai.langstream.ai.agents.commons.storage.provider.StorageProviderObjectReference;
 import ai.langstream.ai.agents.commons.storage.provider.StorageProviderSource;
 import ai.langstream.ai.agents.commons.storage.provider.StorageProviderSourceState;
@@ -29,11 +31,8 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.stream.Collectors;
-
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-
-import static ai.langstream.api.util.ConfigurationUtils.*;
 
 @Slf4j
 public class GoogleCloudStorageSource
@@ -121,11 +120,13 @@ public class GoogleCloudStorageSource
         idleTime = Integer.parseInt(configuration.getOrDefault("idle-time", 5).toString());
         deletedObjectsTopic = getString("deleted-objects-topic", null, configuration);
         deleteObjects = ConfigurationUtils.getBoolean("delete-objects", true, configuration);
-        sourceRecordHeaders = getMap("source-record-headers", Map.of(), configuration)
-                .entrySet()
-                .stream()
-                .map(entry -> SimpleRecord.SimpleHeader.of(entry.getKey(), entry.getValue()))
-                .collect(Collectors.toUnmodifiableList());
+        sourceRecordHeaders =
+                getMap("source-record-headers", Map.of(), configuration).entrySet().stream()
+                        .map(
+                                entry ->
+                                        SimpleRecord.SimpleHeader.of(
+                                                entry.getKey(), entry.getValue()))
+                        .collect(Collectors.toUnmodifiableList());
         sourceActivitySummaryTopic =
                 getString("source-activity-summary-topic", null, configuration);
         sourceActivitySummaryEvents = getList("source-activity-summary-events", configuration);

--- a/langstream-agents/langstream-agent-google-cloud-storage-source/src/main/java/ai/langstream/agents/gcs/GoogleCloudStorageSource.java
+++ b/langstream-agents/langstream-agent-google-cloud-storage-source/src/main/java/ai/langstream/agents/gcs/GoogleCloudStorageSource.java
@@ -15,12 +15,11 @@
  */
 package ai.langstream.agents.gcs;
 
-import static ai.langstream.api.util.ConfigurationUtils.getString;
-import static ai.langstream.api.util.ConfigurationUtils.requiredNonEmptyField;
-
 import ai.langstream.ai.agents.commons.storage.provider.StorageProviderObjectReference;
 import ai.langstream.ai.agents.commons.storage.provider.StorageProviderSource;
 import ai.langstream.ai.agents.commons.storage.provider.StorageProviderSourceState;
+import ai.langstream.api.runner.code.Header;
+import ai.langstream.api.runner.code.SimpleRecord;
 import ai.langstream.api.util.ConfigurationUtils;
 import com.google.api.gax.paging.Page;
 import com.google.auth.oauth2.GoogleCredentials;
@@ -29,8 +28,12 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
+import java.util.stream.Collectors;
+
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+
+import static ai.langstream.api.util.ConfigurationUtils.*;
 
 @Slf4j
 public class GoogleCloudStorageSource
@@ -46,6 +49,7 @@ public class GoogleCloudStorageSource
 
     private String deletedObjectsTopic;
     private boolean deleteObjects;
+    private Collection<Header> sourceRecordHeaders;
     private String sourceActivitySummaryTopic;
 
     private List<String> sourceActivitySummaryEvents;
@@ -117,6 +121,22 @@ public class GoogleCloudStorageSource
         idleTime = Integer.parseInt(configuration.getOrDefault("idle-time", 5).toString());
         deletedObjectsTopic = getString("deleted-objects-topic", null, configuration);
         deleteObjects = ConfigurationUtils.getBoolean("delete-objects", true, configuration);
+        sourceRecordHeaders = getMap("source-record-headers", Map.of(), configuration)
+                .entrySet()
+                .stream()
+                .map(entry -> SimpleRecord.SimpleHeader.of(entry.getKey(), entry.getValue()))
+                .collect(Collectors.toUnmodifiableList());
+        sourceActivitySummaryTopic =
+                getString("source-activity-summary-topic", null, configuration);
+        sourceActivitySummaryEvents = getList("source-activity-summary-events", configuration);
+        sourceActivitySummaryNumEventsThreshold =
+                getInt("source-activity-summary-events-threshold", 0, configuration);
+        sourceActivitySummaryTimeSecondsThreshold =
+                getInt("source-activity-summary-time-seconds-threshold", 30, configuration);
+        if (sourceActivitySummaryTimeSecondsThreshold < 0) {
+            throw new IllegalArgumentException(
+                    "source-activity-summary-time-seconds-threshold must be > 0");
+        }
         extensions =
                 Set.of(
                         configuration
@@ -212,6 +232,11 @@ public class GoogleCloudStorageSource
     @Override
     public void deleteObject(String name) throws Exception {
         gcsClient.delete(bucketName, name);
+    }
+
+    @Override
+    public Collection<Header> getSourceRecordHeaders() {
+        return sourceRecordHeaders;
     }
 
     static boolean isExtensionAllowed(String name, Set<String> extensions) {

--- a/langstream-agents/langstream-agent-s3/src/main/java/ai/langstream/agents/s3/S3Source.java
+++ b/langstream-agents/langstream-agent-s3/src/main/java/ai/langstream/agents/s3/S3Source.java
@@ -34,7 +34,6 @@ import io.minio.Result;
 import io.minio.messages.Item;
 import java.util.*;
 import java.util.stream.Collectors;
-
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 
@@ -100,12 +99,13 @@ public class S3Source extends StorageProviderSource<S3Source.S3SourceState> {
 
         deleteObjects = ConfigurationUtils.getBoolean("delete-objects", true, configuration);
 
-        sourceRecordHeaders = getMap("source-record-headers", Map.of(), configuration)
-                .entrySet()
-                .stream()
-                .map(entry -> SimpleRecord.SimpleHeader.of(entry.getKey(), entry.getValue()))
-                .collect(Collectors.toUnmodifiableList());
-
+        sourceRecordHeaders =
+                getMap("source-record-headers", Map.of(), configuration).entrySet().stream()
+                        .map(
+                                entry ->
+                                        SimpleRecord.SimpleHeader.of(
+                                                entry.getKey(), entry.getValue()))
+                        .collect(Collectors.toUnmodifiableList());
 
         log.info(
                 "Connecting to S3 Bucket at {} in region {} with user {}",

--- a/langstream-agents/langstream-agent-s3/src/main/java/ai/langstream/agents/s3/S3Source.java
+++ b/langstream-agents/langstream-agent-s3/src/main/java/ai/langstream/agents/s3/S3Source.java
@@ -20,6 +20,8 @@ import static ai.langstream.api.util.ConfigurationUtils.*;
 import ai.langstream.ai.agents.commons.storage.provider.StorageProviderObjectReference;
 import ai.langstream.ai.agents.commons.storage.provider.StorageProviderSource;
 import ai.langstream.ai.agents.commons.storage.provider.StorageProviderSourceState;
+import ai.langstream.api.runner.code.Header;
+import ai.langstream.api.runner.code.SimpleRecord;
 import ai.langstream.api.util.ConfigurationUtils;
 import io.minio.BucketExistsArgs;
 import io.minio.GetObjectArgs;
@@ -31,6 +33,8 @@ import io.minio.RemoveObjectArgs;
 import io.minio.Result;
 import io.minio.messages.Item;
 import java.util.*;
+import java.util.stream.Collectors;
+
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 
@@ -55,6 +59,7 @@ public class S3Source extends StorageProviderSource<S3Source.S3SourceState> {
     private Set<String> extensions = Set.of();
 
     private boolean deleteObjects;
+    private Collection<Header> sourceRecordHeaders;
 
     @Override
     public Class<S3SourceState> getStateClass() {
@@ -94,6 +99,13 @@ public class S3Source extends StorageProviderSource<S3Source.S3SourceState> {
                                 .split(","));
 
         deleteObjects = ConfigurationUtils.getBoolean("delete-objects", true, configuration);
+
+        sourceRecordHeaders = getMap("source-record-headers", Map.of(), configuration)
+                .entrySet()
+                .stream()
+                .map(entry -> SimpleRecord.SimpleHeader.of(entry.getKey(), entry.getValue()))
+                .collect(Collectors.toUnmodifiableList());
+
 
         log.info(
                 "Connecting to S3 Bucket at {} in region {} with user {}",
@@ -209,6 +221,11 @@ public class S3Source extends StorageProviderSource<S3Source.S3SourceState> {
     public void deleteObject(String name) throws Exception {
         minioClient.removeObject(
                 RemoveObjectArgs.builder().bucket(bucketName).object(name).build());
+    }
+
+    @Override
+    public Collection<Header> getSourceRecordHeaders() {
+        return sourceRecordHeaders;
     }
 
     private void makeBucketIfNotExists(String bucketName) throws Exception {

--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/WebCrawlerSource.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/WebCrawlerSource.java
@@ -41,8 +41,6 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
-
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -108,11 +106,13 @@ public class WebCrawlerSource extends AbstractAgentCode implements AgentSource {
                 getBoolean("allow-non-html-contents", false, configuration);
 
         final boolean handleCookies = getBoolean("handle-cookies", true, configuration);
-        sourceRecordHeaders = getMap("source-record-headers", Map.of(), configuration)
-                .entrySet()
-                .stream()
-                .map(entry -> SimpleRecord.SimpleHeader.of(entry.getKey(), entry.getValue()))
-                .collect(Collectors.toUnmodifiableList());
+        sourceRecordHeaders =
+                getMap("source-record-headers", Map.of(), configuration).entrySet().stream()
+                        .map(
+                                entry ->
+                                        SimpleRecord.SimpleHeader.of(
+                                                entry.getKey(), entry.getValue()))
+                        .collect(Collectors.toUnmodifiableList());
 
         log.info("allowed-domains: {}", allowedDomains);
         log.info("forbidden-paths: {}", forbiddenPaths);
@@ -155,10 +155,8 @@ public class WebCrawlerSource extends AbstractAgentCode implements AgentSource {
 
     private void sendDeletedDocument(String url) throws Exception {
         if (deletedDocumentsProducer != null) {
-            SimpleRecord simpleRecord = SimpleRecord.builder()
-                    .headers(sourceRecordHeaders)
-                    .value(url)
-                    .build();
+            SimpleRecord simpleRecord =
+                    SimpleRecord.builder().headers(sourceRecordHeaders).value(url).build();
             // sync so we can handle status correctly
             deletedDocumentsProducer.write(simpleRecord).get();
         }
@@ -302,12 +300,15 @@ public class WebCrawlerSource extends AbstractAgentCode implements AgentSource {
         List<Header> allHeaders = new ArrayList<>(sourceRecordHeaders);
         allHeaders.add(new SimpleRecord.SimpleHeader("url", document.url()));
         allHeaders.add(new SimpleRecord.SimpleHeader("content_type", document.contentType()));
-        allHeaders.add(new SimpleRecord.SimpleHeader("content_diff", document.contentDiff().toString().toLowerCase()));
-        SimpleRecord simpleRecord = SimpleRecord.builder()
-                .headers(allHeaders)
-                .key(document.url())
-                .value(document.content())
-                .build();
+        allHeaders.add(
+                new SimpleRecord.SimpleHeader(
+                        "content_diff", document.contentDiff().toString().toLowerCase()));
+        SimpleRecord simpleRecord =
+                SimpleRecord.builder()
+                        .headers(allHeaders)
+                        .key(document.url())
+                        .value(document.content())
+                        .build();
 
         return List.of(simpleRecord);
     }

--- a/langstream-agents/langstream-agents-commons-storage-provider/src/main/java/ai/langstream/ai/agents/commons/storage/provider/StorageProviderSource.java
+++ b/langstream-agents/langstream-agents-commons-storage-provider/src/main/java/ai/langstream/ai/agents/commons/storage/provider/StorageProviderSource.java
@@ -160,11 +160,7 @@ public abstract class StorageProviderSource<T extends StorageProviderSourceState
             allHeaders.add(new SimpleRecord.SimpleHeader("bucket", bucketName));
             allHeaders.add(new SimpleRecord.SimpleHeader("content_diff", contentDiff));
             SimpleRecord record =
-                    SimpleRecord.builder()
-                            .key(name)
-                            .value(read)
-                            .headers(allHeaders)
-                            .build();
+                    SimpleRecord.builder().key(name).value(read).headers(allHeaders).build();
             return List.of(record);
         } catch (Exception e) {
             log.error("Error reading object {}", name, e);

--- a/langstream-agents/langstream-agents-commons-storage-provider/src/main/java/ai/langstream/ai/agents/commons/storage/provider/StorageProviderSource.java
+++ b/langstream-agents/langstream-agents-commons-storage-provider/src/main/java/ai/langstream/ai/agents/commons/storage/provider/StorageProviderSource.java
@@ -64,6 +64,8 @@ public abstract class StorageProviderSource<T extends StorageProviderSourceState
 
     public abstract void deleteObject(String name) throws Exception;
 
+    public abstract Collection<Header> getSourceRecordHeaders();
+
     @Override
     public void init(Map<String, Object> configuration) {
         agentConfiguration = configuration;
@@ -152,16 +154,16 @@ public abstract class StorageProviderSource<T extends StorageProviderSourceState
                 contentDiff = "no_state_storage";
             }
             processed(0, 1);
+
+            List<Header> allHeaders = new ArrayList<>(getSourceRecordHeaders());
+            allHeaders.add(new SimpleRecord.SimpleHeader("name", name));
+            allHeaders.add(new SimpleRecord.SimpleHeader("bucket", bucketName));
+            allHeaders.add(new SimpleRecord.SimpleHeader("content_diff", contentDiff));
             SimpleRecord record =
                     SimpleRecord.builder()
                             .key(name)
                             .value(read)
-                            .headers(
-                                    List.of(
-                                            new SimpleRecord.SimpleHeader("name", name),
-                                            new SimpleRecord.SimpleHeader("bucket", bucketName),
-                                            new SimpleRecord.SimpleHeader(
-                                                    "content_diff", contentDiff)))
+                            .headers(allHeaders)
                             .build();
             return List.of(record);
         } catch (Exception e) {
@@ -245,7 +247,7 @@ public abstract class StorageProviderSource<T extends StorageProviderSourceState
                         "Emitting source activity summary to topic {}",
                         getSourceActivitySummaryTopic());
                 String value = MAPPER.writeValueAsString(currentSourceActivitySummary);
-                SimpleRecord simpleRecord = SimpleRecord.of(getBucketName(), value);
+                SimpleRecord simpleRecord = buildSimpleRecord(value);
                 sourceActivitySummaryProducer.write(simpleRecord).get();
             } else {
                 log.warn("No source activity summary producer configured, event will be lost");
@@ -255,6 +257,14 @@ public abstract class StorageProviderSource<T extends StorageProviderSourceState
                             new ArrayList<>(), new ArrayList<>(), new ArrayList<>()));
             stateStorage.store(state);
         }
+    }
+
+    private SimpleRecord buildSimpleRecord(String value) {
+        return SimpleRecord.builder()
+                .key(getBucketName())
+                .value(value)
+                .headers(getSourceRecordHeaders())
+                .build();
     }
 
     private void checkDeletedObjects(
@@ -283,7 +293,7 @@ public abstract class StorageProviderSource<T extends StorageProviderSourceState
                                 new StorageProviderSourceState.ObjectDetail(
                                         bucketName, objectName, System.currentTimeMillis()));
                 if (deletedObjectsProducer != null) {
-                    SimpleRecord simpleRecord = SimpleRecord.of(bucketName, objectName);
+                    SimpleRecord simpleRecord = buildSimpleRecord(objectName);
                     deletedObjectsProducer.write(simpleRecord).get();
                 }
             }

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/ObjectStorageProcessorAgentProvider.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/ObjectStorageProcessorAgentProvider.java
@@ -23,6 +23,7 @@ import ai.langstream.impl.agents.AbstractComposableAgentProvider;
 import ai.langstream.runtime.impl.k8s.KubernetesClusterRuntime;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/ObjectStorageProcessorAgentProvider.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/ObjectStorageProcessorAgentProvider.java
@@ -23,7 +23,6 @@ import ai.langstream.impl.agents.AbstractComposableAgentProvider;
 import ai.langstream.runtime.impl.k8s.KubernetesClusterRuntime;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/StorageProviderSourceAgentProvider.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/StorageProviderSourceAgentProvider.java
@@ -23,6 +23,7 @@ import ai.langstream.impl.agents.AbstractComposableAgentProvider;
 import ai.langstream.runtime.impl.k8s.KubernetesClusterRuntime;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -183,6 +184,13 @@ public class StorageProviderSourceAgentProvider extends AbstractComposableAgentP
                                 """)
         @JsonProperty("source-activity-summary-time-seconds-threshold")
         private int sourceActivitySummaryTimeSecondsThreshold;
+        @ConfigProperty(
+                description =
+                        """
+                                Additional headers to add to emitted records.
+                                """)
+        @JsonProperty("source-record-headers")
+        private Map<String, String> sourceRecordHeaders;
     }
 
     @AgentConfig(
@@ -315,6 +323,13 @@ public class StorageProviderSourceAgentProvider extends AbstractComposableAgentP
                                 """)
         @JsonProperty("source-activity-summary-time-seconds-threshold")
         private int sourceActivitySummaryTimeSecondsThreshold;
+        @ConfigProperty(
+                description =
+                        """
+                                Additional headers to add to emitted records.
+                                """)
+        @JsonProperty("source-record-headers")
+        private Map<String, String> sourceRecordHeaders;
     }
 
     @AgentConfig(
@@ -415,5 +430,13 @@ public class StorageProviderSourceAgentProvider extends AbstractComposableAgentP
                                 """)
         @JsonProperty("source-activity-summary-time-seconds-threshold")
         private int sourceActivitySummaryTimeSecondsThreshold;
+
+        @ConfigProperty(
+                description =
+                        """
+                                Additional headers to add to emitted records.
+                                """)
+        @JsonProperty("source-record-headers")
+        private Map<String, String> sourceRecordHeaders;
     }
 }

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/StorageProviderSourceAgentProvider.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/StorageProviderSourceAgentProvider.java
@@ -184,6 +184,7 @@ public class StorageProviderSourceAgentProvider extends AbstractComposableAgentP
                                 """)
         @JsonProperty("source-activity-summary-time-seconds-threshold")
         private int sourceActivitySummaryTimeSecondsThreshold;
+
         @ConfigProperty(
                 description =
                         """
@@ -323,6 +324,7 @@ public class StorageProviderSourceAgentProvider extends AbstractComposableAgentP
                                 """)
         @JsonProperty("source-activity-summary-time-seconds-threshold")
         private int sourceActivitySummaryTimeSecondsThreshold;
+
         @ConfigProperty(
                 description =
                         """

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/WebCrawlerSourceAgentProvider.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/WebCrawlerSourceAgentProvider.java
@@ -30,6 +30,7 @@ import ai.langstream.impl.agents.AbstractComposableAgentProvider;
 import ai.langstream.runtime.impl.k8s.KubernetesClusterRuntime;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
@@ -310,5 +311,13 @@ public class WebCrawlerSourceAgentProvider extends AbstractComposableAgentProvid
                 defaultValue = "")
         @JsonProperty("deleted-documents-topic")
         private String deletedDocumentsTopic;
+
+        @ConfigProperty(
+                description =
+                        """
+                                Additional headers to add to emitted records.
+                                """)
+        @JsonProperty("source-record-headers")
+        private Map<String, String> sourceRecordHeaders;
     }
 }

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/AbstractKafkaApplicationRunner.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/AbstractKafkaApplicationRunner.java
@@ -24,15 +24,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import ai.langstream.AbstractApplicationRunner;
 import ai.langstream.kafka.extensions.KafkaContainerExtension;
 import ai.langstream.runtime.agent.api.AgentAPIController;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -50,6 +48,7 @@ public abstract class AbstractKafkaApplicationRunner extends AbstractApplication
 
     @RegisterExtension
     protected static final KafkaContainerExtension kafkaContainer = new KafkaContainerExtension();
+
     public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private volatile boolean validateConsumerOffsets = true;
@@ -214,22 +213,32 @@ public abstract class AbstractKafkaApplicationRunner extends AbstractApplication
         return result;
     }
 
-    protected static void assertRecordEquals(ConsumerRecord record, Object key, Object value, Map<String, String> headers) {
+    protected static void assertRecordEquals(
+            ConsumerRecord record, Object key, Object value, Map<String, String> headers) {
         final Object recordKey = record.key();
         final Object recordValue = record.value();
-        Map<String, String> recordHeaders = Arrays.stream(record.headers().toArray()).collect(Collectors.toMap(Header::key, h -> new String(h.value())));
+        Map<String, String> recordHeaders =
+                Arrays.stream(record.headers().toArray())
+                        .collect(Collectors.toMap(Header::key, h -> new String(h.value())));
 
-        log.info("""
+        log.info(
+                """
                 Comparing record with:
                 key: {}
                 value: {}
                 headers: {}
-                
+
                 vs expected:
                 key: {}
                 value: {}
                 headers: {}
-                """, recordKey, recordValue, recordHeaders, key, value, headers);
+                """,
+                recordKey,
+                recordValue,
+                recordHeaders,
+                key,
+                value,
+                headers);
         assertEquals(key, record.key());
         assertEquals(value, record.value());
         assertEquals(headers, recordHeaders);

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/S3SourceIT.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/S3SourceIT.java
@@ -23,17 +23,13 @@ import io.minio.MakeBucketArgs;
 import io.minio.MinioClient;
 import io.minio.PutObjectArgs;
 import io.minio.RemoveObjectArgs;
-
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.function.BiConsumer;
-
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.localstack.LocalStackContainer;
@@ -57,7 +53,7 @@ class S3SourceIT extends AbstractKafkaApplicationRunner {
 
         String tenant = "tenant";
 
-        String[] expectedAgents = new String[]{appId + "-step1"};
+        String[] expectedAgents = new String[] {appId + "-step1"};
         String endpoint = localstack.getEndpointOverride(S3).toString();
         Map<String, String> application =
                 Map.of(
@@ -106,33 +102,47 @@ class S3SourceIT extends AbstractKafkaApplicationRunner {
         }
 
         try (ApplicationRuntime applicationRuntime =
-                     deployApplication(
-                             tenant, appId, application, buildInstanceYaml(), expectedAgents)) {
+                deployApplication(
+                        tenant, appId, application, buildInstanceYaml(), expectedAgents)) {
 
             try (KafkaConsumer<String, String> deletedDocumentsConsumer =
-                         createConsumer("deleted-objects");
-                 KafkaConsumer<String, String> consumer =
-                         createConsumer(applicationRuntime.getGlobal("output-topic"));) {
+                            createConsumer("deleted-objects");
+                    KafkaConsumer<String, String> consumer =
+                            createConsumer(applicationRuntime.getGlobal("output-topic")); ) {
 
                 executeAgentRunners(applicationRuntime);
 
-                waitForMessages(consumer, (consumerRecords, objects) -> {
-                    assertEquals(2, consumerRecords.size());
-                    assertRecordEquals(
-                            consumerRecords.get(0),
-                            "test-0.txt",
-                            "content0",
-                            Map.of("bucket", "test-bucket", "content_diff", "new", "name", "test-0.txt", "my-id"
-                                    , "a2b9b4e0-7b3b-4b3b-8b3b-0b3b3b3b3b3b"
-                            ));
-                    assertRecordEquals(
-                            consumerRecords.get(1),
-                            "test-1.txt",
-                            "content1",
-                            Map.of("bucket", "test-bucket", "content_diff", "new", "name", "test-1.txt", "my-id"
-                                    , "a2b9b4e0-7b3b-4b3b-8b3b-0b3b3b3b3b3b"));
-
-                });
+                waitForMessages(
+                        consumer,
+                        (consumerRecords, objects) -> {
+                            assertEquals(2, consumerRecords.size());
+                            assertRecordEquals(
+                                    consumerRecords.get(0),
+                                    "test-0.txt",
+                                    "content0",
+                                    Map.of(
+                                            "bucket",
+                                            "test-bucket",
+                                            "content_diff",
+                                            "new",
+                                            "name",
+                                            "test-0.txt",
+                                            "my-id",
+                                            "a2b9b4e0-7b3b-4b3b-8b3b-0b3b3b3b3b3b"));
+                            assertRecordEquals(
+                                    consumerRecords.get(1),
+                                    "test-1.txt",
+                                    "content1",
+                                    Map.of(
+                                            "bucket",
+                                            "test-bucket",
+                                            "content_diff",
+                                            "new",
+                                            "name",
+                                            "test-1.txt",
+                                            "my-id",
+                                            "a2b9b4e0-7b3b-4b3b-8b3b-0b3b3b3b3b3b"));
+                        });
 
                 minioClient.removeObject(
                         RemoveObjectArgs.builder()
@@ -142,14 +152,16 @@ class S3SourceIT extends AbstractKafkaApplicationRunner {
 
                 executeAgentRunners(applicationRuntime);
 
-                waitForMessages(deletedDocumentsConsumer, (consumerRecords, objects) -> {
-                    assertEquals(1, consumerRecords.size());
-                    assertRecordEquals(
-                            consumerRecords.get(0),
-                            "test-bucket",
-                            "test-0.txt",
-                            Map.of("my-id", "a2b9b4e0-7b3b-4b3b-8b3b-0b3b3b3b3b3b"));
-                });
+                waitForMessages(
+                        deletedDocumentsConsumer,
+                        (consumerRecords, objects) -> {
+                            assertEquals(1, consumerRecords.size());
+                            assertRecordEquals(
+                                    consumerRecords.get(0),
+                                    "test-bucket",
+                                    "test-0.txt",
+                                    Map.of("my-id", "a2b9b4e0-7b3b-4b3b-8b3b-0b3b3b3b3b3b"));
+                        });
             }
         }
     }
@@ -161,7 +173,7 @@ class S3SourceIT extends AbstractKafkaApplicationRunner {
 
         String tenant = "tenant";
 
-        String[] expectedAgents = new String[]{appId + "-step1"};
+        String[] expectedAgents = new String[] {appId + "-step1"};
         String endpoint = localstack.getEndpointOverride(S3).toString();
         Map<String, String> application =
                 Map.of(
@@ -211,13 +223,13 @@ class S3SourceIT extends AbstractKafkaApplicationRunner {
         }
 
         try (ApplicationRuntime applicationRuntime =
-                     deployApplication(
-                             tenant, appId, application, buildInstanceYaml(), expectedAgents)) {
+                deployApplication(
+                        tenant, appId, application, buildInstanceYaml(), expectedAgents)) {
 
             try (KafkaConsumer<String, String> activitiesConsumer =
-                         createConsumer("s3-bucket-activity");
-                 KafkaConsumer<String, String> consumer =
-                         createConsumer(applicationRuntime.getGlobal("output-topic"));) {
+                            createConsumer("s3-bucket-activity");
+                    KafkaConsumer<String, String> consumer =
+                            createConsumer(applicationRuntime.getGlobal("output-topic")); ) {
 
                 executeAgentRunners(applicationRuntime);
 

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/S3SourceIT.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/S3SourceIT.java
@@ -23,13 +23,17 @@ import io.minio.MakeBucketArgs;
 import io.minio.MinioClient;
 import io.minio.PutObjectArgs;
 import io.minio.RemoveObjectArgs;
+
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.function.BiConsumer;
+
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.localstack.LocalStackContainer;
@@ -53,7 +57,7 @@ class S3SourceIT extends AbstractKafkaApplicationRunner {
 
         String tenant = "tenant";
 
-        String[] expectedAgents = new String[] {appId + "-step1"};
+        String[] expectedAgents = new String[]{appId + "-step1"};
         String endpoint = localstack.getEndpointOverride(S3).toString();
         Map<String, String> application =
                 Map.of(
@@ -79,6 +83,8 @@ class S3SourceIT extends AbstractKafkaApplicationRunner {
                                         deleted-objects-topic: "deleted-objects"
                                         delete-objects: false
                                         idle-time: 1
+                                        source-record-headers:
+                                            my-id: a2b9b4e0-7b3b-4b3b-8b3b-0b3b3b3b3b3b
                                 """
                                 .formatted(endpoint, endpoint));
 
@@ -100,17 +106,33 @@ class S3SourceIT extends AbstractKafkaApplicationRunner {
         }
 
         try (ApplicationRuntime applicationRuntime =
-                deployApplication(
-                        tenant, appId, application, buildInstanceYaml(), expectedAgents)) {
+                     deployApplication(
+                             tenant, appId, application, buildInstanceYaml(), expectedAgents)) {
 
             try (KafkaConsumer<String, String> deletedDocumentsConsumer =
-                            createConsumer("deleted-objects");
-                    KafkaConsumer<String, String> consumer =
-                            createConsumer(applicationRuntime.getGlobal("output-topic")); ) {
+                         createConsumer("deleted-objects");
+                 KafkaConsumer<String, String> consumer =
+                         createConsumer(applicationRuntime.getGlobal("output-topic"));) {
 
                 executeAgentRunners(applicationRuntime);
 
-                waitForMessages(consumer, List.of("content0", "content1"));
+                waitForMessages(consumer, (consumerRecords, objects) -> {
+                    assertEquals(2, consumerRecords.size());
+                    assertRecordEquals(
+                            consumerRecords.get(0),
+                            "test-0.txt",
+                            "content0",
+                            Map.of("bucket", "test-bucket", "content_diff", "new", "name", "test-0.txt", "my-id"
+                                    , "a2b9b4e0-7b3b-4b3b-8b3b-0b3b3b3b3b3b"
+                            ));
+                    assertRecordEquals(
+                            consumerRecords.get(1),
+                            "test-1.txt",
+                            "content1",
+                            Map.of("bucket", "test-bucket", "content_diff", "new", "name", "test-1.txt", "my-id"
+                                    , "a2b9b4e0-7b3b-4b3b-8b3b-0b3b3b3b3b3b"));
+
+                });
 
                 minioClient.removeObject(
                         RemoveObjectArgs.builder()
@@ -120,7 +142,14 @@ class S3SourceIT extends AbstractKafkaApplicationRunner {
 
                 executeAgentRunners(applicationRuntime);
 
-                waitForMessages(deletedDocumentsConsumer, List.of("test-0.txt"));
+                waitForMessages(deletedDocumentsConsumer, (consumerRecords, objects) -> {
+                    assertEquals(1, consumerRecords.size());
+                    assertRecordEquals(
+                            consumerRecords.get(0),
+                            "test-bucket",
+                            "test-0.txt",
+                            Map.of("my-id", "a2b9b4e0-7b3b-4b3b-8b3b-0b3b3b3b3b3b"));
+                });
             }
         }
     }
@@ -132,7 +161,7 @@ class S3SourceIT extends AbstractKafkaApplicationRunner {
 
         String tenant = "tenant";
 
-        String[] expectedAgents = new String[] {appId + "-step1"};
+        String[] expectedAgents = new String[]{appId + "-step1"};
         String endpoint = localstack.getEndpointOverride(S3).toString();
         Map<String, String> application =
                 Map.of(
@@ -182,13 +211,13 @@ class S3SourceIT extends AbstractKafkaApplicationRunner {
         }
 
         try (ApplicationRuntime applicationRuntime =
-                deployApplication(
-                        tenant, appId, application, buildInstanceYaml(), expectedAgents)) {
+                     deployApplication(
+                             tenant, appId, application, buildInstanceYaml(), expectedAgents)) {
 
             try (KafkaConsumer<String, String> activitiesConsumer =
-                            createConsumer("s3-bucket-activity");
-                    KafkaConsumer<String, String> consumer =
-                            createConsumer(applicationRuntime.getGlobal("output-topic")); ) {
+                         createConsumer("s3-bucket-activity");
+                 KafkaConsumer<String, String> consumer =
+                         createConsumer(applicationRuntime.getGlobal("output-topic"));) {
 
                 executeAgentRunners(applicationRuntime);
 


### PR DESCRIPTION
added `source-record-headers` as map of headers to add to each emitted message for sources:
- webcrawler
- s3 source
- azure bs source
- gcs source

```
configuration:
  bucketName: "test-bucket"
  source-record-headers:
    my-id: a2b9b4e0-7b3b-4b3b-8b3b-0b3b3b3b3b3b
```