### PR TITLE
gateways: allow authorization via http header

### DIFF
--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/AuthenticationInterceptor.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/AuthenticationInterceptor.java
@@ -60,7 +60,7 @@ public class AuthenticationInterceptor implements HandshakeInterceptor {
             final Map<String, String> vars =
                     antPathMatcher.extractUriTemplateVariables(handler.path(), path);
             final GatewayRequestContext gatewayRequestContext =
-                    gatewayRequestHandler.validateRequest(
+                    gatewayRequestHandler.validateWebSocketRequest(
                             handler.tenantFromPath(vars, querystring),
                             handler.applicationIdFromPath(vars, querystring),
                             handler.gatewayFromPath(vars, querystring),

--- a/langstream-api/src/main/java/ai/langstream/api/model/Gateway.java
+++ b/langstream-api/src/main/java/ai/langstream/api/model/Gateway.java
@@ -62,11 +62,26 @@ public final class Gateway {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class Authentication {
+        public enum HttpCredentialsSource {
+            header,
+            query
+        }
+
+        public Authentication(
+                String provider, Map<String, Object> configuration, boolean allowTestMode) {
+            this.provider = provider;
+            this.configuration = configuration;
+            this.allowTestMode = allowTestMode;
+        }
+
         private String provider;
         private Map<String, Object> configuration;
 
         @JsonProperty("allow-test-mode")
         private boolean allowTestMode = true;
+
+        @JsonProperty("http-credentials-source")
+        private HttpCredentialsSource httpAuthenticationSource = HttpCredentialsSource.query;
     }
 
     public record KeyValueComparison(

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/gateway/ChatGatewayCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/gateway/ChatGatewayCmd.java
@@ -232,37 +232,40 @@ public class ChatGatewayCmd extends BaseGatewayCmd {
             }
             final String url =
                     validateGatewayAndGetUrl(
-                            applicationId,
-                            chatGatewayId,
-                            Gateways.Gateway.TYPE_CHAT,
-                            finalParams,
-                            consumeGatewayOptions,
-                            credentials,
-                            testCredentials,
-                            Protocols.ws);
+                                    applicationId,
+                                    chatGatewayId,
+                                    Gateways.Gateway.TYPE_CHAT,
+                                    finalParams,
+                                    consumeGatewayOptions,
+                                    credentials,
+                                    testCredentials,
+                                    Protocols.ws)
+                            .getUrl();
             return new ChatGatewayConnection(url, connectTimeout);
         }
 
         final String consumePath =
                 validateGatewayAndGetUrl(
-                        applicationId,
-                        consumeFromGatewayId,
-                        Gateways.Gateway.TYPE_CONSUME,
-                        params,
-                        consumeGatewayOptions,
-                        credentials,
-                        testCredentials,
-                        Protocols.ws);
+                                applicationId,
+                                consumeFromGatewayId,
+                                Gateways.Gateway.TYPE_CONSUME,
+                                params,
+                                consumeGatewayOptions,
+                                credentials,
+                                testCredentials,
+                                Protocols.ws)
+                        .getUrl();
         final String producePath =
                 validateGatewayAndGetUrl(
-                        applicationId,
-                        produceToGatewayId,
-                        Gateways.Gateway.TYPE_PRODUCE,
-                        params,
-                        Map.of(),
-                        credentials,
-                        testCredentials,
-                        Protocols.ws);
+                                applicationId,
+                                produceToGatewayId,
+                                Gateways.Gateway.TYPE_PRODUCE,
+                                params,
+                                Map.of(),
+                                credentials,
+                                testCredentials,
+                                Protocols.ws)
+                        .getUrl();
         return new ProduceConsumeGatewaysConnection(consumePath, producePath, connectTimeout);
     }
 

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/gateway/ConsumeGatewayCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/gateway/ConsumeGatewayCmd.java
@@ -77,14 +77,15 @@ public class ConsumeGatewayCmd extends BaseGatewayCmd {
         }
         final String consumePath =
                 validateGatewayAndGetUrl(
-                        applicationId,
-                        gatewayId,
-                        Gateways.Gateway.TYPE_CONSUME,
-                        params,
-                        options,
-                        credentials,
-                        testCredentials,
-                        Protocols.ws);
+                                applicationId,
+                                gatewayId,
+                                Gateways.Gateway.TYPE_CONSUME,
+                                params,
+                                options,
+                                credentials,
+                                testCredentials,
+                                Protocols.ws)
+                        .getUrl();
 
         final Duration connectTimeout =
                 connectTimeoutSeconds > 0 ? Duration.ofSeconds(connectTimeoutSeconds) : null;

--- a/langstream-cli/src/test/java/ai/langstream/cli/commands/applications/CommandTestBase.java
+++ b/langstream-cli/src/test/java/ai/langstream/cli/commands/applications/CommandTestBase.java
@@ -53,8 +53,8 @@ public class CommandTestBase {
         cliYaml = Path.of(tempDir.toFile().getAbsolutePath(), "cli.yaml");
         final String config =
                 String.format(
-                        "webServiceUrl: http://localhost:%d\ntenant: %s",
-                        wmRuntimeInfo.getHttpPort(), TENANT);
+                        "webServiceUrl: http://localhost:%d\napiGatewayUrl: ws://localhost:%d\ntenant: %s",
+                        wmRuntimeInfo.getHttpPort(), wmRuntimeInfo.getHttpPort(), TENANT);
         Files.writeString(cliYaml, config);
         wireMock = wmRuntimeInfo.getWireMock();
         wireMockBaseUrl = wmRuntimeInfo.getHttpBaseUrl();

--- a/langstream-cli/src/test/java/ai/langstream/cli/commands/applications/GatewaysCmdTest.java
+++ b/langstream-cli/src/test/java/ai/langstream/cli/commands/applications/GatewaysCmdTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.cli.commands.applications;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class GatewaysCmdTest extends CommandTestBase {
+
+    @Test
+    public void testProduceHttpQuery() throws Exception {
+        Map<String, Object> response =
+                Map.of(
+                        "application",
+                        Map.of(
+                                "" + "gateways",
+                                Map.of(
+                                        "gateways",
+                                        List.of(
+                                                Map.of(
+                                                        "id", "g1",
+                                                        "type", "produce",
+                                                        "topic", "t1",
+                                                        "authentication",
+                                                                Map.of(
+                                                                        "provider", "basic",
+                                                                        "http-credentials-source",
+                                                                                "query"))))));
+
+        wireMock.register(
+                WireMock.get(String.format("/api/applications/%s/my-app?stats=false", TENANT))
+                        .willReturn(WireMock.ok(new ObjectMapper().writeValueAsString(response))));
+
+        wireMock.register(
+                WireMock.post(
+                                String.format(
+                                        "/api/gateways/produce/%s/my-app/g1?credentials=myc",
+                                        TENANT))
+                        .withRequestBody(
+                                equalToJson("{\"key\":null,\"value\":\"hello\",\"headers\":null}"))
+                        .willReturn(WireMock.ok()));
+
+        CommandResult result =
+                executeCommand(
+                        "gateway",
+                        "produce",
+                        "my-app",
+                        "g1",
+                        "-c",
+                        "myc",
+                        "--protocol",
+                        "http",
+                        "-v",
+                        "hello");
+        assertEquals(0, result.exitCode());
+        assertEquals("", result.err());
+    }
+
+    @Test
+    public void testProduceHttpHeader() throws Exception {
+        Map<String, Object> response =
+                Map.of(
+                        "application",
+                        Map.of(
+                                "" + "gateways",
+                                Map.of(
+                                        "gateways",
+                                        List.of(
+                                                Map.of(
+                                                        "id", "g1",
+                                                        "type", "produce",
+                                                        "topic", "t1",
+                                                        "authentication",
+                                                                Map.of(
+                                                                        "provider", "basic",
+                                                                        "http-credentials-source",
+                                                                                "header"))))));
+
+        wireMock.register(
+                WireMock.get(String.format("/api/applications/%s/my-app?stats=false", TENANT))
+                        .willReturn(WireMock.ok(new ObjectMapper().writeValueAsString(response))));
+
+        wireMock.register(
+                WireMock.post(String.format("/api/gateways/produce/%s/my-app/g1", TENANT))
+                        .withHeader("Authorization", equalTo("myc"))
+                        .withRequestBody(
+                                equalToJson("{\"key\":null,\"value\":\"hello\",\"headers\":null}"))
+                        .willReturn(WireMock.ok()));
+
+        CommandResult result =
+                executeCommand(
+                        "gateway",
+                        "produce",
+                        "my-app",
+                        "g1",
+                        "-c",
+                        "myc",
+                        "--protocol",
+                        "http",
+                        "-v",
+                        "hello");
+        assertEquals(0, result.exitCode());
+        assertEquals("", result.err());
+    }
+}

--- a/langstream-core/src/main/java/ai/langstream/impl/common/ApplicationPlaceholderResolver.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/common/ApplicationPlaceholderResolver.java
@@ -229,7 +229,8 @@ public class ApplicationPlaceholderResolver {
                         new Gateway.Authentication(
                                 authentication.getProvider(),
                                 resolveMap(context, gateway.getAuthentication().getConfiguration()),
-                                authentication.isAllowTestMode());
+                                authentication.isAllowTestMode(),
+                                authentication.getHttpAuthenticationSource());
             }
 
             final String topic = resolveValueAsString(context, gateway.getTopic());


### PR DESCRIPTION
Added flag to the gateway inside `authentication` named `http-credentials-source` defaults to `query`. Possible values are `query` and `header`.

If using an http endpoint, the api gateway will check this gateway flag to gather the credentials. This apply both to `produce` and `service` endpoints.

CLI has been updated to decide the auth mode based on the gateway config (only for produce with --protocol http) 