### PR TITLE
feat: allow dynamic indexes for pinecone writer/reader

### DIFF
--- a/langstream-agents/langstream-vector-agents/src/main/java/ai/langstream/agents/vector/pinecone/PineconeDataSource.java
+++ b/langstream-agents/langstream-vector-agents/src/main/java/ai/langstream/agents/vector/pinecone/PineconeDataSource.java
@@ -165,13 +165,15 @@ public class PineconeDataSource implements DataSourceProvider {
         private List<Map<String, Object>> executeQuery(Query parsedQuery) {
             List<Map<String, Object>> results;
 
+
+            final String indexName = parsedQuery.getIndex() == null ?
+                    clientConfig.getIndexName() : parsedQuery.getIndex();
             if (log.isDebugEnabled()) {
-                log.debug("Query request: {}", parsedQuery);
+                log.debug("Query request on index {}: {}", indexName, parsedQuery);
             }
-            log.info("Query request: {}", parsedQuery);
 
             QueryResponseWithUnsignedIndices response =
-                    getIndexConnection(clientConfig.getIndexName())
+                    getIndexConnection(indexName)
                             .query(
                                     parsedQuery.getTopK(),
                                     parsedQuery.getVector(),
@@ -301,6 +303,10 @@ public class PineconeDataSource implements DataSourceProvider {
      */
     @Data
     public static final class Query {
+
+        @JsonProperty("index")
+        private String index;
+
         @JsonProperty("vector")
         private List<Float> vector;
 

--- a/langstream-agents/langstream-vector-agents/src/main/java/ai/langstream/agents/vector/pinecone/PineconeDataSource.java
+++ b/langstream-agents/langstream-vector-agents/src/main/java/ai/langstream/agents/vector/pinecone/PineconeDataSource.java
@@ -165,11 +165,16 @@ public class PineconeDataSource implements DataSourceProvider {
         private List<Map<String, Object>> executeQuery(Query parsedQuery) {
             List<Map<String, Object>> results;
 
-
-            final String indexName = parsedQuery.getIndex() == null ?
-                    clientConfig.getIndexName() : parsedQuery.getIndex();
+            final String indexName =
+                    parsedQuery.getIndex() == null
+                            ? clientConfig.getIndexName()
+                            : parsedQuery.getIndex();
             if (log.isDebugEnabled()) {
                 log.debug("Query request on index {}: {}", indexName, parsedQuery);
+            }
+            if (indexName == null) {
+                throw new IllegalArgumentException(
+                        "index name is null. Please provide an index name in the agent with the field 'index' or in the datasource configuration");
             }
 
             QueryResponseWithUnsignedIndices response =

--- a/langstream-core/src/main/java/ai/langstream/impl/resources/datasource/PineconeDatasourceConfig.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/resources/datasource/PineconeDatasourceConfig.java
@@ -80,9 +80,8 @@ public class PineconeDatasourceConfig extends BaseDatasourceConfig {
     @ConfigProperty(
             description =
                     """
-                            Index name parameter for connecting to the Pinecone service.
-                                    """,
-            required = true)
+                            Default index name for connecting to the Pinecone service, if not specified in the agents.
+                                    """)
     @JsonProperty("index-name")
     private String index;
 

--- a/langstream-core/src/test/java/ai/langstream/impl/resources/ResourceNodeProviderTest.java
+++ b/langstream-core/src/test/java/ai/langstream/impl/resources/ResourceNodeProviderTest.java
@@ -376,7 +376,7 @@ class ResourceNodeProviderTest {
                                         "xxx",
                                         "server-side-timeout-sec",
                                         "10000")),
-                        Arguments.of(NON_VALID, "pinecone", Map.of("api-key", "xxx")),
+                        Arguments.of(VALID, "pinecone", Map.of("api-key", "xxx")),
                         Arguments.of(
                                 VALID,
                                 "pinecone",

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/PineconeIT.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/PineconeIT.java
@@ -18,6 +18,8 @@ package ai.langstream.kafka;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
@@ -139,6 +141,136 @@ class PineconeIT extends AbstractKafkaApplicationRunner {
                         consumer,
                         List.of(
                                 "{\"embeddings\":[999,999,5],\"content_query\":\"hello0\",\"query-result\":[{\"similarity\":0.99999374,\"id\":\"0\",\"content\":\"hello0\"}]}"));
+            }
+        }
+    }
+
+    @Test
+    public void testWithDynamicIndex() throws Exception {
+        Map<String, String> application =
+                Map.of(
+                        "configuration.yaml",
+                        """
+                                configuration:
+                                  resources:
+                                    - type: "vector-database"
+                                      name: "PineconeDatasource"
+                                      configuration:
+                                        service: "pinecone"
+                                        api-key: "%s"
+                                """
+                                .formatted(API_KEY),
+                        "pipeline-write.yaml",
+                        """
+                                assets:
+                                  - name: "p-index-0"
+                                    asset-type: "pinecone-index"
+                                    creation-mode: create-if-not-exists
+                                    deletion-mode: delete
+                                    config:
+                                       datasource: "PineconeDatasource"
+                                       name: "p-index-0"
+                                       dimension: 3
+                                       metric: "cosine"
+                                       cloud: aws
+                                       region: us-east-1
+                                  - name: "p-index-1"
+                                    asset-type: "pinecone-index"
+                                    creation-mode: create-if-not-exists
+                                    deletion-mode: delete
+                                    config:
+                                       datasource: "PineconeDatasource"
+                                       name: "p-index-1"
+                                       dimension: 3
+                                       metric: "cosine"
+                                       cloud: aws
+                                       region: us-east-1
+                                topics:
+                                  - name: "insert-topic"
+                                    creation-mode: create-if-not-exists
+                                pipeline:
+                                  - id: write
+                                    name: "Write"
+                                    type: "vector-db-sink"
+                                    input: "insert-topic"
+                                    configuration:
+                                      datasource: "PineconeDatasource"
+                                      vector.index: "value.index"
+                                      vector.id: "value.id"
+                                      vector.vector: "value.embeddings"
+                                      vector.metadata.content: "value.content"
+                                """,
+                        "pipeline-read.yaml",
+                        """
+                                topics:
+                                  - name: "input-topic"
+                                    creation-mode: create-if-not-exists
+                                  - name: "result-topic"
+                                    creation-mode: create-if-not-exists
+                                pipeline:
+                                  - id: read
+                                    name: "Execute Query"
+                                    type: "query-vector-db"
+                                    input: "input-topic"
+                                    output: "result-topic"
+                                    configuration:
+                                      datasource: "PineconeDatasource"
+                                      query: |
+                                        {
+                                              "index": ?,
+                                              "vector": ?,
+                                              "topK": 5
+                                         }
+                                      fields:
+                                        - "value.index"
+                                        - "value.embeddings"
+                                      output-field: "value.query-result"
+                                """);
+
+        String[] expectedAgents = new String[] {"app-write", "app-read"};
+        try (ApplicationRuntime applicationRuntime =
+                     deployApplication(
+                             "tenant", "app", application, buildInstanceYaml(), expectedAgents)) {
+            try (KafkaProducer<String, String> producer = createProducer();
+                 KafkaConsumer<String, String> consumer = createConsumer("result-topic")) {
+
+                ObjectMapper mapper = new ObjectMapper();
+                for (int i = 0; i < 2; i++) {
+                    String content = mapper.writeValueAsString(Map.of(
+                            "index", "p-index-" + i,
+                            "id", i,
+                            "content", "hello" + i,
+                            "embeddings", List.of(999, 999, i)));
+                    sendMessage(
+                            "insert-topic",
+                            "key" + i,
+                            content,
+                            List.of(),
+                            producer);
+                }
+                executeAgentRunners(applicationRuntime);
+                log.info("Waiting for pinecone to index");
+                Thread.sleep(10000);
+
+                sendMessage(
+                        "input-topic",
+                        "{\"embeddings\":[999,999,999],\"index\":\"p-index-0\"}",
+                        producer);
+                executeAgentRunners(applicationRuntime);
+                waitForMessages(
+                        consumer,
+                        List.of(
+                                "{\"embeddings\":[999,999,999],\"index\":\"p-index-0\",\"query-result\":[{\"similarity\":0.8164967,\"id\":\"0\",\"content\":\"hello0\"}]}"));
+
+                sendMessage(
+                        "input-topic",
+                        "{\"embeddings\":[999,999,999],\"index\":\"p-index-1\"}",
+                        producer);
+                executeAgentRunners(applicationRuntime);
+                waitForMessages(
+                        consumer,
+                        List.of(
+                                "{\"embeddings\":[999,999,999],\"index\":\"p-index-1\",\"query-result\":[{\"similarity\":0.8169051,\"id\":\"1\",\"content\":\"hello1\"}]}"));
             }
         }
     }

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/PineconeIT.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/PineconeIT.java
@@ -15,11 +15,10 @@
  */
 package ai.langstream.kafka;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
@@ -229,24 +228,25 @@ class PineconeIT extends AbstractKafkaApplicationRunner {
 
         String[] expectedAgents = new String[] {"app-write", "app-read"};
         try (ApplicationRuntime applicationRuntime =
-                     deployApplication(
-                             "tenant", "app", application, buildInstanceYaml(), expectedAgents)) {
+                deployApplication(
+                        "tenant", "app", application, buildInstanceYaml(), expectedAgents)) {
             try (KafkaProducer<String, String> producer = createProducer();
-                 KafkaConsumer<String, String> consumer = createConsumer("result-topic")) {
+                    KafkaConsumer<String, String> consumer = createConsumer("result-topic")) {
 
                 ObjectMapper mapper = new ObjectMapper();
                 for (int i = 0; i < 2; i++) {
-                    String content = mapper.writeValueAsString(Map.of(
-                            "index", "p-index-" + i,
-                            "id", i,
-                            "content", "hello" + i,
-                            "embeddings", List.of(999, 999, i)));
-                    sendMessage(
-                            "insert-topic",
-                            "key" + i,
-                            content,
-                            List.of(),
-                            producer);
+                    String content =
+                            mapper.writeValueAsString(
+                                    Map.of(
+                                            "index",
+                                            "p-index-" + i,
+                                            "id",
+                                            i,
+                                            "content",
+                                            "hello" + i,
+                                            "embeddings",
+                                            List.of(999, 999, i)));
+                    sendMessage("insert-topic", "key" + i, content, List.of(), producer);
                 }
                 executeAgentRunners(applicationRuntime);
                 log.info("Waiting for pinecone to index");


### PR DESCRIPTION
* In the vector-db-sink added a `vector.index` to override the index defined in the datasource.  
```
- id: write
  name: "Write"
  type: "vector-db-sink"
  input: "insert-topic"
  configuration:
    datasource: "PineconeDatasource"
    vector.index: "value.index"
    vector.id: "value.id"
    vector.vector: "value.embeddings"
    vector.metadata.content: "value.content"
```
* In the query-vector-db added a `index` field to override the index defined in the datasource. 

```
- id: read
  name: "Execute Query"
  type: "query-vector-db"
  input: "input-topic"
  output: "result-topic"
  configuration:
    datasource: "PineconeDatasource"
    query: |
      {
            "index": ?,
            "vector": ?,
            "topK": 5
        }
    fields:
      - "value.index"
      - "value.embeddings"
    output-field: "value.query-result"
```
* Both the cases will fallback to the index defined in the datasource, which is now optional in the config