### PR TITLE
feat: add deletion-mode to agents

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,20 +37,20 @@ jobs:
         include:
           - name: Runtime IT - Group 0
             build_docker: "true"
-            test_cmd: ./mvnw -ntp failsafe:integration-test failsafe:verify -pl ":langstream-runtime-impl" -PskipPython -DintegrationTests.excludedGroups=group-1
+            test_cmd: ./mvnw -ntp failsafe:integration-test failsafe:verify -pl ":langstream-runtime-impl" -PskipPython -DintegrationTests.excludedGroups=group-1 -Dspotless.skip -Dlicense.skip
           - name: Runtime IT - Group 1
             build_docker: "true"
-            test_cmd: ./mvnw -ntp failsafe:integration-test failsafe:verify -pl ":langstream-runtime-impl" -PskipPython -DintegrationTests.groups=group-1
+            test_cmd: ./mvnw -ntp failsafe:integration-test failsafe:verify -pl ":langstream-runtime-impl" -PskipPython -DintegrationTests.groups=group-1 -Dspotless.skip -Dlicense.skip
           - name: Deployer
-            test_cmd: ./mvnw -ntp verify -f langstream-k8s-deployer -Pdocker -PskipPython
+            test_cmd: ./mvnw -ntp verify -f langstream-k8s-deployer -Pdocker -PskipPython -Dspotless.skip -Dlicense.skip
           - name: Api Gateway
-            test_cmd: ./mvnw -ntp verify -pl ":langstream-api-gateway" -Pdocker -PskipPython
+            test_cmd: ./mvnw -ntp verify -pl ":langstream-api-gateway" -Pdocker -PskipPython -Dspotless.skip -Dlicense.skip
           - name: Control plane
-            test_cmd: ./mvnw -ntp verify -pl langstream-webservice -Pdocker -PskipPython
+            test_cmd: ./mvnw -ntp verify -pl langstream-webservice -Pdocker -PskipPython -Dspotless.skip -Dlicense.skip
           - name: Agents
-            test_cmd: ./mvnw -ntp verify -pl langstream-agents -Pdocker -PskipPython
+            test_cmd: ./mvnw -ntp verify -pl langstream-agents -PskipPython -Dspotless.skip -Dlicense.skip
           - name: Other
-            test_cmd: ./mvnw -ntp verify -PtestSuiteOthers -PskipPython
+            test_cmd: ./mvnw -ntp verify -PtestSuiteOthers -PskipPython -Dspotless.skip -Dlicense.skip
           - name: Style
             setup_python: "true"
             test_cmd: |

--- a/langstream-api/src/main/java/ai/langstream/api/model/AgentConfiguration.java
+++ b/langstream-api/src/main/java/ai/langstream/api/model/AgentConfiguration.java
@@ -15,10 +15,9 @@
  */
 package ai.langstream.api.model;
 
+import ai.langstream.api.runtime.AgentNode;
 import java.util.HashMap;
 import java.util.Map;
-
-import ai.langstream.api.runtime.AgentNode;
 import lombok.Data;
 
 @Data

--- a/langstream-api/src/main/java/ai/langstream/api/model/AgentConfiguration.java
+++ b/langstream-api/src/main/java/ai/langstream/api/model/AgentConfiguration.java
@@ -17,6 +17,8 @@ package ai.langstream.api.model;
 
 import java.util.HashMap;
 import java.util.Map;
+
+import ai.langstream.api.runtime.AgentNode;
 import lombok.Data;
 
 @Data
@@ -31,4 +33,5 @@ public class AgentConfiguration {
     private ResourcesSpec resources;
     private ErrorsSpec errors;
     private SignalsFromSpec signalsFrom;
+    private AgentNode.DeletionMode deletionMode;
 }

--- a/langstream-api/src/main/java/ai/langstream/api/runtime/AgentNode.java
+++ b/langstream-api/src/main/java/ai/langstream/api/runtime/AgentNode.java
@@ -47,6 +47,5 @@ public interface AgentNode extends ConnectionImplementation {
 
     Map<String, DiskSpec> getDisks();
 
-
     DeletionMode getDeletionMode();
 }

--- a/langstream-api/src/main/java/ai/langstream/api/runtime/AgentNode.java
+++ b/langstream-api/src/main/java/ai/langstream/api/runtime/AgentNode.java
@@ -21,6 +21,11 @@ import java.util.Map;
 
 public interface AgentNode extends ConnectionImplementation {
 
+    enum DeletionMode {
+        none,
+        cleanup;
+    }
+
     /**
      * The id of the agent. This can be used to compute subscriptions or consumer groups.
      *
@@ -41,4 +46,7 @@ public interface AgentNode extends ConnectionImplementation {
     ResourcesSpec getResources();
 
     Map<String, DiskSpec> getDisks();
+
+
+    DeletionMode getDeletionMode();
 }

--- a/langstream-core/src/main/java/ai/langstream/impl/common/AbstractAgentProvider.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/common/AbstractAgentProvider.java
@@ -261,7 +261,8 @@ public abstract class AbstractAgentProvider implements AgentNodeProvider {
                 agentConfiguration.getResources(),
                 agentConfiguration.getErrors(),
                 disks,
-                signalsFrom);
+                signalsFrom,
+                agentConfiguration.getDeletionMode());
     }
 
     private static Map<String, Topic> computeSignalsFromTopic(

--- a/langstream-core/src/main/java/ai/langstream/impl/common/DefaultAgentNode.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/common/DefaultAgentNode.java
@@ -44,6 +44,7 @@ public class DefaultAgentNode implements AgentNode {
     private ConnectionImplementation outputConnectionImplementation;
     private final boolean composable;
     private final Map<String, Topic> signalsFrom;
+    private final DeletionMode deletionMode;
 
     DefaultAgentNode(
             String id,
@@ -57,7 +58,8 @@ public class DefaultAgentNode implements AgentNode {
             ResourcesSpec resourcesSpec,
             ErrorsSpec errorsSpec,
             Map<String, DiskSpec> disks,
-            Map<String, Topic> signalsFrom) {
+            Map<String, Topic> signalsFrom,
+            DeletionMode deletionMode) {
         this.agentType = agentType;
         this.composable = composable;
         this.id = id;
@@ -70,6 +72,7 @@ public class DefaultAgentNode implements AgentNode {
         this.errorsSpec = errorsSpec != null ? errorsSpec : ErrorsSpec.DEFAULT;
         this.disks = disks != null ? new HashMap<>(disks) : new HashMap<>();
         this.signalsFrom = signalsFrom != null ? new HashMap<>(signalsFrom) : new HashMap<>();
+        this.deletionMode = deletionMode;
     }
 
     public <T> T getCustomMetadata() {

--- a/langstream-core/src/main/java/ai/langstream/impl/deploy/ApplicationDeployer.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/deploy/ApplicationDeployer.java
@@ -201,7 +201,10 @@ public final class ApplicationDeployer implements AutoCloseable {
         Objects.requireNonNull(agentCodeRegistry, "Agent code registry is not set");
         for (AgentNode agentImplementation : executionPlan.getAgents().values()) {
             if (agentImplementation.getDeletionMode() == AgentNode.DeletionMode.none) {
-                log.info("Skipping cleanup for agent {}, deletion-mode = {}", agentImplementation.getId(), agentImplementation.getDeletionMode());
+                log.info(
+                        "Skipping cleanup for agent {}, deletion-mode = {}",
+                        agentImplementation.getId(),
+                        agentImplementation.getDeletionMode());
                 continue;
             }
             if (agentImplementation instanceof DefaultAgentNode defaultAgentImplementation) {
@@ -231,7 +234,10 @@ public final class ApplicationDeployer implements AutoCloseable {
                             tt);
                 }
             } else {
-                log.warn("Skipping cleanup for agent {}, unexpected impl {}", agentImplementation.getId(), agentImplementation.getClass().getName());
+                log.warn(
+                        "Skipping cleanup for agent {}, unexpected impl {}",
+                        agentImplementation.getId(),
+                        agentImplementation.getClass().getName());
             }
         }
     }

--- a/langstream-core/src/main/java/ai/langstream/impl/deploy/ApplicationDeployer.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/deploy/ApplicationDeployer.java
@@ -200,7 +200,12 @@ public final class ApplicationDeployer implements AutoCloseable {
     private void cleanupAgents(String tenant, ExecutionPlan executionPlan, Path codeDirectory) {
         Objects.requireNonNull(agentCodeRegistry, "Agent code registry is not set");
         for (AgentNode agentImplementation : executionPlan.getAgents().values()) {
+            if (agentImplementation.getDeletionMode() == AgentNode.DeletionMode.none) {
+                log.info("Skipping cleanup for agent {}, deletion-mode = {}", agentImplementation.getId(), agentImplementation.getDeletionMode());
+                continue;
+            }
             if (agentImplementation instanceof DefaultAgentNode defaultAgentImplementation) {
+                log.info("Start cleanup for agent {}", agentImplementation.getId());
 
                 String agentId = defaultAgentImplementation.getId();
                 String agentType = defaultAgentImplementation.getAgentType();
@@ -225,6 +230,8 @@ public final class ApplicationDeployer implements AutoCloseable {
                             agentId,
                             tt);
                 }
+            } else {
+                log.warn("Skipping cleanup for agent {}, unexpected impl {}", agentImplementation.getId(), agentImplementation.getClass().getName());
             }
         }
     }
@@ -242,12 +249,12 @@ public final class ApplicationDeployer implements AutoCloseable {
         Objects.requireNonNull(assetManagerRegistry, "Asset manager registry is not set");
         for (AssetNode assetNode : executionPlan.getAssets()) {
             AssetDefinition asset = MAPPER.convertValue(assetNode.config(), AssetDefinition.class);
-            cleanupAsset(asset, assetManagerRegistry);
+            cleanupAsset(asset);
         }
     }
 
     @SneakyThrows
-    private void cleanupAsset(AssetDefinition asset, AssetManagerRegistry assetManagerRegistry) {
+    private void cleanupAsset(AssetDefinition asset) {
         log.info(
                 "Cleaning up asset {} type {} with deletion mode {}",
                 asset.getId(),

--- a/langstream-core/src/main/java/ai/langstream/impl/parser/ModelBuilder.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/parser/ModelBuilder.java
@@ -950,8 +950,10 @@ public class ModelBuilder {
                             ? pipeline.getErrors()
                             : errors.withDefaultsFrom(pipeline.getErrors()));
             res.setSignalsFrom(signalsFrom == null ? null : new SignalsFromSpec(signalsFrom));
-            res.setDeletionMode(deletionMode == null ?
-                    AgentNode.DeletionMode.cleanup : AgentNode.DeletionMode.valueOf(deletionMode));
+            res.setDeletionMode(
+                    deletionMode == null
+                            ? AgentNode.DeletionMode.cleanup
+                            : AgentNode.DeletionMode.valueOf(deletionMode));
             return res;
         }
     }

--- a/langstream-core/src/main/java/ai/langstream/impl/parser/ModelBuilder.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/parser/ModelBuilder.java
@@ -22,6 +22,7 @@ import static ai.langstream.api.model.ErrorsSpec.SKIP;
 import ai.langstream.api.archetype.ArchetypeDefinition;
 import ai.langstream.api.model.*;
 import ai.langstream.api.model.Module;
+import ai.langstream.api.runtime.AgentNode;
 import ai.langstream.impl.uti.FileUtils;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -931,6 +932,9 @@ public class ModelBuilder {
         private ResourcesSpec resources;
         private ErrorsSpec errors;
 
+        @JsonProperty("deletion-mode")
+        private String deletionMode;
+
         AgentConfiguration toAgentConfiguration(Pipeline pipeline) {
             AgentConfiguration res = new AgentConfiguration();
             res.setId(id);
@@ -946,6 +950,8 @@ public class ModelBuilder {
                             ? pipeline.getErrors()
                             : errors.withDefaultsFrom(pipeline.getErrors()));
             res.setSignalsFrom(signalsFrom == null ? null : new SignalsFromSpec(signalsFrom));
+            res.setDeletionMode(deletionMode == null ?
+                    AgentNode.DeletionMode.cleanup : AgentNode.DeletionMode.valueOf(deletionMode));
             return res;
         }
     }

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/S3SourceIT.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/S3SourceIT.java
@@ -487,18 +487,15 @@ class S3SourceIT extends AbstractKafkaApplicationRunner {
 
         minioClient.makeBucket(MakeBucketArgs.builder().bucket("test-bucket").build());
         minioClient.putObject(
-                PutObjectArgs.builder()
-                        .bucket("test-bucket")
-                        .object("test-0.txt")
-                        .stream(
+                PutObjectArgs.builder().bucket("test-bucket").object("test-0.txt").stream(
                                 new ByteArrayInputStream("s".getBytes(StandardCharsets.UTF_8)),
                                 "s".length(),
                                 -1)
                         .build());
 
         try (ApplicationRuntime applicationRuntime =
-                     deployApplication(
-                             tenant, appId, application, buildInstanceYaml(), expectedAgents)) {
+                deployApplication(
+                        tenant, appId, application, buildInstanceYaml(), expectedAgents)) {
             executeAgentRunners(applicationRuntime);
 
             assertTrue(

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/S3SourceIT.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/S3SourceIT.java
@@ -450,4 +450,75 @@ class S3SourceIT extends AbstractKafkaApplicationRunner {
             }
         }
     }
+
+    @Test
+    public void testSkipCleanup() throws Exception {
+
+        final String appId = "app-" + UUID.randomUUID().toString().substring(0, 4);
+
+        String tenant = "tenant";
+
+        String[] expectedAgents = new String[] {appId + "-step1"};
+        String endpoint = localstack.getEndpointOverride(S3).toString();
+        Map<String, String> application =
+                Map.of(
+                        "module.yaml",
+                        """
+                                module: "module-1"
+                                id: "pipeline-1"
+                                topics:
+                                  - name: "${globals.output-topic}"
+                                    creation-mode: create-if-not-exists
+                                pipeline:
+                                  - type: "s3-source"
+                                    id: "step1"
+                                    output: "${globals.output-topic}"
+                                    deletion-mode: none
+                                    configuration:\s
+                                        bucketName: "test-bucket"
+                                        endpoint: "%s"
+                                        state-storage: s3
+                                        state-storage-s3-bucket: "test-state-bucket"
+                                        state-storage-s3-endpoint: "%s"
+                                """
+                                .formatted(endpoint, endpoint));
+
+        MinioClient minioClient = MinioClient.builder().endpoint(endpoint).build();
+
+        minioClient.makeBucket(MakeBucketArgs.builder().bucket("test-bucket").build());
+        minioClient.putObject(
+                PutObjectArgs.builder()
+                        .bucket("test-bucket")
+                        .object("test-0.txt")
+                        .stream(
+                                new ByteArrayInputStream("s".getBytes(StandardCharsets.UTF_8)),
+                                "s".length(),
+                                -1)
+                        .build());
+
+        try (ApplicationRuntime applicationRuntime =
+                     deployApplication(
+                             tenant, appId, application, buildInstanceYaml(), expectedAgents)) {
+            executeAgentRunners(applicationRuntime);
+
+            assertTrue(
+                    minioClient.bucketExists(
+                            BucketExistsArgs.builder().bucket("test-state-bucket").build()));
+            assertNotNull(
+                    minioClient.statObject(
+                            StatObjectArgs.builder()
+                                    .bucket("test-state-bucket")
+                                    .object(appId + "-step1.step1.status.json")
+                                    .build()));
+        }
+        assertTrue(
+                minioClient.bucketExists(
+                        BucketExistsArgs.builder().bucket("test-state-bucket").build()));
+        assertNotNull(
+                minioClient.statObject(
+                        StatObjectArgs.builder()
+                                .bucket("test-state-bucket")
+                                .object(appId + "-step1.step1.status.json")
+                                .build()));
+    }
 }

--- a/langstream-webservice/src/test/java/ai/langstream/webservice/application/ApplicationResourceTest.java
+++ b/langstream-webservice/src/test/java/ai/langstream/webservice/application/ApplicationResourceTest.java
@@ -371,7 +371,8 @@ class ApplicationResourceTest {
                                                           "retries" : 0,
                                                           "on-failure" : "fail"
                                                         },
-                                                        "signalsFrom" : null
+                                                        "signalsFrom" : null,
+                                                        "deletionMode" : "cleanup"
                                                       } ]
                                                     } ],
                                                     "topics" : [ {

--- a/langstream-webservice/src/test/java/ai/langstream/webservice/application/ApplicationServiceValidateUpdateTest.java
+++ b/langstream-webservice/src/test/java/ai/langstream/webservice/application/ApplicationServiceValidateUpdateTest.java
@@ -284,6 +284,7 @@ class ApplicationServiceValidateUpdateTest {
                                 null,
                                 Map.of(),
                                 null,
+                                null,
                                 null)),
                 List.of(newModel("agent", "My Agent", "drop", "input-topic", "output-topic")),
                 true);
@@ -333,6 +334,7 @@ class ApplicationServiceValidateUpdateTest {
                                 null,
                                 Map.of("fields", "f"),
                                 null,
+                                null,
                                 null)),
                 false);
 
@@ -352,6 +354,7 @@ class ApplicationServiceValidateUpdateTest {
                                 null,
                                 Map.of("when", "true"),
                                 null,
+                                null,
                                 null)),
                 List.of(
                         new ModelBuilder.AgentModel(
@@ -362,6 +365,7 @@ class ApplicationServiceValidateUpdateTest {
                                 "output-topic",
                                 null,
                                 Map.of("when", "false"),
+                                null,
                                 null,
                                 null)),
                 true);
@@ -377,6 +381,7 @@ class ApplicationServiceValidateUpdateTest {
                                 null,
                                 Map.of("when", "true"),
                                 null,
+                                null,
                                 null)),
                 List.of(
                         new ModelBuilder.AgentModel(
@@ -388,6 +393,7 @@ class ApplicationServiceValidateUpdateTest {
                                 null,
                                 Map.of("composable", "false"),
                                 null,
+                                null,
                                 null)),
                 true);
 
@@ -402,6 +408,7 @@ class ApplicationServiceValidateUpdateTest {
                                 null,
                                 Map.of(),
                                 new ResourcesSpec(1, 1, null),
+                                null,
                                 null)),
                 List.of(
                         new ModelBuilder.AgentModel(
@@ -413,6 +420,7 @@ class ApplicationServiceValidateUpdateTest {
                                 null,
                                 Map.of(),
                                 new ResourcesSpec(1, 1, null),
+                                null,
                                 null)),
                 true);
 
@@ -427,6 +435,7 @@ class ApplicationServiceValidateUpdateTest {
                                 null,
                                 Map.of(),
                                 new ResourcesSpec(1, 1, null),
+                                null,
                                 null)),
                 List.of(
                         new ModelBuilder.AgentModel(
@@ -438,6 +447,7 @@ class ApplicationServiceValidateUpdateTest {
                                 null,
                                 Map.of(),
                                 new ResourcesSpec(2, 1, null),
+                                null,
                                 null)),
                 true);
 
@@ -452,6 +462,7 @@ class ApplicationServiceValidateUpdateTest {
                                 null,
                                 Map.of(),
                                 new ResourcesSpec(1, 1, null),
+                                null,
                                 null)),
                 List.of(
                         new ModelBuilder.AgentModel(
@@ -463,6 +474,7 @@ class ApplicationServiceValidateUpdateTest {
                                 null,
                                 Map.of(),
                                 new ResourcesSpec(1, 2, null),
+                                null,
                                 null)),
                 true);
 
@@ -477,6 +489,7 @@ class ApplicationServiceValidateUpdateTest {
                                 null,
                                 Map.of(),
                                 new ResourcesSpec(1, 1, null),
+                                null,
                                 null)),
                 List.of(
                         new ModelBuilder.AgentModel(
@@ -488,6 +501,7 @@ class ApplicationServiceValidateUpdateTest {
                                 null,
                                 Map.of(),
                                 new ResourcesSpec(2, 2, null),
+                                null,
                                 null)),
                 true);
 
@@ -502,6 +516,7 @@ class ApplicationServiceValidateUpdateTest {
                                 null,
                                 Map.of(),
                                 new ResourcesSpec(2, 2, null),
+                                null,
                                 null)),
                 List.of(
                         new ModelBuilder.AgentModel(
@@ -513,6 +528,7 @@ class ApplicationServiceValidateUpdateTest {
                                 null,
                                 Map.of(),
                                 new ResourcesSpec(1, 1, null),
+                                null,
                                 null)),
                 true);
 
@@ -527,6 +543,7 @@ class ApplicationServiceValidateUpdateTest {
                                 null,
                                 Map.of(),
                                 new ResourcesSpec(1, 1, null),
+                                null,
                                 null)),
                 List.of(
                         new ModelBuilder.AgentModel(
@@ -538,6 +555,7 @@ class ApplicationServiceValidateUpdateTest {
                                 "my-signals",
                                 Map.of(),
                                 new ResourcesSpec(1, 1, null),
+                                null,
                                 null)),
                 true);
 
@@ -552,6 +570,7 @@ class ApplicationServiceValidateUpdateTest {
                                 null,
                                 Map.of(),
                                 new ResourcesSpec(1, 1, null),
+                                null,
                                 null)),
                 List.of(
                         new ModelBuilder.AgentModel(
@@ -563,6 +582,7 @@ class ApplicationServiceValidateUpdateTest {
                                 "my-signals2",
                                 Map.of(),
                                 new ResourcesSpec(1, 1, null),
+                                null,
                                 null)),
                 true);
 
@@ -577,6 +597,7 @@ class ApplicationServiceValidateUpdateTest {
                                 "my-signals2",
                                 Map.of(),
                                 new ResourcesSpec(1, 1, null),
+                                null,
                                 null)),
                 List.of(
                         new ModelBuilder.AgentModel(
@@ -588,6 +609,7 @@ class ApplicationServiceValidateUpdateTest {
                                 null,
                                 Map.of(),
                                 new ResourcesSpec(1, 1, null),
+                                null,
                                 null)),
                 true);
     }
@@ -665,6 +687,6 @@ class ApplicationServiceValidateUpdateTest {
     static ModelBuilder.AgentModel newModel(
             String id, String name, String type, String input, String output) {
         return new ModelBuilder.AgentModel(
-                id, name, type, input, output, null, Map.of(), null, null);
+                id, name, type, input, output, null, Map.of(), null, null, null);
     }
 }


### PR DESCRIPTION
Added `deletion-mode` to agent: `none` or `cleanup`, default is `cleanup`
Example:
```
- type: "s3-source"
   id: "step1"
   output: "${globals.output-topic}"
   deletion-mode: none
```
in this case the s3-source cleanup method won't run


