### PR TITLE
gateways: allow full value body in payload

### DIFF
--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/api/ProducePayload.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/api/ProducePayload.java
@@ -15,30 +15,32 @@
  */
 package ai.langstream.apigateway.api;
 
-import lombok.AllArgsConstructor;
-
 import java.util.Map;
 
 public interface ProducePayload {
 
     ProduceRequest toProduceRequest();
-    record ValuePayload(Object value) implements ProducePayload {
-            @Override
-            public Object key() {
-                return null;
-            }
 
-            @Override
-            public Map<String, String> headers() {
-                return null;
-            }
+    record ValuePayload(Object value) implements ProducePayload {
+        @Override
+        public Object key() {
+            return null;
+        }
+
+        @Override
+        public Map<String, String> headers() {
+            return null;
+        }
 
         @Override
         public ProduceRequest toProduceRequest() {
             return new ProduceRequest(null, value, null);
         }
     }
+
     Object key();
+
     Object value();
+
     Map<String, String> headers();
 }

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/api/ProducePayload.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/api/ProducePayload.java
@@ -15,12 +15,30 @@
  */
 package ai.langstream.apigateway.api;
 
+import lombok.AllArgsConstructor;
+
 import java.util.Map;
 
-public record ProduceRequest(Object key, Object value, Map<String, String> headers) implements ProducePayload {
+public interface ProducePayload {
 
-    @Override
-    public ProduceRequest toProduceRequest() {
-        return this;
+    ProduceRequest toProduceRequest();
+    record ValuePayload(Object value) implements ProducePayload {
+            @Override
+            public Object key() {
+                return null;
+            }
+
+            @Override
+            public Map<String, String> headers() {
+                return null;
+            }
+
+        @Override
+        public ProduceRequest toProduceRequest() {
+            return new ProduceRequest(null, value, null);
+        }
     }
+    Object key();
+    Object value();
+    Map<String, String> headers();
 }

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/api/ProduceRequest.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/api/ProduceRequest.java
@@ -17,7 +17,8 @@ package ai.langstream.apigateway.api;
 
 import java.util.Map;
 
-public record ProduceRequest(Object key, Object value, Map<String, String> headers) implements ProducePayload {
+public record ProduceRequest(Object key, Object value, Map<String, String> headers)
+        implements ProducePayload {
 
     @Override
     public ProduceRequest toProduceRequest() {

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/ProduceGateway.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/ProduceGateway.java
@@ -35,11 +35,7 @@ import ai.langstream.apigateway.websocket.AuthenticatedGatewayRequestContext;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
@@ -213,6 +209,7 @@ public class ProduceGateway implements AutoCloseable {
 
     public static ProducePayload parseProduceRequest(
             String payload, Gateway.ProducePayloadSchema payloadSchema) throws ProduceException {
+        Objects.requireNonNull(payloadSchema);
         try {
             if (payloadSchema == Gateway.ProducePayloadSchema.full) {
                 return mapper.readValue(payload, ProduceRequest.class);

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/ProduceGateway.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/ProduceGateway.java
@@ -27,6 +27,7 @@ import ai.langstream.api.runner.topics.TopicProducer;
 import ai.langstream.api.runtime.ClusterRuntimeRegistry;
 import ai.langstream.api.runtime.StreamingClusterRuntime;
 import ai.langstream.api.runtime.Topic;
+import ai.langstream.apigateway.api.ProducePayload;
 import ai.langstream.apigateway.api.ProduceRequest;
 import ai.langstream.apigateway.api.ProduceResponse;
 import ai.langstream.apigateway.util.StreamingClusterUtil;
@@ -204,21 +205,23 @@ public class ProduceGateway implements AutoCloseable {
         return new TopicProducerAndRuntime(topicProducer, runtime);
     }
 
-    public void produceMessage(String payload) throws ProduceException {
-        final ProduceRequest produceRequest = parseProduceRequest(payload);
-        produceMessage(produceRequest);
+    public void produceMessage(String payload, Gateway.ProducePayloadSchema payloadSchema) throws ProduceException {
+        final ProducePayload producePayload = parseProduceRequest(payload, payloadSchema);
+        produceMessage(producePayload.toProduceRequest());
     }
 
-    public static ProduceRequest parseProduceRequest(String payload) throws ProduceException {
-        final ProduceRequest produceRequest;
+    public static ProducePayload parseProduceRequest(String payload, Gateway.ProducePayloadSchema payloadSchema) throws ProduceException {
         try {
-            produceRequest = mapper.readValue(payload, ProduceRequest.class);
+            if (payloadSchema == Gateway.ProducePayloadSchema.full) {
+                return mapper.readValue(payload, ProduceRequest.class);
+            }
+            Map value = mapper.readValue(payload, Map.class);
+            return new ProducePayload.ValuePayload(value);
         } catch (JsonProcessingException err) {
             throw new ProduceException(
                     "Error while parsing JSON payload: " + err.getMessage(),
                     ProduceResponse.Status.BAD_REQUEST);
         }
-        return produceRequest;
     }
 
     public void produceMessage(ProduceRequest produceRequest) throws ProduceException {

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/ProduceGateway.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/ProduceGateway.java
@@ -205,12 +205,14 @@ public class ProduceGateway implements AutoCloseable {
         return new TopicProducerAndRuntime(topicProducer, runtime);
     }
 
-    public void produceMessage(String payload, Gateway.ProducePayloadSchema payloadSchema) throws ProduceException {
+    public void produceMessage(String payload, Gateway.ProducePayloadSchema payloadSchema)
+            throws ProduceException {
         final ProducePayload producePayload = parseProduceRequest(payload, payloadSchema);
         produceMessage(producePayload.toProduceRequest());
     }
 
-    public static ProducePayload parseProduceRequest(String payload, Gateway.ProducePayloadSchema payloadSchema) throws ProduceException {
+    public static ProducePayload parseProduceRequest(
+            String payload, Gateway.ProducePayloadSchema payloadSchema) throws ProduceException {
         try {
             if (payloadSchema == Gateway.ProducePayloadSchema.full) {
                 return mapper.readValue(payload, ProduceRequest.class);

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/http/GatewayResource.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/http/GatewayResource.java
@@ -126,15 +126,19 @@ public class GatewayResource {
                             context.gateway().getProduceOptions(), authContext);
             produceGateway.start(context.gateway().getTopic(), commonHeaders, authContext);
 
-            Gateway.ProducePayloadSchema producePayloadSchema = context.gateway().getProduceOptions() == null ?
-                    Gateway.ProducePayloadSchema.full : context.gateway().getProduceOptions().payloadSchema();
-            final ProducePayload producePayload = parseProducePayload(request, payload, producePayloadSchema);
+            Gateway.ProducePayloadSchema producePayloadSchema =
+                    context.gateway().getProduceOptions() == null
+                            ? Gateway.ProducePayloadSchema.full
+                            : context.gateway().getProduceOptions().payloadSchema();
+            final ProducePayload producePayload =
+                    parseProducePayload(request, payload, producePayloadSchema);
             produceGateway.produceMessage(producePayload.toProduceRequest());
             return ProduceResponse.OK;
         }
     }
 
-    private ProducePayload parseProducePayload(WebRequest request, String payload, Gateway.ProducePayloadSchema payloadSchema)
+    private ProducePayload parseProducePayload(
+            WebRequest request, String payload, Gateway.ProducePayloadSchema payloadSchema)
             throws ProduceGateway.ProduceException {
         final String contentType = request.getHeader("Content-Type");
         if (contentType == null || contentType.equals(MediaType.TEXT_PLAIN_VALUE)) {
@@ -265,9 +269,12 @@ public class GatewayResource {
                     new String(
                             servletRequest.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
 
-            Gateway.ProducePayloadSchema producePayloadSchema = context.gateway().getServiceOptions() == null ?
-                    Gateway.ProducePayloadSchema.full : context.gateway().getServiceOptions().getPayloadSchema();
-            final ProducePayload producePayload = parseProducePayload(request, payload, producePayloadSchema);
+            Gateway.ProducePayloadSchema producePayloadSchema =
+                    context.gateway().getServiceOptions() == null
+                            ? Gateway.ProducePayloadSchema.full
+                            : context.gateway().getServiceOptions().getPayloadSchema();
+            final ProducePayload producePayload =
+                    parseProducePayload(request, payload, producePayloadSchema);
             return handleServiceWithTopics(producePayload, authContext);
         }
     }

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/handlers/AbstractHandler.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/handlers/AbstractHandler.java
@@ -331,7 +331,10 @@ public abstract class AbstractHandler extends TextWebSocketHandler {
         context.attributes().put(ATTRIBUTE_PRODUCE_GATEWAY, produceGateway);
     }
 
-    protected void produceMessage(WebSocketSession webSocketSession, TextMessage message, Gateway.ProducePayloadSchema payloadSchema)
+    protected void produceMessage(
+            WebSocketSession webSocketSession,
+            TextMessage message,
+            Gateway.ProducePayloadSchema payloadSchema)
             throws IOException {
         try {
             final AuthenticatedGatewayRequestContext context = getContext(webSocketSession);

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/handlers/AbstractHandler.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/handlers/AbstractHandler.java
@@ -331,13 +331,13 @@ public abstract class AbstractHandler extends TextWebSocketHandler {
         context.attributes().put(ATTRIBUTE_PRODUCE_GATEWAY, produceGateway);
     }
 
-    protected void produceMessage(WebSocketSession webSocketSession, TextMessage message)
+    protected void produceMessage(WebSocketSession webSocketSession, TextMessage message, Gateway.ProducePayloadSchema payloadSchema)
             throws IOException {
         try {
             final AuthenticatedGatewayRequestContext context = getContext(webSocketSession);
             final ProduceGateway produceGateway =
                     (ProduceGateway) context.attributes().get(ATTRIBUTE_PRODUCE_GATEWAY);
-            produceGateway.produceMessage(message.getPayload());
+            produceGateway.produceMessage(message.getPayload(), payloadSchema);
             webSocketSession.sendMessage(
                     new TextMessage(mapper.writeValueAsString(ProduceResponse.OK)));
         } catch (ProduceGateway.ProduceException exception) {

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/handlers/ChatHandler.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/handlers/ChatHandler.java
@@ -175,8 +175,10 @@ public class ChatHandler extends AbstractHandler {
             AuthenticatedGatewayRequestContext context,
             TextMessage message)
             throws Exception {
-        Gateway.ProducePayloadSchema producePayloadSchema = context.gateway().getChatOptions() == null ?
-                Gateway.ProducePayloadSchema.full : context.gateway().getChatOptions().getPayloadSchema();
+        Gateway.ProducePayloadSchema producePayloadSchema =
+                context.gateway().getChatOptions() == null
+                        ? Gateway.ProducePayloadSchema.full
+                        : context.gateway().getChatOptions().getPayloadSchema();
         produceMessage(webSocketSession, message, producePayloadSchema);
     }
 

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/handlers/ChatHandler.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/handlers/ChatHandler.java
@@ -175,7 +175,9 @@ public class ChatHandler extends AbstractHandler {
             AuthenticatedGatewayRequestContext context,
             TextMessage message)
             throws Exception {
-        produceMessage(webSocketSession, message);
+        Gateway.ProducePayloadSchema producePayloadSchema = context.gateway().getChatOptions() == null ?
+                Gateway.ProducePayloadSchema.full : context.gateway().getChatOptions().getPayloadSchema();
+        produceMessage(webSocketSession, message, producePayloadSchema);
     }
 
     @Override

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/handlers/ProduceHandler.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/handlers/ProduceHandler.java
@@ -104,7 +104,9 @@ public class ProduceHandler extends AbstractHandler {
             AuthenticatedGatewayRequestContext context,
             TextMessage message)
             throws Exception {
-        produceMessage(webSocketSession, message);
+        Gateway.ProducePayloadSchema producePayloadSchema = context.gateway().getProduceOptions() == null ?
+                Gateway.ProducePayloadSchema.full : context.gateway().getProduceOptions().payloadSchema();
+        produceMessage(webSocketSession, message, producePayloadSchema);
     }
 
     @Override

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/handlers/ProduceHandler.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/handlers/ProduceHandler.java
@@ -104,8 +104,10 @@ public class ProduceHandler extends AbstractHandler {
             AuthenticatedGatewayRequestContext context,
             TextMessage message)
             throws Exception {
-        Gateway.ProducePayloadSchema producePayloadSchema = context.gateway().getProduceOptions() == null ?
-                Gateway.ProducePayloadSchema.full : context.gateway().getProduceOptions().payloadSchema();
+        Gateway.ProducePayloadSchema producePayloadSchema =
+                context.gateway().getProduceOptions() == null
+                        ? Gateway.ProducePayloadSchema.full
+                        : context.gateway().getProduceOptions().payloadSchema();
         produceMessage(webSocketSession, message, producePayloadSchema);
     }
 

--- a/langstream-api-gateway/src/test/java/ai/langstream/apigateway/http/GatewayResourceTest.java
+++ b/langstream-api-gateway/src/test/java/ai/langstream/apigateway/http/GatewayResourceTest.java
@@ -44,7 +44,6 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import io.micrometer.core.instrument.Metrics;
-
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -57,7 +56,6 @@ import java.util.Map;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
-
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.concurrent.BasicThreadFactory;
@@ -80,7 +78,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @SpringBootTest(
         webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
         properties = {
-                "spring.main.allow-bean-definition-overriding=true",
+            "spring.main.allow-bean-definition-overriding=true",
         })
 @WireMockTest
 @Slf4j
@@ -114,19 +112,19 @@ abstract class GatewayResourceTest {
                 WireMock.get("/agent-endpoint").willReturn(WireMock.ok("agent response ROOT")));
         ApplicationStore mock = Mockito.mock(ApplicationStore.class);
         doAnswer(
-                invocationOnMock -> {
-                    final StoredApplication storedApplication = new StoredApplication();
-                    final Application application = buildApp(instanceYaml);
-                    storedApplication.setInstance(application);
-                    return storedApplication;
-                })
+                        invocationOnMock -> {
+                            final StoredApplication storedApplication = new StoredApplication();
+                            final Application application = buildApp(instanceYaml);
+                            storedApplication.setInstance(application);
+                            return storedApplication;
+                        })
                 .when(mock)
                 .get(anyString(), anyString(), anyBoolean());
         doAnswer(
-                invocationOnMock ->
-                        ApplicationSpecs.builder()
-                                .application(buildApp(instanceYaml))
-                                .build())
+                        invocationOnMock ->
+                                ApplicationSpecs.builder()
+                                        .application(buildApp(instanceYaml))
+                                        .build())
                 .when(mock)
                 .getSpecs(anyString(), anyString());
 
@@ -147,8 +145,7 @@ abstract class GatewayResourceTest {
         return props;
     }
 
-    @Autowired
-    private TopicConnectionsRuntimeProviderBean topicConnectionsRuntimeProvider;
+    @Autowired private TopicConnectionsRuntimeProviderBean topicConnectionsRuntimeProvider;
 
     @NotNull
     private static Application buildApp(String instanceYaml) throws Exception {
@@ -166,10 +163,11 @@ abstract class GatewayResourceTest {
                                             map.put("name", t.topic());
                                             map.put("creation-mode", "create-if-not-exists");
                                             if (t.schemaType() != null) {
-                                                map.put("schema", Map.of(
-                                                        "type", t.schemaType(),
-                                                        "schema", t.schemaDef()
-                                                ));
+                                                map.put(
+                                                        "schema",
+                                                        Map.of(
+                                                                "type", t.schemaType(),
+                                                                "schema", t.schemaDef()));
                                             }
                                             return map;
                                         })
@@ -188,13 +186,10 @@ abstract class GatewayResourceTest {
         return application;
     }
 
-    @LocalServerPort
-    int port;
+    @LocalServerPort int port;
 
-    @Autowired
-    MockMvc mockMvc;
-    @Autowired
-    ApplicationStore store;
+    @Autowired MockMvc mockMvc;
+    @Autowired ApplicationStore store;
 
     static WireMock wireMock;
     static String wireMockBaseUrl;
@@ -327,7 +322,9 @@ abstract class GatewayResourceTest {
                                         .id("produce-value")
                                         .type(Gateway.GatewayType.produce)
                                         .topic(topic)
-                                        .produceOptions(new Gateway.ProduceOptions(null, Gateway.ProducePayloadSchema.value))
+                                        .produceOptions(
+                                                new Gateway.ProduceOptions(
+                                                        null, Gateway.ProducePayloadSchema.value))
                                         .build(),
                                 Gateway.builder()
                                         .id("consume")
@@ -665,7 +662,7 @@ abstract class GatewayResourceTest {
                 baseUrl + "?test-credentials=test-user-password", "{\"value\": \"my-value\"}");
         produceJsonAndExpectUnauthorized(
                 ("http://localhost:%d/api/gateways/produce/tenant1/application1/produce-no-test?test-credentials=test"
-                        + "-user-password")
+                                + "-user-password")
                         .formatted(port),
                 "{\"value\": \"my-value\"}");
     }
@@ -751,14 +748,22 @@ abstract class GatewayResourceTest {
                                         .type(Gateway.GatewayType.service)
                                         .serviceOptions(
                                                 new Gateway.ServiceOptions(
-                                                        null, inputTopic, outputTopic, Gateway.ProducePayloadSchema.full, List.of()))
+                                                        null,
+                                                        inputTopic,
+                                                        outputTopic,
+                                                        Gateway.ProducePayloadSchema.full,
+                                                        List.of()))
                                         .build(),
                                 Gateway.builder()
                                         .id("svc-value")
                                         .type(Gateway.GatewayType.service)
                                         .serviceOptions(
                                                 new Gateway.ServiceOptions(
-                                                        null, inputTopic, outputTopic, Gateway.ProducePayloadSchema.value, List.of()))
+                                                        null,
+                                                        inputTopic,
+                                                        outputTopic,
+                                                        Gateway.ProducePayloadSchema.value,
+                                                        List.of()))
                                         .build()));
 
         final String url =
@@ -781,10 +786,13 @@ abstract class GatewayResourceTest {
 
         assertMessageContent(
                 new MsgRecord("my-key2", "{\"test\":\"hello\"}", Map.of("header1", "value1")),
-                produceJsonAndGetBody(url, "{\"key\": \"my-key2\", \"value\": {\"test\":\"hello\"}, \"headers\": {\"header1\":\"value1\"}}"));
+                produceJsonAndGetBody(
+                        url,
+                        "{\"key\": \"my-key2\", \"value\": {\"test\":\"hello\"}, \"headers\": {\"header1\":\"value1\"}}"));
 
         final String valueUrl =
-                "http://localhost:%d/api/gateways/service/tenant1/application1/svc-value".formatted(port);
+                "http://localhost:%d/api/gateways/service/tenant1/application1/svc-value"
+                        .formatted(port);
         assertMessageContent(
                 new MsgRecord(null, "{\"key\":\"my-key\",\"value\":\"my-value\"}", Map.of()),
                 produceJsonAndGetBody(valueUrl, "{\"key\": \"my-key\", \"value\": \"my-value\"}"));
@@ -807,21 +815,21 @@ abstract class GatewayResourceTest {
                             final String fromTopic = resolveTopicName(logicalFromTopic);
                             final String toTopic = resolveTopicName(logicalToTopic);
                             try (final TopicConsumer consumer =
-                                         runtime.createConsumer(
-                                                 null,
-                                                 streamingCluster,
-                                                 Map.of(
-                                                         "topic",
-                                                         fromTopic,
-                                                         "subscriptionName",
-                                                         "s"));) {
+                                    runtime.createConsumer(
+                                            null,
+                                            streamingCluster,
+                                            Map.of(
+                                                    "topic",
+                                                    fromTopic,
+                                                    "subscriptionName",
+                                                    "s")); ) {
                                 consumer.start();
 
                                 try (final TopicProducer producer =
-                                             runtime.createProducer(
-                                                     null,
-                                                     streamingCluster,
-                                                     Map.of("topic", toTopic));) {
+                                        runtime.createProducer(
+                                                null,
+                                                streamingCluster,
+                                                Map.of("topic", toTopic)); ) {
 
                                     producer.start();
                                     while (true) {
@@ -838,7 +846,13 @@ abstract class GatewayResourceTest {
                                                 fromTopic,
                                                 records);
                                         for (Record record : records) {
-                                            log.info("read record key {} value {} ({})", record.key(), record.value(), record.value() == null ? "NULL" : record.value().getClass());
+                                            log.info(
+                                                    "read record key {} value {} ({})",
+                                                    record.key(),
+                                                    record.value(),
+                                                    record.value() == null
+                                                            ? "NULL"
+                                                            : record.value().getClass());
                                             producer.write(record).get();
                                         }
                                         consumer.commit(records);
@@ -852,7 +866,8 @@ abstract class GatewayResourceTest {
                             } catch (InterruptedException e) {
                                 Thread.currentThread().interrupt();
                             } catch (Throwable e) {
-                                if (e.getCause() != null && e.getCause() instanceof InterruptedException) {
+                                if (e.getCause() != null
+                                        && e.getCause() instanceof InterruptedException) {
                                     Thread.currentThread().interrupt();
                                 } else {
                                     log.error("Error in topic exchange", e);
@@ -865,8 +880,7 @@ abstract class GatewayResourceTest {
                         futuresExecutor);
     }
 
-    private record MsgRecord(Object key, Object value, Map<String, String> headers) {
-    }
+    private record MsgRecord(Object key, Object value, Map<String, String> headers) {}
 
     @SneakyThrows
     private void assertMessageContent(MsgRecord expected, String actual) {
@@ -884,8 +898,7 @@ abstract class GatewayResourceTest {
 
     protected abstract StreamingCluster getStreamingCluster();
 
-    record TopicWithSchema(String topic, String schemaType, String schemaDef) {
-    }
+    record TopicWithSchema(String topic, String schemaType, String schemaDef) {}
 
     private void prepareTopicsForTest(String... topic) throws Exception {
         prepareTopicsForTest(
@@ -895,7 +908,6 @@ abstract class GatewayResourceTest {
                                     return new TopicWithSchema(t, null, null);
                                 })
                         .toArray(TopicWithSchema[]::new));
-
     }
 
     private void prepareTopicsForTest(TopicWithSchema... topic) throws Exception {

--- a/langstream-api-gateway/src/test/java/ai/langstream/apigateway/http/ServiceAgentGatewayResourceTest.java
+++ b/langstream-api-gateway/src/test/java/ai/langstream/apigateway/http/ServiceAgentGatewayResourceTest.java
@@ -200,7 +200,7 @@ class ServiceAgentGatewayResourceTest {
                                         .type(Gateway.GatewayType.service)
                                         .serviceOptions(
                                                 new Gateway.ServiceOptions(
-                                                        "my-agent", null, null, List.of()))
+                                                        "my-agent", null, null, null, List.of()))
                                         .build()));
 
         String url =

--- a/langstream-api-gateway/src/test/java/ai/langstream/apigateway/websocket/handlers/ProduceConsumeHandlerTest.java
+++ b/langstream-api-gateway/src/test/java/ai/langstream/apigateway/websocket/handlers/ProduceConsumeHandlerTest.java
@@ -1445,7 +1445,7 @@ abstract class ProduceConsumeHandlerTest {
                                                 new Gateway.ChatOptions(
                                                         topic,
                                                         topic,
-                                                        null,
+                                                        Gateway.ProducePayloadSchema.full,
                                                         List.of(
                                                                 Gateway.KeyValueComparison
                                                                         .valueFromParameters(

--- a/langstream-api-gateway/src/test/java/ai/langstream/apigateway/websocket/handlers/ProduceConsumeHandlerTest.java
+++ b/langstream-api-gateway/src/test/java/ai/langstream/apigateway/websocket/handlers/ProduceConsumeHandlerTest.java
@@ -1445,6 +1445,7 @@ abstract class ProduceConsumeHandlerTest {
                                                 new Gateway.ChatOptions(
                                                         topic,
                                                         topic,
+                                                        null,
                                                         List.of(
                                                                 Gateway.KeyValueComparison
                                                                         .valueFromParameters(

--- a/langstream-api/src/main/java/ai/langstream/api/model/Gateway.java
+++ b/langstream-api/src/main/java/ai/langstream/api/model/Gateway.java
@@ -84,6 +84,11 @@ public final class Gateway {
         private HttpCredentialsSource httpAuthenticationSource = HttpCredentialsSource.query;
     }
 
+    public enum ProducePayloadSchema {
+        full,
+        value;
+    }
+
     public record KeyValueComparison(
             String key,
             String value,
@@ -138,7 +143,19 @@ public final class Gateway {
         }
     }
 
-    public record ProduceOptions(List<KeyValueComparison> headers) {}
+    public record ProduceOptions(List<KeyValueComparison> headers,
+                                 @JsonProperty("payload-schema") ProducePayloadSchema payloadSchema) {
+
+        public ProduceOptions {
+            if (payloadSchema == null) {
+                payloadSchema = ProducePayloadSchema.full;
+            }
+        }
+
+        public ProduceOptions(List<KeyValueComparison> headers) {
+            this(headers, null);
+        }
+    }
 
     public record ConsumeOptions(ConsumeOptionsFilters filters) {}
 
@@ -154,6 +171,9 @@ public final class Gateway {
 
         @JsonProperty("answers-topic")
         private String answersTopic;
+
+        @JsonProperty("payload-schema")
+        private ProducePayloadSchema payloadSchema = ProducePayloadSchema.full;
 
         List<KeyValueComparison> headers;
     }
@@ -171,6 +191,9 @@ public final class Gateway {
 
         @JsonProperty("output-topic")
         private String outputTopic;
+
+        @JsonProperty("payload-schema")
+        private ProducePayloadSchema payloadSchema = ProducePayloadSchema.full;
 
         List<KeyValueComparison> headers;
     }

--- a/langstream-api/src/main/java/ai/langstream/api/model/Gateway.java
+++ b/langstream-api/src/main/java/ai/langstream/api/model/Gateway.java
@@ -143,8 +143,9 @@ public final class Gateway {
         }
     }
 
-    public record ProduceOptions(List<KeyValueComparison> headers,
-                                 @JsonProperty("payload-schema") ProducePayloadSchema payloadSchema) {
+    public record ProduceOptions(
+            List<KeyValueComparison> headers,
+            @JsonProperty("payload-schema") ProducePayloadSchema payloadSchema) {
 
         public ProduceOptions {
             if (payloadSchema == null) {

--- a/langstream-cli/src/main/java/ai/langstream/cli/api/model/Gateways.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/api/model/Gateways.java
@@ -51,7 +51,9 @@ public class Gateways {
                                         (String) map.get("type"),
                                         (List<String>) map.get("parameters"),
                                         (Map<String, Object>) map.get("authentication"),
-                                        (Map<String, Object>) map.get("chat-options")))
+                                        (Map<String, Object>) map.get("chat-options"),
+                                        (Map<String, Object>) map.get("produce-options"),
+                                        (Map<String, Object>) map.get("service-options")))
                 .collect(Collectors.toList());
     }
 
@@ -71,5 +73,11 @@ public class Gateways {
 
         @JsonProperty("chat-options")
         Map<String, Object> chatOptions;
+
+        @JsonProperty("produce-options")
+        Map<String, Object> produceOptions;
+
+        @JsonProperty("service-options")
+        Map<String, Object> serviceOptions;
     }
 }

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/gateway/BaseGatewayCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/gateway/BaseGatewayCmd.java
@@ -89,7 +89,6 @@ public abstract class BaseGatewayCmd extends BaseCmd {
         private final String url;
         private final Map<String, String> headers;
         private final boolean fullPayloadSchema;
-
     }
 
     protected GatewayRequestInfo validateGatewayAndGetUrl(
@@ -138,7 +137,13 @@ public abstract class BaseGatewayCmd extends BaseCmd {
             if (!type.equals("produce")) {
                 throw new IllegalArgumentException("HTTP protocol is only supported for produce");
             }
-            boolean fullPayloadSchema = gatewayInfo.getProduceOptions() == null || !"value".equals(gatewayInfo.getProduceOptions().getOrDefault("payload-schema", "full"));
+            boolean fullPayloadSchema =
+                    gatewayInfo.getProduceOptions() == null
+                            || !"value"
+                                    .equals(
+                                            gatewayInfo
+                                                    .getProduceOptions()
+                                                    .getOrDefault("payload-schema", "full"));
 
             return new GatewayRequestInfo(
                     String.format(

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/gateway/BaseGatewayCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/gateway/BaseGatewayCmd.java
@@ -88,6 +88,8 @@ public abstract class BaseGatewayCmd extends BaseCmd {
     protected static class GatewayRequestInfo {
         private final String url;
         private final Map<String, String> headers;
+        private final boolean fullPayloadSchema;
+
     }
 
     protected GatewayRequestInfo validateGatewayAndGetUrl(
@@ -136,6 +138,8 @@ public abstract class BaseGatewayCmd extends BaseCmd {
             if (!type.equals("produce")) {
                 throw new IllegalArgumentException("HTTP protocol is only supported for produce");
             }
+            boolean fullPayloadSchema = gatewayInfo.getProduceOptions() == null || !"value".equals(gatewayInfo.getProduceOptions().getOrDefault("payload-schema", "full"));
+
             return new GatewayRequestInfo(
                     String.format(
                             "%s/api/gateways/%s/%s/%s/%s?%s",
@@ -145,7 +149,8 @@ public abstract class BaseGatewayCmd extends BaseCmd {
                             applicationId,
                             gatewayId,
                             computeQueryString(systemParams, params, options)),
-                    httpHeaders);
+                    httpHeaders,
+                    fullPayloadSchema);
         }
 
         return new GatewayRequestInfo(
@@ -157,7 +162,8 @@ public abstract class BaseGatewayCmd extends BaseCmd {
                         applicationId,
                         gatewayId,
                         computeQueryString(systemParams, params, options)),
-                httpHeaders);
+                httpHeaders,
+                true);
     }
 
     private String getTenant() {

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/gateway/ProduceGatewayCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/gateway/ProduceGatewayCmd.java
@@ -107,8 +107,20 @@ public class ProduceGatewayCmd extends BaseGatewayCmd {
         final Duration connectTimeout =
                 connectTimeoutSeconds > 0 ? Duration.ofSeconds(connectTimeoutSeconds) : null;
 
-        final ProduceRequest produceRequest = new ProduceRequest(messageKey, messageValue, headers);
-        final String json = messageMapper.writeValueAsString(produceRequest);
+        final String json;
+        if (gatewayRequestInfo.isFullPayloadSchema()) {
+            final ProduceRequest produceRequest = new ProduceRequest(messageKey, messageValue, headers);
+            json = messageMapper.writeValueAsString(produceRequest);
+        } else {
+            if (messageKey != null) {
+                log("Warning: key is ignored when the payload schema is value");
+            }
+            if (headers != null && !headers.isEmpty()) {
+                log("Warning: headers are ignored when the payload schema is value");
+            }
+            json = messageMapper.writeValueAsString(messageValue);
+        }
+
 
         if (protocol == Protocols.http) {
             produceHttp(

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/gateway/ProduceGatewayCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/gateway/ProduceGatewayCmd.java
@@ -109,7 +109,8 @@ public class ProduceGatewayCmd extends BaseGatewayCmd {
 
         final String json;
         if (gatewayRequestInfo.isFullPayloadSchema()) {
-            final ProduceRequest produceRequest = new ProduceRequest(messageKey, messageValue, headers);
+            final ProduceRequest produceRequest =
+                    new ProduceRequest(messageKey, messageValue, headers);
             json = messageMapper.writeValueAsString(produceRequest);
         } else {
             if (messageKey != null) {
@@ -120,7 +121,6 @@ public class ProduceGatewayCmd extends BaseGatewayCmd {
             }
             json = messageMapper.writeValueAsString(messageValue);
         }
-
 
         if (protocol == Protocols.http) {
             produceHttp(

--- a/langstream-pulsar-runtime/src/main/java/ai/langstream/pulsar/runner/PulsarTopicConnectionsRuntimeProvider.java
+++ b/langstream-pulsar-runtime/src/main/java/ai/langstream/pulsar/runner/PulsarTopicConnectionsRuntimeProvider.java
@@ -729,18 +729,14 @@ public class PulsarTopicConnectionsRuntimeProvider implements TopicConnectionsRu
                 }
                 log.info("Writing message {} to topic {} with schema {}", r, topic, schema);
 
+                Map<String, String> properties = new HashMap<>();
+                for (Header header : r.headers()) {
+                    properties.put(header.key(), header.valueAsString());
+                }
                 TypedMessageBuilder<K> message =
-                        producer.newMessage()
-                                .properties(
-                                        r.headers().stream()
-                                                .collect(
-                                                        Collectors.toMap(
-                                                                Header::key,
-                                                                h ->
-                                                                        h.value() != null
-                                                                                ? h.value()
-                                                                                        .toString()
-                                                                                : null)));
+                        producer
+                                .newMessage()
+                                .properties(properties);
 
                 if (schema instanceof KeyValueSchema<?, ?> keyValueSchema) {
                     KeyValue<?, ?> keyValue =
@@ -777,7 +773,7 @@ public class PulsarTopicConnectionsRuntimeProvider implements TopicConnectionsRu
                 log.info("Inferred schema from record {} -> {}", r, schema);
             }
 
-            private Object convertValue(Object value, Schema<?> schema) {
+            private static Object convertValue(Object value, Schema<?> schema) {
                 if (value == null) {
                     return null;
                 }
@@ -788,6 +784,9 @@ public class PulsarTopicConnectionsRuntimeProvider implements TopicConnectionsRu
                         }
                         return value.toString().getBytes(StandardCharsets.UTF_8);
                     case STRING:
+                        if (value instanceof String) {
+                            return value;
+                        }
                         if (Map.class.isAssignableFrom(value.getClass())
                                 || Collection.class.isAssignableFrom(value.getClass())) {
                             try {

--- a/langstream-pulsar-runtime/src/main/java/ai/langstream/pulsar/runner/PulsarTopicConnectionsRuntimeProvider.java
+++ b/langstream-pulsar-runtime/src/main/java/ai/langstream/pulsar/runner/PulsarTopicConnectionsRuntimeProvider.java
@@ -607,6 +607,8 @@ public class PulsarTopicConnectionsRuntimeProvider implements TopicConnectionsRu
             static final Map<Class<?>, Schema<?>> BASE_SCHEMAS =
                     Map.ofEntries(
                             entry(String.class, Schema.STRING),
+                            entry(Map.class, Schema.STRING),
+                            entry(Collection.class, Schema.STRING),
                             entry(Boolean.class, Schema.BOOL),
                             entry(Byte.class, Schema.INT8),
                             entry(Short.class, Schema.INT16),
@@ -786,6 +788,14 @@ public class PulsarTopicConnectionsRuntimeProvider implements TopicConnectionsRu
                         }
                         return value.toString().getBytes(StandardCharsets.UTF_8);
                     case STRING:
+                        if (Map.class.isAssignableFrom(value.getClass())
+                                || Collection.class.isAssignableFrom(value.getClass())) {
+                            try {
+                                return mapper.writeValueAsString(value);
+                            } catch (IOException e) {
+                                throw new RuntimeException(e);
+                            }
+                        }
                         return value.toString();
                     default:
                         throw new IllegalArgumentException(

--- a/langstream-pulsar-runtime/src/main/java/ai/langstream/pulsar/runner/PulsarTopicConnectionsRuntimeProvider.java
+++ b/langstream-pulsar-runtime/src/main/java/ai/langstream/pulsar/runner/PulsarTopicConnectionsRuntimeProvider.java
@@ -733,10 +733,7 @@ public class PulsarTopicConnectionsRuntimeProvider implements TopicConnectionsRu
                 for (Header header : r.headers()) {
                     properties.put(header.key(), header.valueAsString());
                 }
-                TypedMessageBuilder<K> message =
-                        producer
-                                .newMessage()
-                                .properties(properties);
+                TypedMessageBuilder<K> message = producer.newMessage().properties(properties);
 
                 if (schema instanceof KeyValueSchema<?, ?> keyValueSchema) {
                     KeyValue<?, ?> keyValue =

--- a/langstream-pulsar-runtime/src/test/java/ai/langstream/pulsar/PulsarClusterRuntimeDockerTest.java
+++ b/langstream-pulsar-runtime/src/test/java/ai/langstream/pulsar/PulsarClusterRuntimeDockerTest.java
@@ -32,8 +32,6 @@ import ai.langstream.api.runtime.ExecutionPlan;
 import ai.langstream.api.runtime.PluginsRegistry;
 import ai.langstream.impl.deploy.ApplicationDeployer;
 import ai.langstream.impl.parser.ModelBuilder;
-
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
@@ -156,21 +154,21 @@ class PulsarClusterRuntimeDockerTest {
                                         type: "string"
                                     keySchema:
                                         type: "string"
-                                  
+
                                 """),
                                 buildInstanceYaml(),
                                 null)
                         .getApplication();
 
         try (ApplicationDeployer deployer =
-                     ApplicationDeployer.builder()
-                             .registry(new ClusterRuntimeRegistry())
-                             .pluginsRegistry(new PluginsRegistry())
-                             .topicConnectionsRuntimeRegistry(new TopicConnectionsRuntimeRegistry())
-                             .deployContext(DeployContext.NO_DEPLOY_CONTEXT)
-                             .assetManagerRegistry(new AssetManagerRegistry())
-                             .agentCodeRegistry(new AgentCodeRegistry())
-                             .build()) {
+                ApplicationDeployer.builder()
+                        .registry(new ClusterRuntimeRegistry())
+                        .pluginsRegistry(new PluginsRegistry())
+                        .topicConnectionsRuntimeRegistry(new TopicConnectionsRuntimeRegistry())
+                        .deployContext(DeployContext.NO_DEPLOY_CONTEXT)
+                        .assetManagerRegistry(new AssetManagerRegistry())
+                        .agentCodeRegistry(new AgentCodeRegistry())
+                        .build()) {
 
             Module module = applicationInstance.getModule("module-1");
 
@@ -178,30 +176,31 @@ class PulsarClusterRuntimeDockerTest {
                     deployer.createImplementation("app", applicationInstance);
             assertTrue(
                     implementation.getConnectionImplementation(
-                            module,
-                            Connection.fromTopic(TopicDefinition.fromName("input-topic")))
+                                    module,
+                                    Connection.fromTopic(TopicDefinition.fromName("input-topic")))
                             instanceof PulsarTopic);
 
             deployer.setup("tenant", implementation);
             deployer.deploy("tenant", implementation, null);
 
-
             SchemaInfo schemaInfo = admin.schemas().getSchemaInfo("public/default/input-topic");
             assertEquals("input-topic", schemaInfo.getName());
             assertEquals(SchemaType.KEY_VALUE, schemaInfo.getType());
-            assertEquals("{\"key\":{\"name\":\"Schema\",\"schema\":\"\",\"type\":\"STRING\",\"timestamp\":0,\"properties\":{}},\"value\":{\"name\":\"Schema\",\"schema\":\"\",\"type\":\"STRING\",\"timestamp\":0,\"properties\":{}}}", schemaInfo.getSchemaDefinition());
-            assertEquals(Map.of(
-                    "key.schema.properties", "{}",
-                    "value.schema.properties", "{}",
-                    "value.schema.type", "STRING",
-                    "key.schema.name", "Schema",
-                    "value.schema.name", "Schema",
-                    "kv.encoding.type", "SEPARATED",
-                    "key.schema.type", "STRING"
-            ), schemaInfo.getProperties());
+            assertEquals(
+                    "{\"key\":{\"name\":\"Schema\",\"schema\":\"\",\"type\":\"STRING\",\"timestamp\":0,\"properties\":{}},\"value\":{\"name\":\"Schema\",\"schema\":\"\",\"type\":\"STRING\",\"timestamp\":0,\"properties\":{}}}",
+                    schemaInfo.getSchemaDefinition());
+            assertEquals(
+                    Map.of(
+                            "key.schema.properties", "{}",
+                            "value.schema.properties", "{}",
+                            "value.schema.type", "STRING",
+                            "key.schema.name", "Schema",
+                            "value.schema.name", "Schema",
+                            "kv.encoding.type", "SEPARATED",
+                            "key.schema.type", "STRING"),
+                    schemaInfo.getProperties());
         }
     }
-
 
     private static String buildInstanceYaml() {
         return """


### PR DESCRIPTION
New option in "service-options", "produce-options" and "chat-options" named `payload-schema` which could be `full`, `value`. (default is full)
With `full`, the expected JSON payload is key, value and headers. 
With `value`, the expected JSON payload is the value itself. key and headers will be null. (exactly like `full` with body `{"value": .., "key": null, "headers": null}`