### PR TITLE
feat: add events-topic to assets

### DIFF
--- a/langstream-agents/langstream-agent-s3/src/test/java/ai/langstream/agents/s3/S3AssetTest.java
+++ b/langstream-agents/langstream-agent-s3/src/test/java/ai/langstream/agents/s3/S3AssetTest.java
@@ -51,6 +51,7 @@ public class S3AssetTest {
                         "create-if-not-exists",
                         "delete",
                         "s3-bucket",
+                        null,
                         Map.of(
                                 "bucket-name",
                                 "test",

--- a/langstream-agents/langstream-vector-agents/src/main/java/ai/langstream/agents/vector/solr/SolrAssetsManagerProvider.java
+++ b/langstream-agents/langstream-vector-agents/src/main/java/ai/langstream/agents/vector/solr/SolrAssetsManagerProvider.java
@@ -135,7 +135,6 @@ public class SolrAssetsManagerProvider implements AssetManagerProvider {
                 return false;
             }
             String collectionUrl = datasource.getRESTCollectionUrl();
-            ;
             log.info("Deleting collection {}", datasource.getCollectionName());
             execute("DELETE", collectionUrl);
             return true;

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/ConsumeGateway.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/ConsumeGateway.java
@@ -92,15 +92,6 @@ public class ConsumeGateway implements AutoCloseable {
         final StreamingCluster streamingCluster =
                 requestContext.application().getInstance().streamingCluster();
 
-        final String configString;
-        try {
-            configString =
-                    mapper.writeValueAsString(
-                            Pair.of(streamingCluster.type(), streamingCluster.configuration()));
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
-
         TopicConnectionsRuntimeCache.Key key =
                 new TopicConnectionsRuntimeCache.Key(
                         requestContext.tenant(),
@@ -111,14 +102,9 @@ public class ConsumeGateway implements AutoCloseable {
         topicConnectionsRuntime =
                 topicConnectionsRuntimeCache.getOrCreate(
                         key,
-                        () -> {
-                            TopicConnectionsRuntime topicConnectionsRuntime =
-                                    topicConnectionsRuntimeRegistry
+                        () -> topicConnectionsRuntimeRegistry
                                             .getTopicConnectionsRuntime(streamingCluster)
-                                            .asTopicConnectionsRuntime();
-                            topicConnectionsRuntime.init(streamingCluster);
-                            return topicConnectionsRuntime;
-                        });
+                                            .asTopicConnectionsRuntime());
 
         final String positionParameter =
                 requestContext.options().getOrDefault("position", "latest");

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/ConsumeGateway.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/ConsumeGateway.java
@@ -31,7 +31,6 @@ import ai.langstream.api.runtime.Topic;
 import ai.langstream.apigateway.api.ConsumePushMessage;
 import ai.langstream.apigateway.util.StreamingClusterUtil;
 import ai.langstream.apigateway.websocket.AuthenticatedGatewayRequestContext;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
 import java.util.Base64;
@@ -48,7 +47,6 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.tuple.Pair;
 
 @Slf4j
 public class ConsumeGateway implements AutoCloseable {
@@ -102,9 +100,10 @@ public class ConsumeGateway implements AutoCloseable {
         topicConnectionsRuntime =
                 topicConnectionsRuntimeCache.getOrCreate(
                         key,
-                        () -> topicConnectionsRuntimeRegistry
-                                            .getTopicConnectionsRuntime(streamingCluster)
-                                            .asTopicConnectionsRuntime());
+                        () ->
+                                topicConnectionsRuntimeRegistry
+                                        .getTopicConnectionsRuntime(streamingCluster)
+                                        .asTopicConnectionsRuntime());
 
         final String positionParameter =
                 requestContext.options().getOrDefault("position", "latest");

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/LRUTopicConnectionsRuntimeCache.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/LRUTopicConnectionsRuntimeCache.java
@@ -37,11 +37,6 @@ public class LRUTopicConnectionsRuntimeCache
         }
 
         @Override
-        public void init(StreamingCluster streamingCluster) {
-            object.init(streamingCluster);
-        }
-
-        @Override
         public void deploy(ExecutionPlan applicationInstance) {
             object.deploy(applicationInstance);
         }

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/ProduceGateway.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/ProduceGateway.java
@@ -185,10 +185,10 @@ public class ProduceGateway implements AutoCloseable {
         TopicConnectionsRuntime runtime =
                 topicConnectionsRuntimeCache.getOrCreate(
                         topicsConnectionRuntimeKey,
-                        () -> topicConnectionsRuntimeRegistry
-                                            .getTopicConnectionsRuntime(streamingCluster)
-                                            .asTopicConnectionsRuntime()
-                            );
+                        () ->
+                                topicConnectionsRuntimeRegistry
+                                        .getTopicConnectionsRuntime(streamingCluster)
+                                        .asTopicConnectionsRuntime());
 
         final TopicProducer topicProducer =
                 runtime.createProducer(null, streamingCluster, Map.of("topic", topic));

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/ProduceGateway.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/ProduceGateway.java
@@ -185,14 +185,10 @@ public class ProduceGateway implements AutoCloseable {
         TopicConnectionsRuntime runtime =
                 topicConnectionsRuntimeCache.getOrCreate(
                         topicsConnectionRuntimeKey,
-                        () -> {
-                            TopicConnectionsRuntime topicConnectionsRuntime =
-                                    topicConnectionsRuntimeRegistry
+                        () -> topicConnectionsRuntimeRegistry
                                             .getTopicConnectionsRuntime(streamingCluster)
-                                            .asTopicConnectionsRuntime();
-                            topicConnectionsRuntime.init(streamingCluster);
-                            return topicConnectionsRuntime;
-                        });
+                                            .asTopicConnectionsRuntime()
+                            );
 
         final TopicProducer topicProducer =
                 runtime.createProducer(null, streamingCluster, Map.of("topic", topic));

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/handlers/AbstractHandler.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/handlers/AbstractHandler.java
@@ -202,14 +202,10 @@ public abstract class AbstractHandler extends TextWebSocketHandler {
         try (final TopicConnectionsRuntime topicConnectionsRuntime =
                 topicConnectionsRuntimeCache.getOrCreate(
                         key,
-                        () -> {
-                            TopicConnectionsRuntime runtime =
-                                    topicConnectionsRuntimeRegistry
+                        () -> topicConnectionsRuntimeRegistry
                                             .getTopicConnectionsRuntime(streamingCluster)
-                                            .asTopicConnectionsRuntime();
-                            runtime.init(streamingCluster);
-                            return runtime;
-                        }); ) {
+                                            .asTopicConnectionsRuntime())
+                        ) {
 
             TopicDefinition topicDefinition =
                     context.application().resolveTopic(gateway.getEventsTopic());

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/handlers/AbstractHandler.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/handlers/AbstractHandler.java
@@ -202,10 +202,10 @@ public abstract class AbstractHandler extends TextWebSocketHandler {
         try (final TopicConnectionsRuntime topicConnectionsRuntime =
                 topicConnectionsRuntimeCache.getOrCreate(
                         key,
-                        () -> topicConnectionsRuntimeRegistry
-                                            .getTopicConnectionsRuntime(streamingCluster)
-                                            .asTopicConnectionsRuntime())
-                        ) {
+                        () ->
+                                topicConnectionsRuntimeRegistry
+                                        .getTopicConnectionsRuntime(streamingCluster)
+                                        .asTopicConnectionsRuntime())) {
 
             TopicDefinition topicDefinition =
                     context.application().resolveTopic(gateway.getEventsTopic());

--- a/langstream-api-gateway/src/test/java/ai/langstream/apigateway/http/GatewayResourceTest.java
+++ b/langstream-api-gateway/src/test/java/ai/langstream/apigateway/http/GatewayResourceTest.java
@@ -811,7 +811,6 @@ abstract class GatewayResourceTest {
                                     topicConnectionsRuntimeRegistry
                                             .getTopicConnectionsRuntime(streamingCluster)
                                             .asTopicConnectionsRuntime();
-                            runtime.init(streamingCluster);
                             final String fromTopic = resolveTopicName(logicalFromTopic);
                             final String toTopic = resolveTopicName(logicalToTopic);
                             try (final TopicConsumer consumer =

--- a/langstream-api-gateway/src/test/java/ai/langstream/apigateway/http/GatewayResourceTest.java
+++ b/langstream-api-gateway/src/test/java/ai/langstream/apigateway/http/GatewayResourceTest.java
@@ -921,12 +921,14 @@ abstract class GatewayResourceTest {
                         .deployContext(DeployContext.NO_DEPLOY_CONTEXT)
                         .build();
         final StreamingCluster streamingCluster = getStreamingCluster();
-        topicConnectionsRuntimeRegistry
-                .getTopicConnectionsRuntime(streamingCluster)
-                .asTopicConnectionsRuntime()
-                .deploy(
-                        deployer.createImplementation(
-                                "app", store.get("t", "app", false).getInstance()));
+        try (TopicConnectionsRuntime runtime =
+                topicConnectionsRuntimeRegistry
+                        .getTopicConnectionsRuntime(streamingCluster)
+                        .asTopicConnectionsRuntime(); ) {
+            runtime.deploy(
+                    deployer.createImplementation(
+                            "app", store.get("t", "app", false).getInstance()));
+        }
     }
 
     protected String resolveTopicName(String topic) {

--- a/langstream-api-gateway/src/test/java/ai/langstream/apigateway/websocket/handlers/ProduceConsumeHandlerTest.java
+++ b/langstream-api-gateway/src/test/java/ai/langstream/apigateway/websocket/handlers/ProduceConsumeHandlerTest.java
@@ -33,6 +33,7 @@ import ai.langstream.api.model.Gateway;
 import ai.langstream.api.model.Gateways;
 import ai.langstream.api.model.StoredApplication;
 import ai.langstream.api.model.StreamingCluster;
+import ai.langstream.api.runner.topics.TopicConnectionsRuntime;
 import ai.langstream.api.runner.topics.TopicConnectionsRuntimeRegistry;
 import ai.langstream.api.runtime.ClusterRuntimeRegistry;
 import ai.langstream.api.runtime.DeployContext;
@@ -274,12 +275,14 @@ abstract class ProduceConsumeHandlerTest {
                         .deployContext(DeployContext.NO_DEPLOY_CONTEXT)
                         .build();
         final StreamingCluster streamingCluster = getStreamingCluster();
-        topicConnectionsRuntimeRegistry
-                .getTopicConnectionsRuntime(streamingCluster)
-                .asTopicConnectionsRuntime()
-                .deploy(
-                        deployer.createImplementation(
-                                "app", store.get("t", "app", false).getInstance()));
+        try (TopicConnectionsRuntime runtime =
+                topicConnectionsRuntimeRegistry
+                        .getTopicConnectionsRuntime(streamingCluster)
+                        .asTopicConnectionsRuntime(); ) {
+            runtime.deploy(
+                    deployer.createImplementation(
+                            "app", store.get("t", "app", false).getInstance()));
+        }
     }
 
     @ParameterizedTest

--- a/langstream-api/src/main/java/ai/langstream/api/events/EventRecord.java
+++ b/langstream-api/src/main/java/ai/langstream/api/events/EventRecord.java
@@ -28,13 +28,18 @@ import lombok.NoArgsConstructor;
 public class EventRecord {
 
     public enum Categories {
-        Gateway
+        Gateway,
+        Asset
     }
 
     public enum Types {
         // gateway
         ClientConnected,
-        ClientDisconnected;
+        ClientDisconnected,
+
+        // asset
+        AssetCreated,
+        AssetDeleted
     }
 
     private Categories category;

--- a/langstream-api/src/main/java/ai/langstream/api/events/EventSources.java
+++ b/langstream-api/src/main/java/ai/langstream/api/events/EventSources.java
@@ -15,6 +15,7 @@
  */
 package ai.langstream.api.events;
 
+import ai.langstream.api.model.AssetDefinition;
 import ai.langstream.api.model.Gateway;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -43,4 +44,18 @@ public class EventSources {
             this.gateway = gateway;
         }
     }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AssetSource extends ApplicationSource {
+        private AssetDefinition asset;
+
+        @Builder
+        public AssetSource(String tenant, String applicationId, AssetDefinition asset) {
+            super(tenant, applicationId);
+            this.asset = asset;
+        }
+    }
+
 }

--- a/langstream-api/src/main/java/ai/langstream/api/events/EventSources.java
+++ b/langstream-api/src/main/java/ai/langstream/api/events/EventSources.java
@@ -57,5 +57,4 @@ public class EventSources {
             this.asset = asset;
         }
     }
-
 }

--- a/langstream-api/src/main/java/ai/langstream/api/model/AssetDefinition.java
+++ b/langstream-api/src/main/java/ai/langstream/api/model/AssetDefinition.java
@@ -46,6 +46,7 @@ public class AssetDefinition {
             String creationMode,
             String deletionMode,
             String assetType,
+            String eventsTopic,
             Map<String, Object> config) {
         this();
         this.id = id;
@@ -54,6 +55,7 @@ public class AssetDefinition {
         this.config = config;
         this.creationMode = Objects.requireNonNullElse(creationMode, CREATE_MODE_NONE);
         this.deletionMode = Objects.requireNonNullElse(deletionMode, DELETE_MODE_NONE);
+        this.eventsTopic = eventsTopic;
         validateCreationMode();
         validateDeletionMode();
     }
@@ -71,6 +73,9 @@ public class AssetDefinition {
 
     @JsonProperty("asset-type")
     private String assetType;
+
+    @JsonProperty("events-topic")
+    private String eventsTopic;
 
     private void validateCreationMode() {
         switch (creationMode) {

--- a/langstream-api/src/main/java/ai/langstream/api/runner/topics/TopicConnectionsRuntime.java
+++ b/langstream-api/src/main/java/ai/langstream/api/runner/topics/TopicConnectionsRuntime.java
@@ -22,7 +22,6 @@ import java.util.Map;
 /** This is the interface that the LangStream runtime to connect to Topics. */
 public interface TopicConnectionsRuntime extends AutoCloseable {
 
-
     /**
      * Deploy the topics on the StreamingCluster
      *

--- a/langstream-api/src/main/java/ai/langstream/api/runner/topics/TopicConnectionsRuntime.java
+++ b/langstream-api/src/main/java/ai/langstream/api/runner/topics/TopicConnectionsRuntime.java
@@ -22,7 +22,6 @@ import java.util.Map;
 /** This is the interface that the LangStream runtime to connect to Topics. */
 public interface TopicConnectionsRuntime extends AutoCloseable {
 
-    default void init(StreamingCluster streamingCluster) {}
 
     /**
      * Deploy the topics on the StreamingCluster

--- a/langstream-api/src/main/java/ai/langstream/api/runner/topics/TopicConnectionsRuntimeAndLoader.java
+++ b/langstream-api/src/main/java/ai/langstream/api/runner/topics/TopicConnectionsRuntimeAndLoader.java
@@ -70,11 +70,6 @@ public record TopicConnectionsRuntimeAndLoader(
         return new TopicConnectionsRuntime() {
 
             @Override
-            public void init(StreamingCluster streamingCluster) {
-                executeNoExceptionWithContextClassloader(code -> code.init(streamingCluster));
-            }
-
-            @Override
             public void deploy(ExecutionPlan applicationInstance) {
                 executeNoExceptionWithContextClassloader(code -> code.deploy(applicationInstance));
             }

--- a/langstream-core/src/main/java/ai/langstream/impl/common/AbstractAssetProvider.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/common/AbstractAssetProvider.java
@@ -61,7 +61,6 @@ public abstract class AbstractAssetProvider implements AssetNodeProvider {
     }
 
     protected void validateAsset(AssetDefinition assetDefinition, Map<String, Object> asset) {}
-    ;
 
     private Map<String, Object> planAsset(
             AssetDefinition assetDefinition,
@@ -90,6 +89,7 @@ public abstract class AbstractAssetProvider implements AssetNodeProvider {
         asset.put("asset-type", type);
         asset.put("creation-mode", assetDefinition.getCreationMode());
         asset.put("deletion-mode", assetDefinition.getDeletionMode());
+        asset.put("events-topic", assetDefinition.getEventsTopic());
         Map<String, Object> configuration = new HashMap<>();
         if (config != null) {
             config.forEach(

--- a/langstream-core/src/main/java/ai/langstream/impl/deploy/ApplicationDeployer.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/deploy/ApplicationDeployer.java
@@ -15,8 +15,12 @@
  */
 package ai.langstream.impl.deploy;
 
+import ai.langstream.api.events.EventRecord;
+import ai.langstream.api.events.EventSources;
 import ai.langstream.api.model.Application;
 import ai.langstream.api.model.AssetDefinition;
+import ai.langstream.api.model.StreamingCluster;
+import ai.langstream.api.model.TopicDefinition;
 import ai.langstream.api.runner.assets.AssetManager;
 import ai.langstream.api.runner.assets.AssetManagerAndLoader;
 import ai.langstream.api.runner.assets.AssetManagerRegistry;
@@ -27,6 +31,7 @@ import ai.langstream.impl.common.ApplicationPlaceholderResolver;
 import ai.langstream.impl.common.DefaultAgentNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.nio.file.Path;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -80,33 +85,94 @@ public final class ApplicationDeployer implements AutoCloseable {
     /**
      * Setup the application by deploying topics and assets.
      *
-     * @param tenant
-     * @param executionPlan
      */
     public void setup(String tenant, ExecutionPlan executionPlan) {
-        setupTopics(executionPlan);
-        setupAssets(executionPlan);
-    }
-
-    private void setupTopics(ExecutionPlan executionPlan) {
-        TopicConnectionsRuntime topicConnectionsRuntime =
+        try (TopicConnectionsRuntime topicConnectionsRuntime =
                 topicConnectionsRuntimeRegistry
                         .getTopicConnectionsRuntime(
                                 executionPlan.getApplication().getInstance().streamingCluster())
-                        .asTopicConnectionsRuntime();
-        topicConnectionsRuntime.deploy(executionPlan);
-    }
-
-    private void setupAssets(ExecutionPlan executionPlan) {
-        Objects.requireNonNull(assetManagerRegistry, "Asset manager registry is not set");
-        for (AssetNode assetNode : executionPlan.getAssets()) {
-            AssetDefinition asset = MAPPER.convertValue(assetNode.config(), AssetDefinition.class);
-            setupAsset(asset, assetManagerRegistry);
+                        .asTopicConnectionsRuntime();) {
+            setupTopics(executionPlan, topicConnectionsRuntime);
+            setupAssets(tenant, executionPlan, topicConnectionsRuntime);
         }
     }
 
+    private void setupTopics(ExecutionPlan executionPlan, TopicConnectionsRuntime topicConnectionsRuntime) {
+        topicConnectionsRuntime.deploy(executionPlan);
+    }
+
+    private void setupAssets(String tenant, ExecutionPlan executionPlan, TopicConnectionsRuntime topicConnectionsRuntime) {
+        Objects.requireNonNull(assetManagerRegistry, "Asset manager registry is not set");
+        Map<String, TopicProducer> producers = new HashMap<>();
+        for (AssetNode assetNode : executionPlan.getAssets()) {
+            AssetDefinition asset = MAPPER.convertValue(assetNode.config(), AssetDefinition.class);
+            boolean created = setupAsset(asset, assetManagerRegistry);
+            if (created) {
+                sendAssetEvent(true, tenant, executionPlan, topicConnectionsRuntime, producers, asset);
+            }
+        }
+        for (TopicProducer producer : producers.values()) {
+            producer.close();
+        }
+    }
+
+    private void sendAssetEvent(boolean created, String tenant, ExecutionPlan executionPlan, TopicConnectionsRuntime topicConnectionsRuntime, Map<String, TopicProducer> producers, AssetDefinition asset) {
+        String topic = asset.getEventsTopic();
+        if (topic == null) {
+            return;
+        }
+        try {
+            String applicationId = executionPlan.getApplicationId();
+            TopicProducer producer = producers
+                    .computeIfAbsent(topic, t -> createTopicProducer(executionPlan, topicConnectionsRuntime, topic));
+            final SimpleRecord record = createAssetCreatedEventRecord(created, tenant, applicationId, asset);
+            producer.write(record).get();
+            log.info("Asset {} event sent for asset {}", created ? "created": "deleted", asset.getId());
+        } catch (Throwable tt) {
+            log.error("Error writing asset {} event for asset {}", created ? "created": "deleted",  asset.getId(), tt);
+        }
+    }
+
+    private TopicProducer createTopicProducer(ExecutionPlan executionPlan, TopicConnectionsRuntime topicConnectionsRuntime, String topic) {
+        TopicDefinition topicDefinition =
+                executionPlan.getApplication().resolveTopic(topic);
+        StreamingCluster streamingCluster = executionPlan.getApplication().getInstance().streamingCluster();
+        StreamingClusterRuntime streamingClusterRuntime =
+                registry.getStreamingClusterRuntime(streamingCluster);
+        Topic topicImplementation =
+                streamingClusterRuntime.createTopicImplementation(
+                        topicDefinition, streamingCluster);
+        final String resolvedTopicName = topicImplementation.topicName();
+
+
+        TopicProducer producer = topicConnectionsRuntime.createProducer(null, streamingCluster,
+                Map.of("topic", resolvedTopicName));
+        producer.start();
+        return producer;
+    }
+
     @SneakyThrows
-    private void setupAsset(AssetDefinition asset, AssetManagerRegistry assetManagerRegistry) {
+    private static SimpleRecord createAssetCreatedEventRecord(boolean created, String tenant, String applicationId, AssetDefinition asset) {
+        final EventSources.AssetSource source =
+                EventSources.AssetSource.builder()
+                        .tenant(tenant)
+                        .applicationId(applicationId)
+                        .asset(asset)
+                        .build();
+        final EventRecord event =
+                EventRecord.builder()
+                        .category(EventRecord.Categories.Asset)
+                        .type(created ? EventRecord.Types.AssetCreated.toString() : EventRecord.Types.AssetDeleted.toString())
+                        .timestamp(System.currentTimeMillis())
+                        .source(MAPPER.convertValue(source, Map.class))
+                        .build();
+
+        final String recordValue = MAPPER.writeValueAsString(event);
+        return SimpleRecord.builder().value(recordValue).build();
+    }
+
+    @SneakyThrows
+    private boolean setupAsset(AssetDefinition asset, AssetManagerRegistry assetManagerRegistry) {
         log.info("Deploying asset {} type {}", asset.getId(), asset.getAssetType());
         AssetManagerAndLoader assetManager =
                 assetManagerRegistry.getAssetManager(asset.getAssetType());
@@ -128,15 +194,18 @@ public final class ApplicationDeployer implements AutoCloseable {
                                 asset.getId(),
                                 asset.getAssetType());
                         assetManagerImpl.deployAsset();
+                        return true;
                     }
+                    return false;
                 }
                 case AssetDefinition.CREATE_MODE_NONE -> {
-                    return;
+                    return false;
                 }
             }
         } finally {
             assetManager.close();
         }
+        return false;
     }
 
     /**
@@ -193,8 +262,14 @@ public final class ApplicationDeployer implements AutoCloseable {
      */
     public void cleanup(String tenant, ExecutionPlan executionPlan, Path codeDirectory) {
         cleanupAgents(tenant, executionPlan, codeDirectory);
-        cleanupTopics(executionPlan);
-        cleanupAssets(executionPlan);
+        try (TopicConnectionsRuntime topicConnectionsRuntime =
+                topicConnectionsRuntimeRegistry
+                        .getTopicConnectionsRuntime(
+                                executionPlan.getApplication().getInstance().streamingCluster())
+                        .asTopicConnectionsRuntime();) {
+            cleanupTopics(executionPlan, topicConnectionsRuntime);
+            cleanupAssets(tenant, executionPlan, topicConnectionsRuntime);
+        }
     }
 
     private void cleanupAgents(String tenant, ExecutionPlan executionPlan, Path codeDirectory) {
@@ -242,25 +317,27 @@ public final class ApplicationDeployer implements AutoCloseable {
         }
     }
 
-    private void cleanupTopics(ExecutionPlan executionPlan) {
-        TopicConnectionsRuntime topicConnectionsRuntime =
-                topicConnectionsRuntimeRegistry
-                        .getTopicConnectionsRuntime(
-                                executionPlan.getApplication().getInstance().streamingCluster())
-                        .asTopicConnectionsRuntime();
+    private void cleanupTopics(ExecutionPlan executionPlan, TopicConnectionsRuntime topicConnectionsRuntime) {
         topicConnectionsRuntime.delete(executionPlan);
     }
 
-    private void cleanupAssets(ExecutionPlan executionPlan) {
+    private void cleanupAssets(String tenant, ExecutionPlan executionPlan, TopicConnectionsRuntime topicConnectionsRuntime) {
         Objects.requireNonNull(assetManagerRegistry, "Asset manager registry is not set");
+        Map<String, TopicProducer> producers = new HashMap<>();
         for (AssetNode assetNode : executionPlan.getAssets()) {
             AssetDefinition asset = MAPPER.convertValue(assetNode.config(), AssetDefinition.class);
-            cleanupAsset(asset);
+            boolean deleted = cleanupAsset(asset);
+            if (deleted) {
+                sendAssetEvent(false, tenant, executionPlan, topicConnectionsRuntime, producers, asset);
+            }
+        }
+        for (TopicProducer producer : producers.values()) {
+            producer.close();
         }
     }
 
     @SneakyThrows
-    private void cleanupAsset(AssetDefinition asset) {
+    private boolean cleanupAsset(AssetDefinition asset) {
         log.info(
                 "Cleaning up asset {} type {} with deletion mode {}",
                 asset.getId(),
@@ -283,12 +360,12 @@ public final class ApplicationDeployer implements AutoCloseable {
                                 "Deleting asset {} of type {}",
                                 asset.getId(),
                                 asset.getAssetType());
-                        assetManagerImpl.deleteAssetIfExists();
-                        break;
+                        return assetManagerImpl.deleteAssetIfExists();
                     }
                 default:
                     {
                         log.info("Keep asset {} of type {}", asset.getId(), asset.getAssetType());
+                        return false;
                     }
             }
         } finally {

--- a/langstream-core/src/main/java/ai/langstream/impl/parser/ModelBuilder.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/parser/ModelBuilder.java
@@ -706,6 +706,7 @@ public class ModelBuilder {
                                     assetDefinition.getCreationMode(),
                                     assetDefinition.getDeletionMode(),
                                     assetDefinition.getAssetType(),
+                                    assetDefinition.getEventsTopic(),
                                     assetDefinition.getConfig()));
                 }
             }
@@ -910,6 +911,9 @@ public class ModelBuilder {
 
         @JsonProperty("asset-type")
         private String assetType;
+
+        @JsonProperty("events-topic")
+        private String eventsTopic;
 
         private Map<String, Object> config;
     }

--- a/langstream-kafka-runtime/src/main/java/ai/langstream/kafka/runner/KafkaTopicConnectionsRuntime.java
+++ b/langstream-kafka-runtime/src/main/java/ai/langstream/kafka/runner/KafkaTopicConnectionsRuntime.java
@@ -40,6 +40,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;

--- a/langstream-kafka-runtime/src/main/java/ai/langstream/kafka/runner/KafkaTopicConnectionsRuntime.java
+++ b/langstream-kafka-runtime/src/main/java/ai/langstream/kafka/runner/KafkaTopicConnectionsRuntime.java
@@ -40,7 +40,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;

--- a/langstream-kafka-runtime/src/test/java/ai/langstream/kafka/KafkaConsumerTest.java
+++ b/langstream-kafka-runtime/src/test/java/ai/langstream/kafka/KafkaConsumerTest.java
@@ -129,7 +129,6 @@ class KafkaConsumerTest {
         StreamingCluster streamingCluster =
                 implementation.getApplication().getInstance().streamingCluster();
         KafkaTopicConnectionsRuntime runtime = new KafkaTopicConnectionsRuntime();
-        runtime.init(streamingCluster);
         String agentId = "agent-1";
         try (TopicProducer producer =
                         runtime.createProducer(
@@ -261,7 +260,6 @@ class KafkaConsumerTest {
         StreamingCluster streamingCluster =
                 implementation.getApplication().getInstance().streamingCluster();
         KafkaTopicConnectionsRuntime runtime = new KafkaTopicConnectionsRuntime();
-        runtime.init(streamingCluster);
         String agentId = "agent-1";
         try (TopicProducer producer =
                         runtime.createProducer(
@@ -363,7 +361,6 @@ class KafkaConsumerTest {
         StreamingCluster streamingCluster =
                 implementation.getApplication().getInstance().streamingCluster();
         KafkaTopicConnectionsRuntime runtime = new KafkaTopicConnectionsRuntime();
-        runtime.init(streamingCluster);
         String agentId = "agent-1";
         try (TopicProducer producer =
                 runtime.createProducer(agentId, streamingCluster, Map.of("topic", topicName)); ) {
@@ -460,7 +457,6 @@ class KafkaConsumerTest {
         StreamingCluster streamingCluster =
                 implementation.getApplication().getInstance().streamingCluster();
         KafkaTopicConnectionsRuntime runtime = new KafkaTopicConnectionsRuntime();
-        runtime.init(streamingCluster);
         String agentId = "agent-1";
         try (TopicProducer producer =
                 runtime.createProducer(agentId, streamingCluster, Map.of("topic", topicName)); ) {

--- a/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/AgentRunner.java
+++ b/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/AgentRunner.java
@@ -272,8 +272,6 @@ public class AgentRunner {
                 Executors.newSingleThreadScheduledExecutor(r -> new Thread(r, statsThreadName));
         try {
 
-            topicConnectionsRuntime.init(configuration.streamingCluster());
-
             // this is closed by the TopicSource
             final TopicConsumer consumer;
             TopicProducer deadLetterProducer = null;

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/assets/DeployAssetsTest.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/assets/DeployAssetsTest.java
@@ -16,14 +16,24 @@
 package ai.langstream.assets;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import ai.langstream.api.model.AssetDefinition;
 import ai.langstream.api.runtime.ExecutionPlan;
 import ai.langstream.kafka.AbstractKafkaApplicationRunner;
 import ai.langstream.mockagents.MockAssetManagerCodeProvider;
+
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Consumer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.pulsar.common.api.proto.CommandEndTxnOnSubscription;
 import org.junit.jupiter.api.Test;
 
 @Slf4j
@@ -62,12 +72,13 @@ class DeployAssetsTest extends AbstractKafkaApplicationRunner {
                           - name: "my-table"
                             creation-mode: create-if-not-exists
                             asset-type: "mock-database-resource"
+                            events-topic: "events-topic"
+                            deletion-mode: delete
                             config:
                                 table: "${globals.table-name}"
                                 datasource: "the-resource"
                           - name: "my-table2"
                             creation-mode: create-if-not-exists
-                            deletion-mode: delete
                             asset-type: "mock-database-resource"
                             config:
                                 table: "other2"
@@ -77,6 +88,8 @@ class DeployAssetsTest extends AbstractKafkaApplicationRunner {
                             creation-mode: create-if-not-exists
                           - name: "output-topic"
                             creation-mode: create-if-not-exists
+                          - name: "events-topic"
+                            creation-mode: create-if-not-exists
                         pipeline:
                           - name: "identity"
                             id: "step1"
@@ -84,7 +97,8 @@ class DeployAssetsTest extends AbstractKafkaApplicationRunner {
                             input: "input-topic"
                             output: "output-topic"
                         """);
-        try (ApplicationRuntime applicationRuntime =
+        try (KafkaConsumer<String, String> consumer = createConsumer("events-topic");
+             ApplicationRuntime applicationRuntime =
                 deployApplicationWithSecrets(
                         tenant, "app", application, buildInstanceYaml(), secrets, expectedAgents)) {
             CopyOnWriteArrayList<AssetDefinition> deployedAssets =
@@ -98,9 +112,49 @@ class DeployAssetsTest extends AbstractKafkaApplicationRunner {
                     (Map<String, Object>) datasource.get("configuration");
             assertEquals("bar", datasourceConfiguration.get("url"));
 
+            waitForMessages(consumer, List.of(
+                    new Consumer<>() {
+                        @Override
+                        @SneakyThrows
+                        public void accept(Object o) {
+                            log.info("Received: {}", o);
+                            ObjectMapper mapper = new ObjectMapper();
+                            Map read = mapper.readValue((String) o, Map.class);
+                            assertEquals(
+                                    "AssetCreated", read.get("type"));
+                            assertEquals(
+                                    "Asset", read.get("category"));
+                            assertEquals(
+                                    "{\"tenant\":\"tenant\",\"applicationId\":\"app\",\"asset\":{\"id\":\"my-table\",\"name\":\"my-table\",\"config\":{\"datasource\":{\"configuration\":{\"service\":\"jdbc\",\"driverClass\":\"org.postgresql.Driver\",\"url\":\"bar\"}},\"table\":\"my-table\"},\"creation-mode\":\"create-if-not-exists\",\"deletion-mode\":\"delete\",\"asset-type\":\"mock-database-resource\",\"events-topic\":\"events-topic\"}}", mapper.writeValueAsString(read.get("source")));
+                            assertNotNull(read.get("timestamp"));
+                        }
+                    }
+            ));
+
+
             final ExecutionPlan plan = applicationRuntime.implementation();
             applicationDeployer.cleanup(tenant, plan, codeDirectory);
             assertEquals(1, deployedAssets.size());
+
+            waitForMessages(consumer, List.of(
+                    new Consumer<>() {
+                        @Override
+                        @SneakyThrows
+                        public void accept(Object o) {
+                            log.info("Received: {}", o);
+                            ObjectMapper mapper = new ObjectMapper();
+                            Map read = mapper.readValue((String) o, Map.class);
+                            assertEquals(
+                                    "AssetDeleted", read.get("type"));
+                            assertEquals(
+                                    "Asset", read.get("category"));
+                            assertEquals(
+                                    "{\"tenant\":\"tenant\",\"applicationId\":\"app\",\"asset\":{\"id\":\"my-table\",\"name\":\"my-table\",\"config\":{\"datasource\":{\"configuration\":{\"service\":\"jdbc\",\"driverClass\":\"org.postgresql.Driver\",\"url\":\"bar\"}},\"table\":\"my-table\"},\"creation-mode\":\"create-if-not-exists\",\"deletion-mode\":\"delete\",\"asset-type\":\"mock-database-resource\",\"events-topic\":\"events-topic\"}}", mapper.writeValueAsString(read.get("source")));
+                            assertNotNull(read.get("timestamp"));
+                        }
+                    }
+            ));
+
         }
     }
 


### PR DESCRIPTION
added `events-topic` to asset definition. 
If defined, when the asset is created or deleted (for app upgrades, it depends on wheter the asset already exists or not) an event is sent to that topic.

the event message looks like this:
```
{
 "category": "Asset",
 "type" : "AssetDeleted" // "AssetCreated",
  "source": // asset def
    { "id": "my-asset" ....}
}
```

