### PR TITLE
feat: gateway jwt auth supports revoked tokens

### DIFF
--- a/langstream-api-gateway-auth/langstream-common-api-gateway-auth/pom.xml
+++ b/langstream-api-gateway-auth/langstream-common-api-gateway-auth/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>langstream-api-gateway-auth</artifactId>
     <groupId>ai.langstream</groupId>
-    <version>0.18.1-SNAPSHOT</version>
+    <version>0.19.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/langstream-api-gateway-auth/langstream-common-api-gateway-auth/pom.xml
+++ b/langstream-api-gateway-auth/langstream-common-api-gateway-auth/pom.xml
@@ -18,20 +18,33 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
-    <artifactId>langstream-ai</artifactId>
+    <artifactId>langstream-api-gateway-auth</artifactId>
     <groupId>ai.langstream</groupId>
-    <version>0.19.2-SNAPSHOT</version>
+    <version>0.18.1-SNAPSHOT</version>
   </parent>
-  <packaging>pom</packaging>
   <modelVersion>4.0.0</modelVersion>
 
-  <artifactId>langstream-api-gateway-auth</artifactId>
+  <artifactId>langstream-common-api-gateway-auth</artifactId>
 
-  <modules>
-    <module>langstream-common-api-gateway-auth</module>
-    <module>langstream-google-api-gateway-auth</module>
-    <module>langstream-github-api-gateway-auth</module>
-    <module>langstream-jwt-api-gateway-auth</module>
-    <module>langstream-http-api-gateway-auth</module>
-  </modules>
+  <dependencies>
+    <dependency>
+      <groupId>ai.langstream</groupId>
+      <artifactId>langstream-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>ai.langstream</groupId>
+      <artifactId>langstream-auth-jwt</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.minio</groupId>
+      <artifactId>minio</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
 </project>

--- a/langstream-api-gateway-auth/langstream-common-api-gateway-auth/pom.xml
+++ b/langstream-api-gateway-auth/langstream-common-api-gateway-auth/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>langstream-api-gateway-auth</artifactId>
     <groupId>ai.langstream</groupId>
-    <version>0.19.1-SNAPSHOT</version>
+    <version>0.19.2-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/langstream-api-gateway-auth/langstream-common-api-gateway-auth/src/main/java/ai/langstream/apigateway/auth/common/store/RevokedTokensAwareAuthenticationProvider.java
+++ b/langstream-api-gateway-auth/langstream-common-api-gateway-auth/src/main/java/ai/langstream/apigateway/auth/common/store/RevokedTokensAwareAuthenticationProvider.java
@@ -1,0 +1,58 @@
+package ai.langstream.apigateway.auth.common.store;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Timer;
+import java.util.TimerTask;
+
+@Slf4j
+public class RevokedTokensAwareAuthenticationProvider implements AutoCloseable{
+
+
+    protected RevokedTokensStore revokedTokesStore;
+
+    private Timer timer;
+
+
+    public void startSyncRevokedTokens(RevokedTokensStoreConfiguration configuration) {
+        if (configuration != null) {
+
+            switch (configuration.type()) {
+                case "s3":
+                    revokedTokesStore = new S3RevokedTokensStore(configuration.config());
+                    break;
+                default:
+                    throw new IllegalArgumentException("Unknown revoked token store type: " + configuration.type());
+            }
+
+            timer = new Timer();
+            final int refreshPeriodSeconds = configuration.refreshPeriod() <= 0 ? 30 : configuration.refreshPeriod();
+            timer.scheduleAtFixedRate(new TimerTask() {
+                @Override
+                public void run() {
+                    try {
+                        revokedTokesStore.refreshRevokedTokens();
+                        onRevokedTokensRefreshed();
+                    } catch (Throwable tt) {
+                        log.error("Error refreshing revoked tokens", tt);
+                    }
+
+                }
+            }, 0, refreshPeriodSeconds * 1000L);
+        }
+    }
+
+    // for testing
+    public void onRevokedTokensRefreshed() {
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (timer != null) {
+            timer.cancel();
+        }
+        if (revokedTokesStore != null) {
+            revokedTokesStore.close();
+        }
+    }
+}

--- a/langstream-api-gateway-auth/langstream-common-api-gateway-auth/src/main/java/ai/langstream/apigateway/auth/common/store/RevokedTokensAwareAuthenticationProvider.java
+++ b/langstream-api-gateway-auth/langstream-common-api-gateway-auth/src/main/java/ai/langstream/apigateway/auth/common/store/RevokedTokensAwareAuthenticationProvider.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ai.langstream.apigateway.auth.common.store;
 
 import java.util.Timer;

--- a/langstream-api-gateway-auth/langstream-common-api-gateway-auth/src/main/java/ai/langstream/apigateway/auth/common/store/RevokedTokensAwareAuthenticationProvider.java
+++ b/langstream-api-gateway-auth/langstream-common-api-gateway-auth/src/main/java/ai/langstream/apigateway/auth/common/store/RevokedTokensAwareAuthenticationProvider.java
@@ -1,18 +1,15 @@
 package ai.langstream.apigateway.auth.common.store;
 
-import lombok.extern.slf4j.Slf4j;
-
 import java.util.Timer;
 import java.util.TimerTask;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class RevokedTokensAwareAuthenticationProvider implements AutoCloseable{
-
+public class RevokedTokensAwareAuthenticationProvider implements AutoCloseable {
 
     protected RevokedTokensStore revokedTokesStore;
 
     private Timer timer;
-
 
     public void startSyncRevokedTokens(RevokedTokensStoreConfiguration configuration) {
         if (configuration != null) {
@@ -22,29 +19,32 @@ public class RevokedTokensAwareAuthenticationProvider implements AutoCloseable{
                     revokedTokesStore = new S3RevokedTokensStore(configuration.config());
                     break;
                 default:
-                    throw new IllegalArgumentException("Unknown revoked token store type: " + configuration.type());
+                    throw new IllegalArgumentException(
+                            "Unknown revoked token store type: " + configuration.type());
             }
 
             timer = new Timer();
-            final int refreshPeriodSeconds = configuration.refreshPeriod() <= 0 ? 30 : configuration.refreshPeriod();
-            timer.scheduleAtFixedRate(new TimerTask() {
-                @Override
-                public void run() {
-                    try {
-                        revokedTokesStore.refreshRevokedTokens();
-                        onRevokedTokensRefreshed();
-                    } catch (Throwable tt) {
-                        log.error("Error refreshing revoked tokens", tt);
-                    }
-
-                }
-            }, 0, refreshPeriodSeconds * 1000L);
+            final int refreshPeriodSeconds =
+                    configuration.refreshPeriod() <= 0 ? 30 : configuration.refreshPeriod();
+            timer.scheduleAtFixedRate(
+                    new TimerTask() {
+                        @Override
+                        public void run() {
+                            try {
+                                revokedTokesStore.refreshRevokedTokens();
+                                onRevokedTokensRefreshed();
+                            } catch (Throwable tt) {
+                                log.error("Error refreshing revoked tokens", tt);
+                            }
+                        }
+                    },
+                    0,
+                    refreshPeriodSeconds * 1000L);
         }
     }
 
     // for testing
-    public void onRevokedTokensRefreshed() {
-    }
+    public void onRevokedTokensRefreshed() {}
 
     @Override
     public void close() throws Exception {

--- a/langstream-api-gateway-auth/langstream-common-api-gateway-auth/src/main/java/ai/langstream/apigateway/auth/common/store/RevokedTokensAwareAuthenticationProvider.java
+++ b/langstream-api-gateway-auth/langstream-common-api-gateway-auth/src/main/java/ai/langstream/apigateway/auth/common/store/RevokedTokensAwareAuthenticationProvider.java
@@ -16,7 +16,7 @@ public class RevokedTokensAwareAuthenticationProvider implements AutoCloseable {
 
             switch (configuration.type()) {
                 case "s3":
-                    revokedTokesStore = new S3RevokedTokensStore(configuration.config());
+                    revokedTokesStore = new S3RevokedTokensStore(configuration.configuration());
                     break;
                 default:
                     throw new IllegalArgumentException(

--- a/langstream-api-gateway-auth/langstream-common-api-gateway-auth/src/main/java/ai/langstream/apigateway/auth/common/store/RevokedTokensStore.java
+++ b/langstream-api-gateway-auth/langstream-common-api-gateway-auth/src/main/java/ai/langstream/apigateway/auth/common/store/RevokedTokensStore.java
@@ -1,0 +1,10 @@
+package ai.langstream.apigateway.auth.common.store;
+
+public interface RevokedTokensStore extends AutoCloseable {
+
+
+    void refreshRevokedTokens();
+
+    boolean isTokenRevoked(String token);
+
+}

--- a/langstream-api-gateway-auth/langstream-common-api-gateway-auth/src/main/java/ai/langstream/apigateway/auth/common/store/RevokedTokensStore.java
+++ b/langstream-api-gateway-auth/langstream-common-api-gateway-auth/src/main/java/ai/langstream/apigateway/auth/common/store/RevokedTokensStore.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ai.langstream.apigateway.auth.common.store;
 
 public interface RevokedTokensStore extends AutoCloseable {

--- a/langstream-api-gateway-auth/langstream-common-api-gateway-auth/src/main/java/ai/langstream/apigateway/auth/common/store/RevokedTokensStore.java
+++ b/langstream-api-gateway-auth/langstream-common-api-gateway-auth/src/main/java/ai/langstream/apigateway/auth/common/store/RevokedTokensStore.java
@@ -2,9 +2,7 @@ package ai.langstream.apigateway.auth.common.store;
 
 public interface RevokedTokensStore extends AutoCloseable {
 
-
     void refreshRevokedTokens();
 
     boolean isTokenRevoked(String token);
-
 }

--- a/langstream-api-gateway-auth/langstream-common-api-gateway-auth/src/main/java/ai/langstream/apigateway/auth/common/store/RevokedTokensStoreConfiguration.java
+++ b/langstream-api-gateway-auth/langstream-common-api-gateway-auth/src/main/java/ai/langstream/apigateway/auth/common/store/RevokedTokensStoreConfiguration.java
@@ -1,9 +1,9 @@
 package ai.langstream.apigateway.auth.common.store;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.util.Map;
 
-public record RevokedTokensStoreConfiguration(String type, @JsonProperty("refresh-period-seconds") int refreshPeriod,
-                                              Map<String, Object> config) {
-}
+public record RevokedTokensStoreConfiguration(
+        String type,
+        @JsonProperty("refresh-period-seconds") int refreshPeriod,
+        Map<String, Object> configuration) {}

--- a/langstream-api-gateway-auth/langstream-common-api-gateway-auth/src/main/java/ai/langstream/apigateway/auth/common/store/RevokedTokensStoreConfiguration.java
+++ b/langstream-api-gateway-auth/langstream-common-api-gateway-auth/src/main/java/ai/langstream/apigateway/auth/common/store/RevokedTokensStoreConfiguration.java
@@ -1,0 +1,9 @@
+package ai.langstream.apigateway.auth.common.store;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Map;
+
+public record RevokedTokensStoreConfiguration(String type, @JsonProperty("refresh-period-seconds") int refreshPeriod,
+                                              Map<String, Object> config) {
+}

--- a/langstream-api-gateway-auth/langstream-common-api-gateway-auth/src/main/java/ai/langstream/apigateway/auth/common/store/RevokedTokensStoreConfiguration.java
+++ b/langstream-api-gateway-auth/langstream-common-api-gateway-auth/src/main/java/ai/langstream/apigateway/auth/common/store/RevokedTokensStoreConfiguration.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ai.langstream.apigateway.auth.common.store;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/langstream-api-gateway-auth/langstream-common-api-gateway-auth/src/main/java/ai/langstream/apigateway/auth/common/store/S3RevokedTokensStore.java
+++ b/langstream-api-gateway-auth/langstream-common-api-gateway-auth/src/main/java/ai/langstream/apigateway/auth/common/store/S3RevokedTokensStore.java
@@ -1,0 +1,127 @@
+package ai.langstream.apigateway.auth.common.store;
+
+import io.minio.DownloadObjectArgs;
+import io.minio.MinioClient;
+import io.minio.errors.ErrorResponseException;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static ai.langstream.api.util.ConfigurationUtils.getString;
+
+@Slf4j
+public class S3RevokedTokensStore implements RevokedTokensStore {
+
+    private final MinioClient minioClient;
+    private final String bucketName;
+    private final String objectName;
+
+    private volatile Set<String> revokedTokens = new HashSet<>();
+
+    public S3RevokedTokensStore(Map<String, Object> config) {
+        bucketName =
+                getString(
+                        "s3-bucket", null,
+                        config);
+
+        objectName =
+                getString(
+                        "s3-object", null,
+                        config);
+        if (bucketName == null || objectName == null) {
+            throw new IllegalArgumentException("S3 bucket and object name must be provided");
+        }
+        final String endpoint =
+                getString(
+                        "s3-endpoint",
+                        null,
+                        config);
+        final String username =
+                getString("s3-access-key", null, config);
+        final String password =
+                getString("s3-secret-key", null, config);
+        final String region = getString("s3-region", "", config);
+
+        log.info(
+                "Connecting to S3 Bucket at {} in region {} with user {}",
+                endpoint,
+                region,
+                username);
+
+        MinioClient.Builder builder =
+                MinioClient.builder().endpoint(endpoint).credentials(username, password);
+        if (!region.isBlank()) {
+            builder.region(region);
+        }
+        minioClient = builder.build();
+    }
+
+    @Override
+    public boolean isTokenRevoked(String token) {
+        synchronized (this) {
+            return revokedTokens.contains(token);
+        }
+    }
+
+    @Override
+    @SneakyThrows
+    public void refreshRevokedTokens() {
+        Set<String> temporaryRevokedTokens = readRevokedTokensFromObject();
+        if (temporaryRevokedTokens == null) {
+            return;
+        }
+        log.info("refreshed revoked tokens, new count {}, old count {}", temporaryRevokedTokens.size(), revokedTokens.size());
+        synchronized (this) {
+            revokedTokens = temporaryRevokedTokens;
+        }
+    }
+
+    private Set<String> readRevokedTokensFromObject() throws IOException {
+        Path tempDirectory = Files.createTempDirectory("revoked-tokens");
+        Path tempFile = tempDirectory.resolve("revoked-tokens.txt");
+        Set<String> temporaryRevokedTokens = new HashSet<>();
+        try {
+            DownloadObjectArgs downloadObjectArgs = DownloadObjectArgs.builder()
+                    .bucket(bucketName)
+                    .object(objectName)
+                    .filename(tempFile.toAbsolutePath().toString())
+                    .build();
+            minioClient.downloadObject(downloadObjectArgs);
+            try (BufferedReader br = new BufferedReader(new FileReader(tempFile.toFile()))) {
+                String line;
+                while ((line = br.readLine()) != null) {
+                    temporaryRevokedTokens.add(line);
+                }
+            }
+        } catch (ErrorResponseException e) {
+            if (e.errorResponse().code().equals("NoSuchKey")) {
+                log.warn("No revoked tokens file found in S3");
+                return null;
+            } else {
+                log.error("Error downloading revoked tokens from S3", e);
+                throw new RuntimeException(e);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        } finally {
+            tempFile.toFile().delete();
+            tempDirectory.toFile().delete();
+        }
+        return temporaryRevokedTokens;
+    }
+
+    @Override
+    public void close() throws Exception {
+        if(minioClient != null) {
+            minioClient.close();
+        }
+    }
+}

--- a/langstream-api-gateway-auth/langstream-common-api-gateway-auth/src/main/java/ai/langstream/apigateway/auth/common/store/S3RevokedTokensStore.java
+++ b/langstream-api-gateway-auth/langstream-common-api-gateway-auth/src/main/java/ai/langstream/apigateway/auth/common/store/S3RevokedTokensStore.java
@@ -1,11 +1,10 @@
 package ai.langstream.apigateway.auth.common.store;
 
+import static ai.langstream.api.util.ConfigurationUtils.getString;
+
 import io.minio.DownloadObjectArgs;
 import io.minio.MinioClient;
 import io.minio.errors.ErrorResponseException;
-import lombok.SneakyThrows;
-import lombok.extern.slf4j.Slf4j;
-
 import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
@@ -14,8 +13,8 @@ import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-
-import static ai.langstream.api.util.ConfigurationUtils.getString;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class S3RevokedTokensStore implements RevokedTokensStore {
@@ -27,27 +26,15 @@ public class S3RevokedTokensStore implements RevokedTokensStore {
     private volatile Set<String> revokedTokens = new HashSet<>();
 
     public S3RevokedTokensStore(Map<String, Object> config) {
-        bucketName =
-                getString(
-                        "s3-bucket", null,
-                        config);
+        bucketName = getString("s3-bucket", null, config);
 
-        objectName =
-                getString(
-                        "s3-object", null,
-                        config);
+        objectName = getString("s3-object", null, config);
         if (bucketName == null || objectName == null) {
             throw new IllegalArgumentException("S3 bucket and object name must be provided");
         }
-        final String endpoint =
-                getString(
-                        "s3-endpoint",
-                        null,
-                        config);
-        final String username =
-                getString("s3-access-key", null, config);
-        final String password =
-                getString("s3-secret-key", null, config);
+        final String endpoint = getString("s3-endpoint", null, config);
+        final String username = getString("s3-access-key", null, config);
+        final String password = getString("s3-secret-key", null, config);
         final String region = getString("s3-region", "", config);
 
         log.info(
@@ -78,7 +65,10 @@ public class S3RevokedTokensStore implements RevokedTokensStore {
         if (temporaryRevokedTokens == null) {
             return;
         }
-        log.info("refreshed revoked tokens, new count {}, old count {}", temporaryRevokedTokens.size(), revokedTokens.size());
+        log.info(
+                "refreshed revoked tokens, new count {}, old count {}",
+                temporaryRevokedTokens.size(),
+                revokedTokens.size());
         synchronized (this) {
             revokedTokens = temporaryRevokedTokens;
         }
@@ -89,11 +79,12 @@ public class S3RevokedTokensStore implements RevokedTokensStore {
         Path tempFile = tempDirectory.resolve("revoked-tokens.txt");
         Set<String> temporaryRevokedTokens = new HashSet<>();
         try {
-            DownloadObjectArgs downloadObjectArgs = DownloadObjectArgs.builder()
-                    .bucket(bucketName)
-                    .object(objectName)
-                    .filename(tempFile.toAbsolutePath().toString())
-                    .build();
+            DownloadObjectArgs downloadObjectArgs =
+                    DownloadObjectArgs.builder()
+                            .bucket(bucketName)
+                            .object(objectName)
+                            .filename(tempFile.toAbsolutePath().toString())
+                            .build();
             minioClient.downloadObject(downloadObjectArgs);
             try (BufferedReader br = new BufferedReader(new FileReader(tempFile.toFile()))) {
                 String line;
@@ -120,7 +111,7 @@ public class S3RevokedTokensStore implements RevokedTokensStore {
 
     @Override
     public void close() throws Exception {
-        if(minioClient != null) {
+        if (minioClient != null) {
             minioClient.close();
         }
     }

--- a/langstream-api-gateway-auth/langstream-common-api-gateway-auth/src/main/java/ai/langstream/apigateway/auth/common/store/S3RevokedTokensStore.java
+++ b/langstream-api-gateway-auth/langstream-common-api-gateway-auth/src/main/java/ai/langstream/apigateway/auth/common/store/S3RevokedTokensStore.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ai.langstream.apigateway.auth.common.store;
 
 import static ai.langstream.api.util.ConfigurationUtils.getString;

--- a/langstream-api-gateway-auth/langstream-github-api-gateway-auth/src/main/java/ai/langstream/apigateway/auth/impl/github/GitHubAuthenticationProvider.java
+++ b/langstream-api-gateway-auth/langstream-github-api-gateway-auth/src/main/java/ai/langstream/apigateway/auth/impl/github/GitHubAuthenticationProvider.java
@@ -19,6 +19,8 @@ import ai.langstream.api.gateway.GatewayAuthenticationProvider;
 import ai.langstream.api.gateway.GatewayAuthenticationResult;
 import ai.langstream.api.gateway.GatewayRequestContext;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -33,6 +35,7 @@ public class GitHubAuthenticationProvider implements GatewayAuthenticationProvid
     private static final ObjectMapper mapper = new ObjectMapper();
 
     private String clientId;
+    private final HttpClient client = HttpClient.newHttpClient();
 
     @Override
     public String type() {
@@ -61,8 +64,6 @@ public class GitHubAuthenticationProvider implements GatewayAuthenticationProvid
             */
 
             if (token != null) {
-
-                HttpClient client = HttpClient.newHttpClient();
                 HttpRequest request =
                         HttpRequest.newBuilder()
                                 .uri(URI.create("https://api.github.com/user"))
@@ -105,5 +106,9 @@ public class GitHubAuthenticationProvider implements GatewayAuthenticationProvid
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @Override
+    public void close() throws Exception {
     }
 }

--- a/langstream-api-gateway-auth/langstream-github-api-gateway-auth/src/main/java/ai/langstream/apigateway/auth/impl/github/GitHubAuthenticationProvider.java
+++ b/langstream-api-gateway-auth/langstream-github-api-gateway-auth/src/main/java/ai/langstream/apigateway/auth/impl/github/GitHubAuthenticationProvider.java
@@ -19,8 +19,6 @@ import ai.langstream.api.gateway.GatewayAuthenticationProvider;
 import ai.langstream.api.gateway.GatewayAuthenticationResult;
 import ai.langstream.api.gateway.GatewayRequestContext;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
-import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -109,6 +107,5 @@ public class GitHubAuthenticationProvider implements GatewayAuthenticationProvid
     }
 
     @Override
-    public void close() throws Exception {
-    }
+    public void close() throws Exception {}
 }

--- a/langstream-api-gateway-auth/langstream-google-api-gateway-auth/src/main/java/ai/langstream/apigateway/auth/impl/google/GoogleAuthenticationProvider.java
+++ b/langstream-api-gateway-auth/langstream-google-api-gateway-auth/src/main/java/ai/langstream/apigateway/auth/impl/google/GoogleAuthenticationProvider.java
@@ -82,6 +82,5 @@ public class GoogleAuthenticationProvider implements GatewayAuthenticationProvid
     }
 
     @Override
-    public void close() throws Exception {
-    }
+    public void close() throws Exception {}
 }

--- a/langstream-api-gateway-auth/langstream-google-api-gateway-auth/src/main/java/ai/langstream/apigateway/auth/impl/google/GoogleAuthenticationProvider.java
+++ b/langstream-api-gateway-auth/langstream-google-api-gateway-auth/src/main/java/ai/langstream/apigateway/auth/impl/google/GoogleAuthenticationProvider.java
@@ -80,4 +80,8 @@ public class GoogleAuthenticationProvider implements GatewayAuthenticationProvid
             throw new RuntimeException(e);
         }
     }
+
+    @Override
+    public void close() throws Exception {
+    }
 }

--- a/langstream-api-gateway-auth/langstream-http-api-gateway-auth/src/main/java/ai/langstream/apigateway/auth/impl/jwt/admin/HttpAuthenticationProvider.java
+++ b/langstream-api-gateway-auth/langstream-http-api-gateway-auth/src/main/java/ai/langstream/apigateway/auth/impl/jwt/admin/HttpAuthenticationProvider.java
@@ -90,4 +90,9 @@ public class HttpAuthenticationProvider implements GatewayAuthenticationProvider
         }
         return url;
     }
+
+    @Override
+    public void close() throws Exception {
+
+    }
 }

--- a/langstream-api-gateway-auth/langstream-http-api-gateway-auth/src/main/java/ai/langstream/apigateway/auth/impl/jwt/admin/HttpAuthenticationProvider.java
+++ b/langstream-api-gateway-auth/langstream-http-api-gateway-auth/src/main/java/ai/langstream/apigateway/auth/impl/jwt/admin/HttpAuthenticationProvider.java
@@ -92,7 +92,5 @@ public class HttpAuthenticationProvider implements GatewayAuthenticationProvider
     }
 
     @Override
-    public void close() throws Exception {
-
-    }
+    public void close() throws Exception {}
 }

--- a/langstream-api-gateway-auth/langstream-jwt-api-gateway-auth/pom.xml
+++ b/langstream-api-gateway-auth/langstream-jwt-api-gateway-auth/pom.xml
@@ -37,5 +37,39 @@
       <artifactId>langstream-auth-jwt</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>ai.langstream</groupId>
+      <artifactId>langstream-common-api-gateway-auth</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>localstack</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.github.tomakehurst</groupId>
+      <artifactId>wiremock</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.github.tomakehurst</groupId>
+      <artifactId>wiremock</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/langstream-api-gateway-auth/langstream-jwt-api-gateway-auth/src/main/java/ai/langstream/apigateway/auth/impl/jwt/admin/JwtAuthenticationProvider.java
+++ b/langstream-api-gateway-auth/langstream-jwt-api-gateway-auth/src/main/java/ai/langstream/apigateway/auth/impl/jwt/admin/JwtAuthenticationProvider.java
@@ -22,15 +22,14 @@ import ai.langstream.apigateway.auth.common.store.RevokedTokensAwareAuthenticati
 import ai.langstream.auth.jwt.AuthenticationProviderToken;
 import ai.langstream.auth.jwt.JwtProperties;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import java.util.List;
 import java.util.Map;
-
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class JwtAuthenticationProvider extends RevokedTokensAwareAuthenticationProvider implements GatewayAuthenticationProvider {
+public class JwtAuthenticationProvider extends RevokedTokensAwareAuthenticationProvider
+        implements GatewayAuthenticationProvider {
 
     private static final ObjectMapper mapper = new ObjectMapper();
     private AuthenticationProviderToken authenticationProviderToken;
@@ -74,7 +73,8 @@ public class JwtAuthenticationProvider extends RevokedTokensAwareAuthenticationP
         String role;
         try {
             final String credentials = context.credentials();
-            if (revokedTokesStore != null && revokedTokesStore.isTokenRevoked(context.credentials())) {
+            if (revokedTokesStore != null
+                    && revokedTokesStore.isTokenRevoked(context.credentials())) {
                 log.warn("Attempt to use revoked token: {}.", context.credentials());
                 return GatewayAuthenticationResult.authenticationFailed("Invalid token.");
             }

--- a/langstream-api-gateway-auth/langstream-jwt-api-gateway-auth/src/main/java/ai/langstream/apigateway/auth/impl/jwt/admin/JwtAuthenticationProviderConfiguration.java
+++ b/langstream-api-gateway-auth/langstream-jwt-api-gateway-auth/src/main/java/ai/langstream/apigateway/auth/impl/jwt/admin/JwtAuthenticationProviderConfiguration.java
@@ -17,27 +17,15 @@ package ai.langstream.apigateway.auth.impl.jwt.admin;
 
 import ai.langstream.apigateway.auth.common.store.RevokedTokensStoreConfiguration;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.util.List;
-import java.util.Map;
 
 public record JwtAuthenticationProviderConfiguration(
-        @JsonProperty("secret-key")
-        String secretKey,
-        @JsonProperty("public-key")
-        String publicKey,
-        @JsonProperty("auth-claim")
-        String authClaim,
-        @JsonProperty("public-alg")
-        String publicAlg,
-        @JsonProperty("audience-claim")
-        String audienceClaim,
+        @JsonProperty("secret-key") String secretKey,
+        @JsonProperty("public-key") String publicKey,
+        @JsonProperty("auth-claim") String authClaim,
+        @JsonProperty("public-alg") String publicAlg,
+        @JsonProperty("audience-claim") String audienceClaim,
         String audience,
-        @JsonProperty("admin-roles")
-        List<String> adminRoles,
-        @JsonProperty("jwks-hosts-allowlist")
-        String jwksHostsAllowlist,
-        @JsonProperty("revoked-tokens-store")
-        RevokedTokensStoreConfiguration revokedTokenStore) {
-
-}
+        @JsonProperty("admin-roles") List<String> adminRoles,
+        @JsonProperty("jwks-hosts-allowlist") String jwksHostsAllowlist,
+        @JsonProperty("revoked-tokens-store") RevokedTokensStoreConfiguration revokedTokenStore) {}

--- a/langstream-api-gateway-auth/langstream-jwt-api-gateway-auth/src/main/java/ai/langstream/apigateway/auth/impl/jwt/admin/JwtAuthenticationProviderConfiguration.java
+++ b/langstream-api-gateway-auth/langstream-jwt-api-gateway-auth/src/main/java/ai/langstream/apigateway/auth/impl/jwt/admin/JwtAuthenticationProviderConfiguration.java
@@ -15,14 +15,29 @@
  */
 package ai.langstream.apigateway.auth.impl.jwt.admin;
 
+import ai.langstream.apigateway.auth.common.store.RevokedTokensStoreConfiguration;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.List;
+import java.util.Map;
 
 public record JwtAuthenticationProviderConfiguration(
+        @JsonProperty("secret-key")
         String secretKey,
+        @JsonProperty("public-key")
         String publicKey,
+        @JsonProperty("auth-claim")
         String authClaim,
+        @JsonProperty("public-alg")
         String publicAlg,
+        @JsonProperty("audience-claim")
         String audienceClaim,
         String audience,
+        @JsonProperty("admin-roles")
         List<String> adminRoles,
-        String jwksHostsAllowlist) {}
+        @JsonProperty("jwks-hosts-allowlist")
+        String jwksHostsAllowlist,
+        @JsonProperty("revoked-tokens-store")
+        RevokedTokensStoreConfiguration revokedTokenStore) {
+
+}

--- a/langstream-api-gateway-auth/langstream-jwt-api-gateway-auth/src/test/java/ai/langstream/apigateway/auth/impl/jwt/admin/JwtAuthenticationProviderTest.java
+++ b/langstream-api-gateway-auth/langstream-jwt-api-gateway-auth/src/test/java/ai/langstream/apigateway/auth/impl/jwt/admin/JwtAuthenticationProviderTest.java
@@ -1,0 +1,201 @@
+package ai.langstream.apigateway.auth.impl.jwt.admin;
+
+import ai.langstream.api.gateway.GatewayAuthenticationResult;
+import ai.langstream.api.gateway.GatewayRequestContext;
+import ai.langstream.api.model.Application;
+import ai.langstream.api.model.Gateway;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import io.jsonwebtoken.Jwts;
+import io.minio.MakeBucketArgs;
+import io.minio.MinioClient;
+import io.minio.PutObjectArgs;
+import lombok.SneakyThrows;
+import org.awaitility.Awaitility;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.testcontainers.containers.localstack.LocalStackContainer.Service.S3;
+@Testcontainers
+class JwtAuthenticationProviderTest {
+
+
+    @RegisterExtension
+    WireMockExtension wm1 =
+            WireMockExtension.newInstance()
+                    .options(wireMockConfig().dynamicPort())
+                    .failOnUnmatchedRequests(true)
+                    .build();
+
+    KeyPair kp;
+    private static final String JWKS_PATH = "/auth/.well-known/jwks.json";
+
+    private static final DockerImageName localstackImage =
+            DockerImageName.parse("localstack/localstack:2.2.0");
+
+    @Container
+    private static final LocalStackContainer localstack =
+            new LocalStackContainer(localstackImage).withServices(S3);
+
+
+    @BeforeEach
+    public void beforeEach() throws Exception {
+        genAndExposeKeyPair();
+    }
+
+    @Test
+    @SneakyThrows
+    public void test() {
+        MinioClient minioClient = MinioClient.builder()
+                .endpoint(localstack.getEndpointOverride(S3).toString())
+                .build();
+
+        AtomicInteger refreshCount = new AtomicInteger(0);
+
+        JwtAuthenticationProvider provider = new JwtAuthenticationProvider() {
+            @Override
+            public void onRevokedTokensRefreshed() {
+                refreshCount.incrementAndGet();
+            }
+        };
+        provider.initialize(Map.of(
+                "jwks-hosts-allowlist", "localhost",
+                "auth-claim", "iss",
+                "admin-roles", List.of("testrole"),
+                "revoked-tokens-store", Map.of("type", "s3", "refresh-period-seconds", 1,
+                        "config",
+                        Map.of("s3-bucket", "testbucket", "s3-object", "bad-tokens.txt", "s3-endpoint", localstack.getEndpointOverride(S3).toString(),
+                                "s3-access-key", "minioadmin", "s3-secret-key", "minioadmin"))
+        ));
+
+        final String goodToken = Jwts.builder()
+                .claim("iss", "testrole")
+                .claim("jwks_uri", wm1.url(JWKS_PATH))
+                .signWith(kp.getPrivate())
+                .compact();
+        assertTrue(provider.authenticate(newContext(goodToken))
+                .authenticated()
+        );
+
+        assertFalse(provider.authenticate(newContext(Jwts.builder()
+                        .claim("iss", "testrole_no")
+                        .claim("jwks_uri", wm1.url(JWKS_PATH))
+                        .signWith(kp.getPrivate())
+                        .compact()))
+                .authenticated()
+        );
+
+        minioClient.makeBucket(MakeBucketArgs.builder().bucket("testbucket").build());
+        final int before = refreshCount.get();
+
+        String tokenList = "another\n" + goodToken + "\n";
+        minioClient.putObject(PutObjectArgs.builder()
+                .bucket("testbucket")
+                .object("bad-tokens.txt")
+                .stream(new ByteArrayInputStream(tokenList.getBytes(StandardCharsets.UTF_8)), tokenList.length(), -1)
+                .build());
+        Awaitility.await()
+                .untilAsserted(() -> assertTrue(refreshCount.get() > before));
+
+        assertFalse(provider.authenticate(newContext(goodToken))
+                .authenticated()
+        );
+    }
+
+    @NotNull
+    private static GatewayRequestContext newContext(String credentials) {
+        return new GatewayRequestContext() {
+            @Override
+            public String tenant() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public String applicationId() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Application application() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Gateway gateway() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public String credentials() {
+                return credentials;
+            }
+
+            @Override
+            public boolean isTestMode() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Map<String, String> userParameters() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Map<String, String> options() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Map<String, String> httpHeaders() {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+
+
+    private void genAndExposeKeyPair() throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(2048);
+        kp = kpg.generateKeyPair();
+        final RSAPublicKeySpec spec =
+                KeyFactory.getInstance("RSA").getKeySpec(kp.getPublic(), RSAPublicKeySpec.class);
+
+        final byte[] e =
+                Base64.getUrlEncoder()
+                        .withoutPadding()
+                        .encode(spec.getPublicExponent().toByteArray());
+        final byte[] mod =
+                Base64.getUrlEncoder().withoutPadding().encode(spec.getModulus().toByteArray());
+        wm1.stubFor(
+                WireMock.get(JWKS_PATH)
+                        .willReturn(
+                                WireMock.okJson(
+                                        """
+                                                {"keys":[{"alg":"RS256","e":"%s","kid":"1","kty":"RSA","n":"%s"}]}
+                                                """
+                                                .formatted(
+                                                        new String(e, StandardCharsets.UTF_8),
+                                                        new String(mod, StandardCharsets.UTF_8)))));
+    }
+
+}

--- a/langstream-api-gateway-auth/langstream-jwt-api-gateway-auth/src/test/java/ai/langstream/apigateway/auth/impl/jwt/admin/JwtAuthenticationProviderTest.java
+++ b/langstream-api-gateway-auth/langstream-jwt-api-gateway-auth/src/test/java/ai/langstream/apigateway/auth/impl/jwt/admin/JwtAuthenticationProviderTest.java
@@ -1,6 +1,9 @@
 package ai.langstream.apigateway.auth.impl.jwt.admin;
 
-import ai.langstream.api.gateway.GatewayAuthenticationResult;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.testcontainers.containers.localstack.LocalStackContainer.Service.S3;
+
 import ai.langstream.api.gateway.GatewayRequestContext;
 import ai.langstream.api.model.Application;
 import ai.langstream.api.model.Gateway;
@@ -10,18 +13,6 @@ import io.jsonwebtoken.Jwts;
 import io.minio.MakeBucketArgs;
 import io.minio.MinioClient;
 import io.minio.PutObjectArgs;
-import lombok.SneakyThrows;
-import org.awaitility.Awaitility;
-import org.jetbrains.annotations.NotNull;
-import org.junit.Before;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
-import org.testcontainers.containers.localstack.LocalStackContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
-
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyFactory;
@@ -32,13 +23,19 @@ import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import lombok.SneakyThrows;
+import org.awaitility.Awaitility;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
 
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.testcontainers.containers.localstack.LocalStackContainer.Service.S3;
 @Testcontainers
 class JwtAuthenticationProviderTest {
-
 
     @RegisterExtension
     WireMockExtension wm1 =
@@ -57,7 +54,6 @@ class JwtAuthenticationProviderTest {
     private static final LocalStackContainer localstack =
             new LocalStackContainer(localstackImage).withServices(S3);
 
-
     @BeforeEach
     public void beforeEach() throws Exception {
         genAndExposeKeyPair();
@@ -66,60 +62,79 @@ class JwtAuthenticationProviderTest {
     @Test
     @SneakyThrows
     public void test() {
-        MinioClient minioClient = MinioClient.builder()
-                .endpoint(localstack.getEndpointOverride(S3).toString())
-                .build();
+        MinioClient minioClient =
+                MinioClient.builder()
+                        .endpoint(localstack.getEndpointOverride(S3).toString())
+                        .build();
 
         AtomicInteger refreshCount = new AtomicInteger(0);
 
-        JwtAuthenticationProvider provider = new JwtAuthenticationProvider() {
-            @Override
-            public void onRevokedTokensRefreshed() {
-                refreshCount.incrementAndGet();
-            }
-        };
-        provider.initialize(Map.of(
-                "jwks-hosts-allowlist", "localhost",
-                "auth-claim", "iss",
-                "admin-roles", List.of("testrole"),
-                "revoked-tokens-store", Map.of("type", "s3", "refresh-period-seconds", 1,
-                        "config",
-                        Map.of("s3-bucket", "testbucket", "s3-object", "bad-tokens.txt", "s3-endpoint", localstack.getEndpointOverride(S3).toString(),
-                                "s3-access-key", "minioadmin", "s3-secret-key", "minioadmin"))
-        ));
+        JwtAuthenticationProvider provider =
+                new JwtAuthenticationProvider() {
+                    @Override
+                    public void onRevokedTokensRefreshed() {
+                        refreshCount.incrementAndGet();
+                    }
+                };
+        provider.initialize(
+                Map.of(
+                        "jwks-hosts-allowlist",
+                        "localhost",
+                        "auth-claim",
+                        "iss",
+                        "admin-roles",
+                        List.of("testrole"),
+                        "revoked-tokens-store",
+                        Map.of(
+                                "type",
+                                "s3",
+                                "refresh-period-seconds",
+                                1,
+                                "configuration",
+                                Map.of(
+                                        "s3-bucket",
+                                        "testbucket",
+                                        "s3-object",
+                                        "bad-tokens.txt",
+                                        "s3-endpoint",
+                                        localstack.getEndpointOverride(S3).toString(),
+                                        "s3-access-key",
+                                        "minioadmin",
+                                        "s3-secret-key",
+                                        "minioadmin"))));
 
-        final String goodToken = Jwts.builder()
-                .claim("iss", "testrole")
-                .claim("jwks_uri", wm1.url(JWKS_PATH))
-                .signWith(kp.getPrivate())
-                .compact();
-        assertTrue(provider.authenticate(newContext(goodToken))
-                .authenticated()
-        );
-
-        assertFalse(provider.authenticate(newContext(Jwts.builder()
-                        .claim("iss", "testrole_no")
+        final String goodToken =
+                Jwts.builder()
+                        .claim("iss", "testrole")
                         .claim("jwks_uri", wm1.url(JWKS_PATH))
                         .signWith(kp.getPrivate())
-                        .compact()))
-                .authenticated()
-        );
+                        .compact();
+        assertTrue(provider.authenticate(newContext(goodToken)).authenticated());
+
+        assertFalse(
+                provider.authenticate(
+                                newContext(
+                                        Jwts.builder()
+                                                .claim("iss", "testrole_no")
+                                                .claim("jwks_uri", wm1.url(JWKS_PATH))
+                                                .signWith(kp.getPrivate())
+                                                .compact()))
+                        .authenticated());
 
         minioClient.makeBucket(MakeBucketArgs.builder().bucket("testbucket").build());
         final int before = refreshCount.get();
 
         String tokenList = "another\n" + goodToken + "\n";
-        minioClient.putObject(PutObjectArgs.builder()
-                .bucket("testbucket")
-                .object("bad-tokens.txt")
-                .stream(new ByteArrayInputStream(tokenList.getBytes(StandardCharsets.UTF_8)), tokenList.length(), -1)
-                .build());
-        Awaitility.await()
-                .untilAsserted(() -> assertTrue(refreshCount.get() > before));
+        minioClient.putObject(
+                PutObjectArgs.builder().bucket("testbucket").object("bad-tokens.txt").stream(
+                                new ByteArrayInputStream(
+                                        tokenList.getBytes(StandardCharsets.UTF_8)),
+                                tokenList.length(),
+                                -1)
+                        .build());
+        Awaitility.await().untilAsserted(() -> assertTrue(refreshCount.get() > before));
 
-        assertFalse(provider.authenticate(newContext(goodToken))
-                .authenticated()
-        );
+        assertFalse(provider.authenticate(newContext(goodToken)).authenticated());
     }
 
     @NotNull
@@ -172,7 +187,6 @@ class JwtAuthenticationProviderTest {
         };
     }
 
-
     private void genAndExposeKeyPair() throws Exception {
         KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
         kpg.initialize(2048);
@@ -197,5 +211,4 @@ class JwtAuthenticationProviderTest {
                                                         new String(e, StandardCharsets.UTF_8),
                                                         new String(mod, StandardCharsets.UTF_8)))));
     }
-
 }

--- a/langstream-api-gateway-auth/langstream-jwt-api-gateway-auth/src/test/java/ai/langstream/apigateway/auth/impl/jwt/admin/JwtAuthenticationProviderTest.java
+++ b/langstream-api-gateway-auth/langstream-jwt-api-gateway-auth/src/test/java/ai/langstream/apigateway/auth/impl/jwt/admin/JwtAuthenticationProviderTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ai.langstream.apigateway.auth.impl.jwt.admin;
 
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;

--- a/langstream-api-gateway-auth/langstream-jwt-api-gateway-auth/src/test/resources/logback-test.xml
+++ b/langstream-api-gateway-auth/langstream-jwt-api-gateway-auth/src/test/resources/logback-test.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+    Copyright DataStax, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<!DOCTYPE configuration>
+<configuration>
+    <import class="ch.qos.logback.classic.encoder.PatternLayoutEncoder"/>
+    <import class="ch.qos.logback.core.ConsoleAppender"/>
+
+    <appender name="STDOUT" class="ConsoleAppender">
+        <encoder class="PatternLayoutEncoder">
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} -%kvp- %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/langstream-api-gateway/src/test/java/ai/langstream/apigateway/websocket/TestGatewayAuthenticationProvider.java
+++ b/langstream-api-gateway/src/test/java/ai/langstream/apigateway/websocket/TestGatewayAuthenticationProvider.java
@@ -43,4 +43,7 @@ public class TestGatewayAuthenticationProvider implements GatewayAuthenticationP
             return GatewayAuthenticationResult.authenticationFailed("Invalid credentials");
         }
     }
+
+    @Override
+    public void close() throws Exception {}
 }

--- a/langstream-api/src/main/java/ai/langstream/api/gateway/GatewayAuthenticationProvider.java
+++ b/langstream-api/src/main/java/ai/langstream/api/gateway/GatewayAuthenticationProvider.java
@@ -17,11 +17,13 @@ package ai.langstream.api.gateway;
 
 import java.util.Map;
 
-public interface GatewayAuthenticationProvider {
+public interface GatewayAuthenticationProvider extends AutoCloseable {
 
     String type();
 
     void initialize(Map<String, Object> configuration);
 
     GatewayAuthenticationResult authenticate(GatewayRequestContext context);
+
+
 }

--- a/langstream-api/src/main/java/ai/langstream/api/gateway/GatewayAuthenticationProvider.java
+++ b/langstream-api/src/main/java/ai/langstream/api/gateway/GatewayAuthenticationProvider.java
@@ -24,6 +24,4 @@ public interface GatewayAuthenticationProvider extends AutoCloseable {
     void initialize(Map<String, Object> configuration);
 
     GatewayAuthenticationResult authenticate(GatewayRequestContext context);
-
-
 }

--- a/langstream-api/src/main/java/ai/langstream/api/gateway/GatewayAuthenticationProviderRegistry.java
+++ b/langstream-api/src/main/java/ai/langstream/api/gateway/GatewayAuthenticationProviderRegistry.java
@@ -15,31 +15,42 @@
  */
 package ai.langstream.api.gateway;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.SneakyThrows;
+
 import java.util.Map;
 import java.util.Objects;
 import java.util.ServiceLoader;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class GatewayAuthenticationProviderRegistry {
+    private static final ObjectMapper mapper = new ObjectMapper();
+    record ProviderCacheKey(String type, String configString) {}
 
+
+    private static final Map<ProviderCacheKey, GatewayAuthenticationProvider> cachedProviders = new ConcurrentHashMap<>();
+
+    @SneakyThrows
     public static GatewayAuthenticationProvider loadProvider(
             String type, Map<String, Object> configuration) {
         Objects.requireNonNull(type, "type cannot be null");
-        if (configuration == null) {
-            configuration = Map.of();
-        }
-        ServiceLoader<GatewayAuthenticationProvider> loader =
-                ServiceLoader.load(GatewayAuthenticationProvider.class);
-        final GatewayAuthenticationProvider store =
-                loader.stream()
-                        .filter(p -> type.equals(p.get().type()))
-                        .findFirst()
-                        .orElseThrow(
-                                () ->
-                                        new RuntimeException(
-                                                "No GatewayAuthenticationProvider found for type "
-                                                        + type))
-                        .get();
-        store.initialize(configuration);
-        return store;
+        final Map<String, Object> finalConfiguration = configuration == null ? Map.of() : configuration;
+        ProviderCacheKey key = new ProviderCacheKey(type, mapper.writeValueAsString(finalConfiguration));
+        return cachedProviders.computeIfAbsent(key, k -> {
+            ServiceLoader<GatewayAuthenticationProvider> loader =
+                    ServiceLoader.load(GatewayAuthenticationProvider.class);
+            final GatewayAuthenticationProvider store =
+                    loader.stream()
+                            .filter(p -> type.equals(p.get().type()))
+                            .findFirst()
+                            .orElseThrow(
+                                    () ->
+                                            new RuntimeException(
+                                                    "No GatewayAuthenticationProvider found for type "
+                                                            + type))
+                            .get();
+            store.initialize(finalConfiguration);
+            return store;
+        });
     }
 }

--- a/langstream-api/src/main/java/ai/langstream/api/gateway/GatewayAuthenticationProviderRegistry.java
+++ b/langstream-api/src/main/java/ai/langstream/api/gateway/GatewayAuthenticationProviderRegistry.java
@@ -16,41 +16,45 @@
 package ai.langstream.api.gateway;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.SneakyThrows;
-
 import java.util.Map;
 import java.util.Objects;
 import java.util.ServiceLoader;
 import java.util.concurrent.ConcurrentHashMap;
+import lombok.SneakyThrows;
 
 public class GatewayAuthenticationProviderRegistry {
     private static final ObjectMapper mapper = new ObjectMapper();
+
     record ProviderCacheKey(String type, String configString) {}
 
-
-    private static final Map<ProviderCacheKey, GatewayAuthenticationProvider> cachedProviders = new ConcurrentHashMap<>();
+    private static final Map<ProviderCacheKey, GatewayAuthenticationProvider> cachedProviders =
+            new ConcurrentHashMap<>();
 
     @SneakyThrows
     public static GatewayAuthenticationProvider loadProvider(
             String type, Map<String, Object> configuration) {
         Objects.requireNonNull(type, "type cannot be null");
-        final Map<String, Object> finalConfiguration = configuration == null ? Map.of() : configuration;
-        ProviderCacheKey key = new ProviderCacheKey(type, mapper.writeValueAsString(finalConfiguration));
-        return cachedProviders.computeIfAbsent(key, k -> {
-            ServiceLoader<GatewayAuthenticationProvider> loader =
-                    ServiceLoader.load(GatewayAuthenticationProvider.class);
-            final GatewayAuthenticationProvider store =
-                    loader.stream()
-                            .filter(p -> type.equals(p.get().type()))
-                            .findFirst()
-                            .orElseThrow(
-                                    () ->
-                                            new RuntimeException(
-                                                    "No GatewayAuthenticationProvider found for type "
-                                                            + type))
-                            .get();
-            store.initialize(finalConfiguration);
-            return store;
-        });
+        final Map<String, Object> finalConfiguration =
+                configuration == null ? Map.of() : configuration;
+        ProviderCacheKey key =
+                new ProviderCacheKey(type, mapper.writeValueAsString(finalConfiguration));
+        return cachedProviders.computeIfAbsent(
+                key,
+                k -> {
+                    ServiceLoader<GatewayAuthenticationProvider> loader =
+                            ServiceLoader.load(GatewayAuthenticationProvider.class);
+                    final GatewayAuthenticationProvider store =
+                            loader.stream()
+                                    .filter(p -> type.equals(p.get().type()))
+                                    .findFirst()
+                                    .orElseThrow(
+                                            () ->
+                                                    new RuntimeException(
+                                                            "No GatewayAuthenticationProvider found for type "
+                                                                    + type))
+                                    .get();
+                    store.initialize(finalConfiguration);
+                    return store;
+                });
     }
 }


### PR DESCRIPTION
New config inside the jwt config `revoked-tokens-store` to configure to an s3 bucket. 
```
provider: jwt
configuration:
  auth-claim: xx
  revoked-tokens-store:
    type: s3
    refresh-period-seconds: 30
    configuration: 
     s3-bucket: xx
     s3-object: xx
     s3-access-key: xx
     s3-secret-key: xx
```

I've also made all the jwt config kebab case
Currently only implemented for jwt but it's easy to extend to others.

Note that if the bucket or object doesn't exist, the auth works normally.
The object must be in format:
```
token1
token2
token3
... 
```