### PR TITLE
webcrawler: add activity notifications

### DIFF
--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/WebCrawlerSource.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/WebCrawlerSource.java
@@ -35,7 +35,6 @@ import ai.langstream.api.runner.code.SimpleRecord;
 import ai.langstream.api.runner.topics.TopicProducer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.minio.*;
-
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.*;
@@ -43,7 +42,6 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
-
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -80,8 +78,7 @@ public class WebCrawlerSource extends AbstractAgentCode implements AgentSource {
 
     private final BlockingQueue<Document> foundDocuments = new LinkedBlockingQueue<>();
 
-    @Getter
-    private StateStorage<StatusStorage.Status> stateStorage;
+    @Getter private StateStorage<StatusStorage.Status> stateStorage;
 
     private Runnable onReindexStart;
 
@@ -392,11 +389,10 @@ public class WebCrawlerSource extends AbstractAgentCode implements AgentSource {
         return List.of();
     }
 
-
     private void sendSourceActivitySummaryIfNeeded() throws Exception {
         synchronized (this) {
-            StatusStorage.SourceActivitySummary currentSourceActivitySummary = crawler.getStatus()
-                    .getCurrentSourceActivitySummary();
+            StatusStorage.SourceActivitySummary currentSourceActivitySummary =
+                    crawler.getStatus().getCurrentSourceActivitySummary();
             if (currentSourceActivitySummary == null) {
                 return;
             }
@@ -472,15 +468,22 @@ public class WebCrawlerSource extends AbstractAgentCode implements AgentSource {
                             sourceActivitySummaryTopic);
                     String value = MAPPER.writeValueAsString(currentSourceActivitySummary);
                     SimpleRecord simpleRecord =
-                            SimpleRecord.builder().headers(sourceRecordHeaders).value(value).build();
+                            SimpleRecord.builder()
+                                    .headers(sourceRecordHeaders)
+                                    .value(value)
+                                    .build();
                     ;
                     sourceActivitySummaryProducer.write(simpleRecord).get();
                 } else {
                     log.warn("No source activity summary producer configured, event will be lost");
                 }
-                crawler.getStatus().setCurrentSourceActivitySummary(
-                        new StatusStorage.SourceActivitySummary(
-                                new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>()));
+                crawler.getStatus()
+                        .setCurrentSourceActivitySummary(
+                                new StatusStorage.SourceActivitySummary(
+                                        new ArrayList<>(),
+                                        new ArrayList<>(),
+                                        new ArrayList<>(),
+                                        new ArrayList<>()));
                 crawler.getStatus().persist(stateStorage);
             }
         }
@@ -501,8 +504,9 @@ public class WebCrawlerSource extends AbstractAgentCode implements AgentSource {
         synchronized (this) {
             for (Record record : records) {
                 String url = (String) record.key();
-                Document.ContentDiff contentDiff = Document.ContentDiff.valueOf(
-                        record.getHeader("content_diff").valueAsString().toUpperCase());
+                Document.ContentDiff contentDiff =
+                        Document.ContentDiff.valueOf(
+                                record.getHeader("content_diff").valueAsString().toUpperCase());
                 crawler.getStatus().urlProcessed(url, contentDiff);
 
                 if (flushNext.decrementAndGet() == 0) {
@@ -531,7 +535,7 @@ public class WebCrawlerSource extends AbstractAgentCode implements AgentSource {
         super.cleanup(configuration, context);
         String bucketName = getString("bucketName", "langstream-source", agentConfiguration);
         try (StateStorage<StatusStorage.Status> statusStateStorage =
-                     initStateStorage(agentId(), context, agentConfiguration, bucketName);) {
+                initStateStorage(agentId(), context, agentConfiguration, bucketName); ) {
             if (statusStateStorage != null) {
                 statusStateStorage.delete();
             }

--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/StatusStorage.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/StatusStorage.java
@@ -24,11 +24,19 @@ public class StatusStorage {
 
     public record RobotsFile(String content, String contentType) {}
 
+    public record UrlActivityDetail(String url, long detectedAt) {}
+    public record SourceActivitySummary(
+            List<UrlActivityDetail> newUrls,
+            List<UrlActivityDetail> changedUrls,
+            List<UrlActivityDetail> unchangedUrls,
+            List<UrlActivityDetail> deletedUrls) {}
+
     public record Status(
             List<String> remainingUrls,
             List<StoreUrlReference> urls,
             Long lastIndexEndTimestamp,
             Long lastIndexStartTimestamp,
             Map<String, RobotsFile> robotFiles,
-            Map<String, String> allTimeDocuments) {}
+            Map<String, String> allTimeDocuments,
+            StatusStorage.SourceActivitySummary currentSourceActivitySummary) {}
 }

--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/StatusStorage.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/StatusStorage.java
@@ -25,6 +25,7 @@ public class StatusStorage {
     public record RobotsFile(String content, String contentType) {}
 
     public record UrlActivityDetail(String url, long detectedAt) {}
+
     public record SourceActivitySummary(
             List<UrlActivityDetail> newUrls,
             List<UrlActivityDetail> changedUrls,

--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/WebCrawler.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/WebCrawler.java
@@ -350,7 +350,8 @@ public class WebCrawler {
         for (String url : toRemove) {
             onDocumentDeleted.visit(url);
             status.getAllTimeDocuments().remove(url);
-            StatusStorage.UrlActivityDetail urlActivityDetail = new StatusStorage.UrlActivityDetail(url, System.currentTimeMillis());
+            StatusStorage.UrlActivityDetail urlActivityDetail =
+                    new StatusStorage.UrlActivityDetail(url, System.currentTimeMillis());
             status.getCurrentSourceActivitySummary().deletedUrls().add(urlActivityDetail);
         }
     }

--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/WebCrawler.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/WebCrawler.java
@@ -150,14 +150,14 @@ public class WebCrawler {
         if (reference.type() == URLReference.Type.ROBOTS) {
             log.info("Found a robots.txt file");
             handleRobotsFile(current);
-            status.urlProcessed(current);
+            status.urlProcessed(current, null);
             return true;
         }
 
         if (reference.type() == URLReference.Type.SITEMAP) {
             log.info("Found a sitemap file");
             handleSitemapsFile(current);
-            status.urlProcessed(current);
+            status.urlProcessed(current, null);
             return true;
         }
 
@@ -350,6 +350,8 @@ public class WebCrawler {
         for (String url : toRemove) {
             onDocumentDeleted.visit(url);
             status.getAllTimeDocuments().remove(url);
+            StatusStorage.UrlActivityDetail urlActivityDetail = new StatusStorage.UrlActivityDetail(url, System.currentTimeMillis());
+            status.getCurrentSourceActivitySummary().deletedUrls().add(urlActivityDetail);
         }
     }
 

--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerStatus.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerStatus.java
@@ -72,9 +72,10 @@ public class WebCrawlerStatus {
 
     private final Map<String, String> allTimeDocuments = new HashMap<>();
 
-    @Setter private StatusStorage.SourceActivitySummary currentSourceActivitySummary =
-            new StatusStorage.SourceActivitySummary(new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
-
+    @Setter
+    private StatusStorage.SourceActivitySummary currentSourceActivitySummary =
+            new StatusStorage.SourceActivitySummary(
+                    new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
 
     public void reloadFrom(StateStorage<StatusStorage.Status> statusStorage) throws Exception {
         StatusStorage.Status currentStatus = statusStorage.get(StatusStorage.Status.class);
@@ -224,7 +225,8 @@ public class WebCrawlerStatus {
         errorCount.remove(url);
 
         if (contentDiff != null) {
-            StatusStorage.UrlActivityDetail urlActivityDetail = new StatusStorage.UrlActivityDetail(url, System.currentTimeMillis());
+            StatusStorage.UrlActivityDetail urlActivityDetail =
+                    new StatusStorage.UrlActivityDetail(url, System.currentTimeMillis());
             switch (contentDiff) {
                 case NEW:
                     currentSourceActivitySummary.newUrls().add(urlActivityDetail);

--- a/langstream-agents/langstream-agent-webcrawler/src/test/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerStatusTest.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/test/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerStatusTest.java
@@ -39,7 +39,7 @@ class WebCrawlerStatusTest {
         verify(status, 1, 1, 1);
         String url = status.nextUrl();
         verify(status, 1, 0, 1);
-        status.urlProcessed(url);
+        status.urlProcessed(url, null);
         verify(status, 1, 0, 0);
         status.addUrl(URL1, URLReference.Type.PAGE, 0, true);
         verify(status, 1, 0, 0);
@@ -56,7 +56,7 @@ class WebCrawlerStatusTest {
         verify(status, 1, 1, 1);
         String url = status.nextUrl();
         verify(status, 1, 0, 1);
-        status.urlProcessed(url);
+        status.urlProcessed(url, null);
         verify(status, 1, 0, 0);
         status.addUrl(URL2, URLReference.Type.PAGE, 0, true);
         verify(status, 1, 0, 0);
@@ -133,7 +133,7 @@ class WebCrawlerStatusTest {
         verify(status, 2, 1, 2);
         status.persist(storage);
 
-        status.urlProcessed(url);
+        status.urlProcessed(url, null);
         verify(status, 2, 1, 1);
         status.persist(storage);
 
@@ -142,7 +142,7 @@ class WebCrawlerStatusTest {
         verify(status, 2, 1, 1);
 
         url = status.nextUrl();
-        status.urlProcessed(url);
+        status.urlProcessed(url, null);
         verify(status, 2, 0, 0);
         status.persist(storage);
 

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/WebCrawlerSourceAgentProvider.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/WebCrawlerSourceAgentProvider.java
@@ -319,5 +319,40 @@ public class WebCrawlerSourceAgentProvider extends AbstractComposableAgentProvid
                                 """)
         @JsonProperty("source-record-headers")
         private Map<String, String> sourceRecordHeaders;
+
+        @ConfigProperty(
+                description =
+                        """
+                       Write a message to this topic periodically with a summary of the activity in the source.
+                                """)
+        @JsonProperty("source-activity-summary-topic")
+        private String sourceActivitySummaryTopic;
+
+        @ConfigProperty(
+                description =
+                        """
+                       List of events (comma separated) to include in the source activity summary. ('new', 'unchanged', 'unchanged', 'deleted')
+                       To include all: 'new,changed,unchanged,deleted'.
+                       Use this property to disable the source activity summary (by leaving default to empty).
+                                """)
+        @JsonProperty("source-activity-summary-events")
+        private String sourceActivitySummaryEvents;
+
+        @ConfigProperty(
+                defaultValue = "60",
+                description =
+                        """
+                        Trigger source activity summary emission when this number of events have been detected, even if the time threshold has not been reached yet.
+                                """)
+        @JsonProperty("source-activity-summary-events-threshold")
+        private int sourceActivitySummaryNumEventsThreshold;
+
+        @ConfigProperty(
+                description =
+                        """
+                        Trigger source activity summary emission every time this time threshold has been reached.
+                                """)
+        @JsonProperty("source-activity-summary-time-seconds-threshold")
+        private int sourceActivitySummaryTimeSecondsThreshold;
     }
 }

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/WebCrawlerSourceIT.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/WebCrawlerSourceIT.java
@@ -26,7 +26,6 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
@@ -117,8 +116,8 @@ class WebCrawlerSourceIT extends AbstractKafkaApplicationRunner {
 
             try (KafkaConsumer<String, String> deletedDocumentsConsumer =
                             createConsumer("deleted-documents");
-                 KafkaConsumer<String, String> activitiesConsumer =
-                         createConsumer("activities");
+                    KafkaConsumer<String, String> activitiesConsumer =
+                            createConsumer("activities");
                     KafkaConsumer<String, String> consumer =
                             createConsumer(applicationRuntime.getGlobal("output-topic")); ) {
 
@@ -164,7 +163,6 @@ class WebCrawlerSourceIT extends AbstractKafkaApplicationRunner {
                                 "%s/thirdPage.html"
                                         .formatted(wireMockRuntimeInfo.getHttpBaseUrl())));
 
-
                 waitForMessages(
                         activitiesConsumer,
                         List.of(
@@ -178,23 +176,29 @@ class WebCrawlerSourceIT extends AbstractKafkaApplicationRunner {
                                         List<Map<String, Object>> newUrls =
                                                 (List<Map<String, Object>>) map.get("newUrls");
                                         List<Map<String, Object>> changed =
-                                                (List<Map<String, Object>>)
-                                                        map.get("changedUrls");
+                                                (List<Map<String, Object>>) map.get("changedUrls");
                                         List<Map<String, Object>> unchanged =
                                                 (List<Map<String, Object>>)
                                                         map.get("unchangedUrls");
                                         List<Map<String, Object>> deleted =
-                                                (List<Map<String, Object>>)
-                                                        map.get("deletedUrls");
+                                                (List<Map<String, Object>>) map.get("deletedUrls");
                                         assertTrue(changed.isEmpty());
                                         assertTrue(unchanged.isEmpty());
                                         assertTrue(deleted.isEmpty());
                                         assertEquals(2, newUrls.size());
                                         assertEquals(
-                                                "%s/index.html".formatted(wireMockRuntimeInfo.getHttpBaseUrl()), newUrls.get(0).get("url"));
+                                                "%s/index.html"
+                                                        .formatted(
+                                                                wireMockRuntimeInfo
+                                                                        .getHttpBaseUrl()),
+                                                newUrls.get(0).get("url"));
                                         assertNotNull(newUrls.get(0).get("detectedAt"));
                                         assertEquals(
-                                                "%s/secondPage.html".formatted(wireMockRuntimeInfo.getHttpBaseUrl()), newUrls.get(1).get("url"));
+                                                "%s/secondPage.html"
+                                                        .formatted(
+                                                                wireMockRuntimeInfo
+                                                                        .getHttpBaseUrl()),
+                                                newUrls.get(1).get("url"));
                                         assertNotNull(newUrls.get(1).get("detectedAt"));
                                     }
                                 },
@@ -208,23 +212,29 @@ class WebCrawlerSourceIT extends AbstractKafkaApplicationRunner {
                                         List<Map<String, Object>> newUrls =
                                                 (List<Map<String, Object>>) map.get("newUrls");
                                         List<Map<String, Object>> changed =
-                                                (List<Map<String, Object>>)
-                                                        map.get("changedUrls");
+                                                (List<Map<String, Object>>) map.get("changedUrls");
                                         List<Map<String, Object>> unchanged =
                                                 (List<Map<String, Object>>)
                                                         map.get("unchangedUrls");
                                         List<Map<String, Object>> deleted =
-                                                (List<Map<String, Object>>)
-                                                        map.get("deletedUrls");
+                                                (List<Map<String, Object>>) map.get("deletedUrls");
                                         assertTrue(changed.isEmpty());
                                         assertTrue(unchanged.isEmpty());
                                         assertEquals(1, deleted.size());
                                         assertEquals(1, newUrls.size());
                                         assertEquals(
-                                                "%s/thirdPage.html".formatted(wireMockRuntimeInfo.getHttpBaseUrl()), newUrls.get(0).get("url"));
+                                                "%s/thirdPage.html"
+                                                        .formatted(
+                                                                wireMockRuntimeInfo
+                                                                        .getHttpBaseUrl()),
+                                                newUrls.get(0).get("url"));
                                         assertNotNull(newUrls.get(0).get("detectedAt"));
                                         assertEquals(
-                                                "%s/thirdPage.html".formatted(wireMockRuntimeInfo.getHttpBaseUrl()), deleted.get(0).get("url"));
+                                                "%s/thirdPage.html"
+                                                        .formatted(
+                                                                wireMockRuntimeInfo
+                                                                        .getHttpBaseUrl()),
+                                                deleted.get(0).get("url"));
                                         assertNotNull(deleted.get(0).get("detectedAt"));
                                     }
                                 }));


### PR DESCRIPTION
To enable the new notification, these are the configs:
```
source-activity-summary-topic: "s3-bucket-activity"
source-activity-summary-events: "new,changed,unchanged,deleted" # type of events to include, if empty or default this feature is disabled
source-activity-summary-events-threshold: 0 # number of events to force the notification to be sent out, even if time is not passed yet 
source-activity-summary-time-seconds-threshold: 5 # seconds between the first event detected to trigger the notification, if no events, no notification will be sent 
```