### PR TITLE
feat: add api gateway metrics

### DIFF
--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/TopicConnectionsRuntimeCacheFactory.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/TopicConnectionsRuntimeCacheFactory.java
@@ -17,8 +17,8 @@ package ai.langstream.apigateway.gateways;
 
 import ai.langstream.api.runner.topics.TopicConnectionsRuntime;
 import ai.langstream.apigateway.config.TopicProperties;
+import ai.langstream.apigateway.metrics.ApiGatewayMetrics;
 import ai.langstream.apigateway.metrics.MetricsNames;
-import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.binder.cache.GuavaCacheMetrics;
 import java.util.function.Supplier;
 import org.springframework.context.annotation.Bean;
@@ -29,15 +29,15 @@ public class TopicConnectionsRuntimeCacheFactory {
 
     @Bean(destroyMethod = "close")
     public TopicConnectionsRuntimeCache topicConnectionsRuntimeCache(
-            TopicProperties topicProperties) {
+            TopicProperties topicProperties, ApiGatewayMetrics apiGatewayMetrics) {
         if (topicProperties.isConnectionsRuntimeCacheEnabled()) {
             final LRUTopicConnectionsRuntimeCache cache =
                     new LRUTopicConnectionsRuntimeCache(
                             topicProperties.getConnectionsRuntimeCacheSize());
             GuavaCacheMetrics.monitor(
-                    Metrics.globalRegistry,
+                    apiGatewayMetrics.getMeterRegistry(),
                     cache.getCache(),
-                    MetricsNames.TOPIC_CONNECTIONS_RUNTIME_CACHE);
+                    MetricsNames.GUAVA_CACHE_TOPIC_CONNECTIONS_RUNTIME_CACHE);
             return cache;
         } else {
             return new TopicConnectionsRuntimeCache() {

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/TopicConnectionsRuntimeCacheFactory.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/TopicConnectionsRuntimeCacheFactory.java
@@ -16,8 +16,8 @@
 package ai.langstream.apigateway.gateways;
 
 import ai.langstream.api.runner.topics.TopicConnectionsRuntime;
-import ai.langstream.apigateway.metrics.MetricsNames;
 import ai.langstream.apigateway.config.TopicProperties;
+import ai.langstream.apigateway.metrics.MetricsNames;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.binder.cache.GuavaCacheMetrics;
 import java.util.function.Supplier;

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/TopicConnectionsRuntimeCacheFactory.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/TopicConnectionsRuntimeCacheFactory.java
@@ -16,7 +16,7 @@
 package ai.langstream.apigateway.gateways;
 
 import ai.langstream.api.runner.topics.TopicConnectionsRuntime;
-import ai.langstream.apigateway.MetricsNames;
+import ai.langstream.apigateway.metrics.MetricsNames;
 import ai.langstream.apigateway.config.TopicProperties;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.binder.cache.GuavaCacheMetrics;

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/TopicProducerCacheFactory.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/TopicProducerCacheFactory.java
@@ -33,7 +33,6 @@ public class TopicProducerCacheFactory {
         if (topicProperties.isProducersCacheEnabled()) {
             final LRUTopicProducerCache cache =
                     new LRUTopicProducerCache(topicProperties.getProducersCacheSize());
-            System.out.println("INIT GUAVA CACHE");
             GuavaCacheMetrics.monitor(
                     apiGatewayMetrics.getMeterRegistry(),
                     cache.getCache(),

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/TopicProducerCacheFactory.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/TopicProducerCacheFactory.java
@@ -16,7 +16,7 @@
 package ai.langstream.apigateway.gateways;
 
 import ai.langstream.api.runner.topics.TopicProducer;
-import ai.langstream.apigateway.MetricsNames;
+import ai.langstream.apigateway.metrics.MetricsNames;
 import ai.langstream.apigateway.config.TopicProperties;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.binder.cache.GuavaCacheMetrics;

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/TopicProducerCacheFactory.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/TopicProducerCacheFactory.java
@@ -17,8 +17,8 @@ package ai.langstream.apigateway.gateways;
 
 import ai.langstream.api.runner.topics.TopicProducer;
 import ai.langstream.apigateway.config.TopicProperties;
+import ai.langstream.apigateway.metrics.ApiGatewayMetrics;
 import ai.langstream.apigateway.metrics.MetricsNames;
-import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.binder.cache.GuavaCacheMetrics;
 import java.util.function.Supplier;
 import org.springframework.context.annotation.Bean;
@@ -28,12 +28,16 @@ import org.springframework.context.annotation.Configuration;
 public class TopicProducerCacheFactory {
 
     @Bean(destroyMethod = "close")
-    public TopicProducerCache topicProducerCache(TopicProperties topicProperties) {
+    public TopicProducerCache topicProducerCache(
+            TopicProperties topicProperties, ApiGatewayMetrics apiGatewayMetrics) {
         if (topicProperties.isProducersCacheEnabled()) {
             final LRUTopicProducerCache cache =
                     new LRUTopicProducerCache(topicProperties.getProducersCacheSize());
+            System.out.println("INIT GUAVA CACHE");
             GuavaCacheMetrics.monitor(
-                    Metrics.globalRegistry, cache.getCache(), MetricsNames.TOPIC_PRODUCER_CACHE);
+                    apiGatewayMetrics.getMeterRegistry(),
+                    cache.getCache(),
+                    MetricsNames.GUAVA_CACHE_TOPIC_PRODUCER);
             return cache;
         } else {
             return new TopicProducerCache() {

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/TopicProducerCacheFactory.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/TopicProducerCacheFactory.java
@@ -16,8 +16,8 @@
 package ai.langstream.apigateway.gateways;
 
 import ai.langstream.api.runner.topics.TopicProducer;
-import ai.langstream.apigateway.metrics.MetricsNames;
 import ai.langstream.apigateway.config.TopicProperties;
+import ai.langstream.apigateway.metrics.MetricsNames;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.binder.cache.GuavaCacheMetrics;
 import java.util.function.Supplier;

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/http/GatewayResource.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/http/GatewayResource.java
@@ -198,14 +198,16 @@ public class GatewayResource {
             @NotBlank @PathVariable("gateway") String gateway)
             throws Exception {
         return handleServiceCall(request, servletRequest, tenant, application, gateway)
-                .thenApply(response -> {
-                    apiGatewayMetrics.addHttpGatewayRequest(tenant,
-                            application,
-                            gateway,
-                            servletRequest.getMethod(),
-                            response.getStatusCode().value());
-                    return response;
-                });
+                .thenApply(
+                        response -> {
+                            apiGatewayMetrics.addHttpGatewayRequest(
+                                    tenant,
+                                    application,
+                                    gateway,
+                                    servletRequest.getMethod(),
+                                    response.getStatusCode().value());
+                            return response;
+                        });
     }
 
     @GetMapping(value = GATEWAY_SERVICE_PATH)

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/http/GatewayResource.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/http/GatewayResource.java
@@ -197,10 +197,12 @@ public class GatewayResource {
             @NotBlank @PathVariable("application") String application,
             @NotBlank @PathVariable("gateway") String gateway)
             throws Exception {
+        io.micrometer.core.instrument.Timer.Sample sample = apiGatewayMetrics.startTimer();
         return handleServiceCall(request, servletRequest, tenant, application, gateway)
                 .thenApply(
                         response -> {
-                            apiGatewayMetrics.addHttpGatewayRequest(
+                            apiGatewayMetrics.recordHttpGatewayRequest(
+                                    sample,
                                     tenant,
                                     application,
                                     gateway,

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/metrics/ApiGatewayMetrics.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/metrics/ApiGatewayMetrics.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ai.langstream.apigateway.metrics;
 
 import static ai.langstream.apigateway.metrics.MetricsNames.METRIC_GATEWAYS_HTTP_REQUESTS;
@@ -43,7 +58,6 @@ public class ApiGatewayMetrics implements AutoCloseable {
 
     @Override
     public void close() throws Exception {
-        System.out.println("CALL CLOSE");
         meterRegistry.clear();
     }
 }

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/metrics/ApiGatewayMetrics.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/metrics/ApiGatewayMetrics.java
@@ -1,7 +1,8 @@
 package ai.langstream.apigateway.metrics;
 
-import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Timer;
 
 public class ApiGatewayMetrics implements AutoCloseable {
 
@@ -9,21 +10,32 @@ public class ApiGatewayMetrics implements AutoCloseable {
     private static final String TAG_APPLICATION_ID = "application";
     private static final String TAG_GATEWAY_ID = "gateway";
 
-    public void addHttpGatewayRequest(
+    public MeterRegistry getMeterRegistry() {
+        return Metrics.globalRegistry;
+    }
+
+    public Timer.Sample startTimer() {
+        return Timer.start(getMeterRegistry());
+    }
+
+    public void recordHttpGatewayRequest(
+            io.micrometer.core.instrument.Timer.Sample sample,
             String tenant,
             String applicationId,
             String gatewayId,
             String httpMethod,
             int responseStatusCode) {
-        Counter.builder("langstream.gateways.http.requests")
-                .description("HTTP requests to gateways")
-                .tag(TAG_TENANT, tenant)
-                .tag(TAG_APPLICATION_ID, applicationId)
-                .tag(TAG_GATEWAY_ID, gatewayId)
-                .tag("http_method", httpMethod)
-                .tag("response_status_code", responseStatusCode + "")
-                .register(Metrics.globalRegistry)
-                .increment();
+        Timer timer =
+                Timer.builder("langstream.gateways.http.requests")
+                        .description("HTTP requests to gateways")
+                        .tag(TAG_TENANT, tenant)
+                        .tag(TAG_APPLICATION_ID, applicationId)
+                        .tag(TAG_GATEWAY_ID, gatewayId)
+                        .tag("http_method", httpMethod)
+                        .tag("response_status_code", responseStatusCode + "")
+                        .publishPercentiles(0.5, 0.95, 0.99)
+                        .register(getMeterRegistry());
+        sample.stop(timer);
     }
 
     @Override

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/metrics/ApiGatewayMetrics.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/metrics/ApiGatewayMetrics.java
@@ -1,17 +1,22 @@
 package ai.langstream.apigateway.metrics;
 
-import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Metrics;
-import io.micrometer.core.instrument.Timer;
+import static ai.langstream.apigateway.metrics.MetricsNames.METRIC_GATEWAYS_HTTP_REQUESTS;
 
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
 public class ApiGatewayMetrics implements AutoCloseable {
 
     private static final String TAG_TENANT = "tenant";
     private static final String TAG_APPLICATION_ID = "application";
     private static final String TAG_GATEWAY_ID = "gateway";
 
+    private final MeterRegistry meterRegistry;
+
     public MeterRegistry getMeterRegistry() {
-        return Metrics.globalRegistry;
+        return meterRegistry;
     }
 
     public Timer.Sample startTimer() {
@@ -23,15 +28,13 @@ public class ApiGatewayMetrics implements AutoCloseable {
             String tenant,
             String applicationId,
             String gatewayId,
-            String httpMethod,
             int responseStatusCode) {
         Timer timer =
-                Timer.builder("langstream.gateways.http.requests")
+                Timer.builder(METRIC_GATEWAYS_HTTP_REQUESTS)
                         .description("HTTP requests to gateways")
                         .tag(TAG_TENANT, tenant)
                         .tag(TAG_APPLICATION_ID, applicationId)
                         .tag(TAG_GATEWAY_ID, gatewayId)
-                        .tag("http_method", httpMethod)
                         .tag("response_status_code", responseStatusCode + "")
                         .publishPercentiles(0.5, 0.95, 0.99)
                         .register(getMeterRegistry());
@@ -40,7 +43,7 @@ public class ApiGatewayMetrics implements AutoCloseable {
 
     @Override
     public void close() throws Exception {
-        Metrics.globalRegistry.close();
-        Metrics.globalRegistry.clear();
+        System.out.println("CALL CLOSE");
+        meterRegistry.clear();
     }
 }

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/metrics/ApiGatewayMetrics.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/metrics/ApiGatewayMetrics.java
@@ -1,0 +1,35 @@
+package ai.langstream.apigateway.metrics;
+
+import ai.langstream.api.model.Gateway;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Metrics;
+
+public class ApiGatewayMetrics implements AutoCloseable {
+
+    private final static String TAG_TENANT = "tenant";
+    private final static String TAG_APPLICATION_ID = "application";
+    private final static String TAG_GATEWAY_ID = "gateway";
+
+    public void addHttpGatewayRequest(
+            String tenant,
+            String applicationId,
+            String gatewayId,
+            String httpMethod,
+            int responseStatusCode) {
+        Counter.builder("langstream.gateways.http.requests")
+                .description("HTTP requests to gateways")
+                .tag(TAG_TENANT, tenant)
+                .tag(TAG_APPLICATION_ID, applicationId)
+                .tag(TAG_GATEWAY_ID, gatewayId)
+                .tag("http_method", httpMethod)
+                .tag("response_status_code", responseStatusCode + "")
+                .register(Metrics.globalRegistry)
+                .increment();
+    }
+
+    @Override
+    public void close() throws Exception {
+        Metrics.globalRegistry.close();
+        Metrics.globalRegistry.clear();
+    }
+}

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/metrics/ApiGatewayMetrics.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/metrics/ApiGatewayMetrics.java
@@ -1,14 +1,13 @@
 package ai.langstream.apigateway.metrics;
 
-import ai.langstream.api.model.Gateway;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Metrics;
 
 public class ApiGatewayMetrics implements AutoCloseable {
 
-    private final static String TAG_TENANT = "tenant";
-    private final static String TAG_APPLICATION_ID = "application";
-    private final static String TAG_GATEWAY_ID = "gateway";
+    private static final String TAG_TENANT = "tenant";
+    private static final String TAG_APPLICATION_ID = "application";
+    private static final String TAG_GATEWAY_ID = "gateway";
 
     public void addHttpGatewayRequest(
             String tenant,

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/metrics/ApiGatewayMetricsProvider.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/metrics/ApiGatewayMetricsProvider.java
@@ -1,5 +1,6 @@
 package ai.langstream.apigateway.metrics;
 
+import io.micrometer.core.instrument.Metrics;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -8,6 +9,7 @@ public class ApiGatewayMetricsProvider {
 
     @Bean(destroyMethod = "close")
     public ApiGatewayMetrics apiGatewayMetrics() {
-        return new ApiGatewayMetrics();
+        System.out.println("CALL ApiGatewayMetricsProvider");
+        return new ApiGatewayMetrics(Metrics.globalRegistry);
     }
 }

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/metrics/ApiGatewayMetricsProvider.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/metrics/ApiGatewayMetricsProvider.java
@@ -1,0 +1,25 @@
+package ai.langstream.apigateway.metrics;
+
+import ai.langstream.api.model.Gateway;
+import ai.langstream.api.runner.topics.TopicProducer;
+import ai.langstream.apigateway.config.TopicProperties;
+import ai.langstream.apigateway.gateways.LRUTopicProducerCache;
+import ai.langstream.apigateway.gateways.TopicProducerCache;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.binder.cache.GuavaCacheMetrics;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.function.Supplier;
+
+@Configuration
+public class ApiGatewayMetricsProvider {
+
+
+    @Bean(destroyMethod = "close")
+    public ApiGatewayMetrics apiGatewayMetrics() {
+        return new ApiGatewayMetrics();
+    }
+
+}

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/metrics/ApiGatewayMetricsProvider.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/metrics/ApiGatewayMetricsProvider.java
@@ -1,25 +1,13 @@
 package ai.langstream.apigateway.metrics;
 
-import ai.langstream.api.model.Gateway;
-import ai.langstream.api.runner.topics.TopicProducer;
-import ai.langstream.apigateway.config.TopicProperties;
-import ai.langstream.apigateway.gateways.LRUTopicProducerCache;
-import ai.langstream.apigateway.gateways.TopicProducerCache;
-import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.Metrics;
-import io.micrometer.core.instrument.binder.cache.GuavaCacheMetrics;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import java.util.function.Supplier;
-
 @Configuration
 public class ApiGatewayMetricsProvider {
-
 
     @Bean(destroyMethod = "close")
     public ApiGatewayMetrics apiGatewayMetrics() {
         return new ApiGatewayMetrics();
     }
-
 }

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/metrics/MetricsNames.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/metrics/MetricsNames.java
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package ai.langstream.apigateway;
+package ai.langstream.apigateway.metrics;
 
 public class MetricsNames {
-    public static final String TOPIC_PRODUCER_CACHE = "topic_producer_cache";
-    public static final String TOPIC_CONNECTIONS_RUNTIME_CACHE = "topic_connections_runtime_cache";
+    public static final String TOPIC_PRODUCER_CACHE = "langstream_topic_producer_cache";
+    public static final String TOPIC_CONNECTIONS_RUNTIME_CACHE = "langstream_topic_connections_runtime_cache";
 }

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/metrics/MetricsNames.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/metrics/MetricsNames.java
@@ -16,7 +16,11 @@
 package ai.langstream.apigateway.metrics;
 
 public class MetricsNames {
-    public static final String TOPIC_PRODUCER_CACHE = "langstream_topic_producer_cache";
-    public static final String TOPIC_CONNECTIONS_RUNTIME_CACHE =
+    // guava cache metrics are exposed as label value
+    public static final String GUAVA_CACHE_TOPIC_PRODUCER = "langstream_topic_producer_cache";
+    public static final String GUAVA_CACHE_TOPIC_CONNECTIONS_RUNTIME_CACHE =
             "langstream_topic_connections_runtime_cache";
+
+    // metric names are converted by micrometer to naming conventions
+    public static final String METRIC_GATEWAYS_HTTP_REQUESTS = "langstream.gateways.http.requests";
 }

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/metrics/MetricsNames.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/metrics/MetricsNames.java
@@ -17,5 +17,6 @@ package ai.langstream.apigateway.metrics;
 
 public class MetricsNames {
     public static final String TOPIC_PRODUCER_CACHE = "langstream_topic_producer_cache";
-    public static final String TOPIC_CONNECTIONS_RUNTIME_CACHE = "langstream_topic_connections_runtime_cache";
+    public static final String TOPIC_CONNECTIONS_RUNTIME_CACHE =
+            "langstream_topic_connections_runtime_cache";
 }

--- a/langstream-api-gateway/src/test/java/ai/langstream/apigateway/ApiGatewayTestUtil.java
+++ b/langstream-api-gateway/src/test/java/ai/langstream/apigateway/ApiGatewayTestUtil.java
@@ -14,12 +14,14 @@ import lombok.SneakyThrows;
 
 public class ApiGatewayTestUtil {
 
+    public static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
+
     @SneakyThrows
     public static String getPrometheusMetrics(final int port) {
         final String url = "http://localhost:%d/management/prometheus".formatted(port);
         final HttpRequest request = HttpRequest.newBuilder(URI.create(url)).GET().build();
         final HttpResponse<String> response =
-                HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+                HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
         assertEquals(200, response.statusCode());
         return response.body();
     }

--- a/langstream-api-gateway/src/test/java/ai/langstream/apigateway/ApiGatewayTestUtil.java
+++ b/langstream-api-gateway/src/test/java/ai/langstream/apigateway/ApiGatewayTestUtil.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ai.langstream.apigateway;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/langstream-api-gateway/src/test/java/ai/langstream/apigateway/ApiGatewayTestUtil.java
+++ b/langstream-api-gateway/src/test/java/ai/langstream/apigateway/ApiGatewayTestUtil.java
@@ -1,0 +1,60 @@
+package ai.langstream.apigateway;
+
+import lombok.SneakyThrows;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ApiGatewayTestUtil {
+
+    @SneakyThrows
+    public static String getPrometheusMetrics(final int port) {
+        final String url =
+                "http://localhost:%d/management/prometheus"
+                        .formatted(port);
+        final HttpRequest request =
+                HttpRequest.newBuilder(URI.create(url))
+                         .GET()
+                        .build();
+        final HttpResponse<String> response =
+                HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals(200, response.statusCode());
+        return response.body();
+    }
+
+    public record ParsedMetric(String name, String value, Map<String, String> labels) {
+    }
+
+
+    public static List<ParsedMetric> findMetric(String metricName, String metrics) {
+        return metrics.lines()
+                .filter(m -> {
+                    if (m.startsWith("#")) {
+                        return false;
+                    }
+                    return m.startsWith(metricName + "{");
+                })
+                .map(line -> {
+                    final String[] parts = line.split(" ");
+                    String name = parts[0];
+                    final String value = parts[1];
+                    final String labels = name.substring(name.indexOf("{") + 1, name.indexOf("}"));
+                    name = name.substring(0, name.indexOf("{"));
+                    final Map<String, String> labelMap = new HashMap<>();
+                    for (String label : labels.split(",")) {
+                        final String[] labelParts = label.split("=");
+                        labelMap.put(labelParts[0], labelParts[1].substring(1, labelParts[1].length() - 1));
+                    }
+                    return new ParsedMetric(name, value, labelMap);
+                })
+                .collect(Collectors.toList());
+    }
+}

--- a/langstream-api-gateway/src/test/java/ai/langstream/apigateway/ApiGatewayTestUtil.java
+++ b/langstream-api-gateway/src/test/java/ai/langstream/apigateway/ApiGatewayTestUtil.java
@@ -1,6 +1,6 @@
 package ai.langstream.apigateway;
 
-import lombok.SneakyThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -10,51 +10,48 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import lombok.SneakyThrows;
 
 public class ApiGatewayTestUtil {
 
     @SneakyThrows
     public static String getPrometheusMetrics(final int port) {
-        final String url =
-                "http://localhost:%d/management/prometheus"
-                        .formatted(port);
-        final HttpRequest request =
-                HttpRequest.newBuilder(URI.create(url))
-                         .GET()
-                        .build();
+        final String url = "http://localhost:%d/management/prometheus".formatted(port);
+        final HttpRequest request = HttpRequest.newBuilder(URI.create(url)).GET().build();
         final HttpResponse<String> response =
                 HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
         assertEquals(200, response.statusCode());
         return response.body();
     }
 
-    public record ParsedMetric(String name, String value, Map<String, String> labels) {
-    }
-
+    public record ParsedMetric(String name, String value, Map<String, String> labels) {}
 
     public static List<ParsedMetric> findMetric(String metricName, String metrics) {
         return metrics.lines()
-                .filter(m -> {
-                    if (m.startsWith("#")) {
-                        return false;
-                    }
-                    return m.startsWith(metricName + "{");
-                })
-                .map(line -> {
-                    final String[] parts = line.split(" ");
-                    String name = parts[0];
-                    final String value = parts[1];
-                    final String labels = name.substring(name.indexOf("{") + 1, name.indexOf("}"));
-                    name = name.substring(0, name.indexOf("{"));
-                    final Map<String, String> labelMap = new HashMap<>();
-                    for (String label : labels.split(",")) {
-                        final String[] labelParts = label.split("=");
-                        labelMap.put(labelParts[0], labelParts[1].substring(1, labelParts[1].length() - 1));
-                    }
-                    return new ParsedMetric(name, value, labelMap);
-                })
+                .filter(
+                        m -> {
+                            if (m.startsWith("#")) {
+                                return false;
+                            }
+                            return m.startsWith(metricName + "{");
+                        })
+                .map(
+                        line -> {
+                            final String[] parts = line.split(" ");
+                            String name = parts[0];
+                            final String value = parts[1];
+                            final String labels =
+                                    name.substring(name.indexOf("{") + 1, name.indexOf("}"));
+                            name = name.substring(0, name.indexOf("{"));
+                            final Map<String, String> labelMap = new HashMap<>();
+                            for (String label : labels.split(",")) {
+                                final String[] labelParts = label.split("=");
+                                labelMap.put(
+                                        labelParts[0],
+                                        labelParts[1].substring(1, labelParts[1].length() - 1));
+                            }
+                            return new ParsedMetric(name, value, labelMap);
+                        })
                 .collect(Collectors.toList());
     }
 }

--- a/langstream-api-gateway/src/test/java/ai/langstream/apigateway/http/GatewayResourceTest.java
+++ b/langstream-api-gateway/src/test/java/ai/langstream/apigateway/http/GatewayResourceTest.java
@@ -798,12 +798,13 @@ abstract class GatewayResourceTest {
                 produceJsonAndGetBody(valueUrl, "{\"key\": \"my-key\", \"value\": \"my-value\"}"));
 
         String metrics = getPrometheusMetrics(port);
+        System.out.println(metrics);
 
         List<ApiGatewayTestUtil.ParsedMetric> metricsList =
-                findMetric("langstream_gateways_http_requests_total", metrics);
+                findMetric("langstream_gateways_http_requests_seconds_count", metrics);
         assertEquals(2, metricsList.size());
         for (ApiGatewayTestUtil.ParsedMetric parsedMetric : metricsList) {
-            assertEquals("langstream_gateways_http_requests_total", parsedMetric.name());
+            assertEquals("langstream_gateways_http_requests_seconds_count", parsedMetric.name());
             assertEquals("tenant1", parsedMetric.labels().get("tenant"));
             assertEquals("application1", parsedMetric.labels().get("application"));
             assertEquals("POST", parsedMetric.labels().get("http_method"));
@@ -815,6 +816,10 @@ abstract class GatewayResourceTest {
                 assertEquals("1.0", parsedMetric.value());
             }
         }
+        assertEquals(
+                2, findMetric("langstream_gateways_http_requests_seconds_sum", metrics).size());
+        assertEquals(
+                2, findMetric("langstream_gateways_http_requests_seconds_max", metrics).size());
     }
 
     @Test
@@ -868,10 +873,10 @@ abstract class GatewayResourceTest {
         String metrics = getPrometheusMetrics(port);
 
         List<ApiGatewayTestUtil.ParsedMetric> metricsList =
-                findMetric("langstream_gateways_http_requests_total", metrics);
+                findMetric("langstream_gateways_http_requests_seconds_count", metrics);
         assertEquals(1, metricsList.size());
         ApiGatewayTestUtil.ParsedMetric parsedMetric = metricsList.get(0);
-        assertEquals("langstream_gateways_http_requests_total", parsedMetric.name());
+        assertEquals("langstream_gateways_http_requests_seconds_count", parsedMetric.name());
         assertEquals("tenant1", parsedMetric.labels().get("tenant"));
         assertEquals("application1", parsedMetric.labels().get("application"));
         assertEquals("POST", parsedMetric.labels().get("http_method"));

--- a/langstream-api-gateway/src/test/java/ai/langstream/apigateway/http/GatewayResourceTest.java
+++ b/langstream-api-gateway/src/test/java/ai/langstream/apigateway/http/GatewayResourceTest.java
@@ -797,10 +797,10 @@ abstract class GatewayResourceTest {
                 new MsgRecord(null, "{\"key\":\"my-key\",\"value\":\"my-value\"}", Map.of()),
                 produceJsonAndGetBody(valueUrl, "{\"key\": \"my-key\", \"value\": \"my-value\"}"));
 
-
         String metrics = getPrometheusMetrics(port);
 
-        List<ApiGatewayTestUtil.ParsedMetric> metricsList = findMetric("langstream_gateways_http_requests_total", metrics);
+        List<ApiGatewayTestUtil.ParsedMetric> metricsList =
+                findMetric("langstream_gateways_http_requests_total", metrics);
         assertEquals(2, metricsList.size());
         for (ApiGatewayTestUtil.ParsedMetric parsedMetric : metricsList) {
             assertEquals("langstream_gateways_http_requests_total", parsedMetric.name());
@@ -867,7 +867,8 @@ abstract class GatewayResourceTest {
 
         String metrics = getPrometheusMetrics(port);
 
-        List<ApiGatewayTestUtil.ParsedMetric> metricsList = findMetric("langstream_gateways_http_requests_total", metrics);
+        List<ApiGatewayTestUtil.ParsedMetric> metricsList =
+                findMetric("langstream_gateways_http_requests_total", metrics);
         assertEquals(1, metricsList.size());
         ApiGatewayTestUtil.ParsedMetric parsedMetric = metricsList.get(0);
         assertEquals("langstream_gateways_http_requests_total", parsedMetric.name());

--- a/langstream-runtime/langstream-runtime-tester/pom.xml
+++ b/langstream-runtime/langstream-runtime-tester/pom.xml
@@ -183,7 +183,7 @@
                 </goals>
                 <configuration>
                   <url>https://downloads.apache.org</url>
-                  <fromFile>kafka/3.5.2/kafka_2.13-3.5.2.tgz</fromFile>
+                  <fromFile>kafka/3.6.2/kafka_2.13-3.6.2.tgz</fromFile>
                   <toDir>${project.build.directory}/kafka</toDir>
                   <skipIfExists>true</skipIfExists>
                 </configuration>

--- a/langstream-runtime/langstream-runtime-tester/src/main/docker/Dockerfile
+++ b/langstream-runtime/langstream-runtime-tester/src/main/docker/Dockerfile
@@ -22,7 +22,7 @@ USER 0
 
 ADD maven/minio /minio/minio
 ADD maven/herddb-services-0.28.0.zip /herddb/herddb-services-0.28.0.zip
-COPY maven/kafka_2.13-3.5.2.tgz /kafka/kafka.tgz
+COPY maven/kafka_2.13-3.6.2.tgz /kafka/kafka.tgz
 COPY maven/apache-pulsar-3.2.3-bin.tar.gz /pulsar/pulsar.tar.gz
 
 


### PR DESCRIPTION
added timer metric for http gateway calls: 

```
langstream_gateways_http_requests_seconds_count{application="application1",gateway="svc",response_status_code="500",tenant="tenant1",} 1.0
langstream_gateways_http_requests_seconds{application="application1",gateway="svc",response_status_code="500",tenant="tenant1",quantile="0.99",} 1.140850688
```

The prometheus endpoint is /management/prometheus 