### PR TITLE
feat: send event on asset creation/deletion failure

### DIFF
--- a/langstream-agents/langstream-agents-ms365/pom.xml
+++ b/langstream-agents/langstream-agents-ms365/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>langstream-agents</artifactId>
     <groupId>ai.langstream</groupId>
-    <version>0.21.5-SNAPSHOT</version>
+    <version>0.22.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/langstream-api/src/main/java/ai/langstream/api/events/EventRecord.java
+++ b/langstream-api/src/main/java/ai/langstream/api/events/EventRecord.java
@@ -39,7 +39,9 @@ public class EventRecord {
 
         // asset
         AssetCreated,
-        AssetDeleted
+        AssetCreationFailed,
+        AssetDeleted,
+        AssetDeletionFailed,
     }
 
     private Categories category;

--- a/langstream-core/src/main/java/ai/langstream/impl/deploy/ApplicationDeployer.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/deploy/ApplicationDeployer.java
@@ -108,17 +108,30 @@ public final class ApplicationDeployer implements AutoCloseable {
         Map<String, TopicProducer> producers = new HashMap<>();
         try {
             for (AssetNode assetNode : executionPlan.getAssets()) {
-                AssetDefinition asset = MAPPER.convertValue(assetNode.config(), AssetDefinition.class);
+                AssetDefinition asset =
+                        MAPPER.convertValue(assetNode.config(), AssetDefinition.class);
                 try {
                     boolean created = setupAsset(asset, assetManagerRegistry);
                     if (created) {
                         sendAssetEvent(
-                                true, tenant, executionPlan, topicConnectionsRuntime, producers, asset, null);
+                                true,
+                                tenant,
+                                executionPlan,
+                                topicConnectionsRuntime,
+                                producers,
+                                asset,
+                                null);
                     }
                 } catch (Throwable tt) {
                     log.error("Error setting up asset {}", asset.getId(), tt);
                     sendAssetEvent(
-                            true, tenant, executionPlan, topicConnectionsRuntime, producers, asset, tt);
+                            true,
+                            tenant,
+                            executionPlan,
+                            topicConnectionsRuntime,
+                            producers,
+                            asset,
+                            tt);
                     throw tt;
                 }
             }
@@ -190,7 +203,11 @@ public final class ApplicationDeployer implements AutoCloseable {
 
     @SneakyThrows
     private static SimpleRecord createAssetEventRecord(
-            boolean created, String tenant, String applicationId, AssetDefinition asset, Throwable exception) {
+            boolean created,
+            String tenant,
+            String applicationId,
+            AssetDefinition asset,
+            Throwable exception) {
         final EventSources.AssetSource source =
                 EventSources.AssetSource.builder()
                         .tenant(tenant)
@@ -390,26 +407,38 @@ public final class ApplicationDeployer implements AutoCloseable {
         Map<String, TopicProducer> producers = new HashMap<>();
         try {
             for (AssetNode assetNode : executionPlan.getAssets()) {
-                AssetDefinition asset = MAPPER.convertValue(assetNode.config(), AssetDefinition.class);
+                AssetDefinition asset =
+                        MAPPER.convertValue(assetNode.config(), AssetDefinition.class);
                 try {
                     boolean deleted = cleanupAsset(asset);
                     if (deleted) {
-                        sendAssetEvent(false, tenant, executionPlan, topicConnectionsRuntime, producers, asset, null);
+                        sendAssetEvent(
+                                false,
+                                tenant,
+                                executionPlan,
+                                topicConnectionsRuntime,
+                                producers,
+                                asset,
+                                null);
                     }
                 } catch (Throwable tt) {
                     log.error("Error cleaning up asset {}", asset.getId(), tt);
                     sendAssetEvent(
-                            false, tenant, executionPlan, topicConnectionsRuntime, producers, asset, tt);
+                            false,
+                            tenant,
+                            executionPlan,
+                            topicConnectionsRuntime,
+                            producers,
+                            asset,
+                            tt);
                     throw tt;
                 }
-
             }
         } finally {
             for (TopicProducer producer : producers.values()) {
                 producer.close();
             }
         }
-
     }
 
     @SneakyThrows

--- a/langstream-core/src/main/java/ai/langstream/impl/deploy/ApplicationDeployer.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/deploy/ApplicationDeployer.java
@@ -40,6 +40,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 @Builder
 @Slf4j
@@ -105,26 +106,37 @@ public final class ApplicationDeployer implements AutoCloseable {
             TopicConnectionsRuntime topicConnectionsRuntime) {
         Objects.requireNonNull(assetManagerRegistry, "Asset manager registry is not set");
         Map<String, TopicProducer> producers = new HashMap<>();
-        for (AssetNode assetNode : executionPlan.getAssets()) {
-            AssetDefinition asset = MAPPER.convertValue(assetNode.config(), AssetDefinition.class);
-            boolean created = setupAsset(asset, assetManagerRegistry);
-            if (created) {
-                sendAssetEvent(
-                        true, tenant, executionPlan, topicConnectionsRuntime, producers, asset);
+        try {
+            for (AssetNode assetNode : executionPlan.getAssets()) {
+                AssetDefinition asset = MAPPER.convertValue(assetNode.config(), AssetDefinition.class);
+                try {
+                    boolean created = setupAsset(asset, assetManagerRegistry);
+                    if (created) {
+                        sendAssetEvent(
+                                true, tenant, executionPlan, topicConnectionsRuntime, producers, asset, null);
+                    }
+                } catch (Throwable tt) {
+                    log.error("Error setting up asset {}", asset.getId(), tt);
+                    sendAssetEvent(
+                            true, tenant, executionPlan, topicConnectionsRuntime, producers, asset, tt);
+                    throw tt;
+                }
             }
-        }
-        for (TopicProducer producer : producers.values()) {
-            producer.close();
+        } finally {
+            for (TopicProducer producer : producers.values()) {
+                producer.close();
+            }
         }
     }
 
     private void sendAssetEvent(
-            boolean created,
+            boolean creation,
             String tenant,
             ExecutionPlan executionPlan,
             TopicConnectionsRuntime topicConnectionsRuntime,
             Map<String, TopicProducer> producers,
-            AssetDefinition asset) {
+            AssetDefinition asset,
+            Throwable throwable) {
         String topic = asset.getEventsTopic();
         if (topic == null) {
             return;
@@ -138,16 +150,18 @@ public final class ApplicationDeployer implements AutoCloseable {
                                     createTopicProducer(
                                             executionPlan, topicConnectionsRuntime, topic));
             final SimpleRecord record =
-                    createAssetCreatedEventRecord(created, tenant, applicationId, asset);
+                    createAssetEventRecord(creation, tenant, applicationId, asset, throwable);
             producer.write(record).get();
             log.info(
-                    "Asset {} event sent for asset {}",
-                    created ? "created" : "deleted",
+                    "Asset {} (failed={}) event sent for asset {}",
+                    creation ? "created" : "deleted",
+                    throwable != null,
                     asset.getId());
         } catch (Throwable tt) {
             log.error(
-                    "Error writing asset {} event for asset {}",
-                    created ? "created" : "deleted",
+                    "Error writing asset {} (failed={}) event for asset {}",
+                    creation ? "created" : "deleted",
+                    throwable != null,
                     asset.getId(),
                     tt);
         }
@@ -175,23 +189,42 @@ public final class ApplicationDeployer implements AutoCloseable {
     }
 
     @SneakyThrows
-    private static SimpleRecord createAssetCreatedEventRecord(
-            boolean created, String tenant, String applicationId, AssetDefinition asset) {
+    private static SimpleRecord createAssetEventRecord(
+            boolean created, String tenant, String applicationId, AssetDefinition asset, Throwable exception) {
         final EventSources.AssetSource source =
                 EventSources.AssetSource.builder()
                         .tenant(tenant)
                         .applicationId(applicationId)
                         .asset(asset)
                         .build();
+
+        final String eventType;
+        if (created) {
+            if (exception != null) {
+                eventType = EventRecord.Types.AssetCreationFailed.toString();
+            } else {
+                eventType = EventRecord.Types.AssetCreated.toString();
+            }
+        } else {
+            if (exception != null) {
+                eventType = EventRecord.Types.AssetDeletionFailed.toString();
+            } else {
+                eventType = EventRecord.Types.AssetDeleted.toString();
+            }
+        }
+        Map<String, Object> data = new HashMap<>();
+        if (exception != null) {
+            data.put("error-message", exception.getMessage());
+            data.put("error-stacktrace", ExceptionUtils.getStackTrace(exception));
+        }
+
         final EventRecord event =
                 EventRecord.builder()
                         .category(EventRecord.Categories.Asset)
-                        .type(
-                                created
-                                        ? EventRecord.Types.AssetCreated.toString()
-                                        : EventRecord.Types.AssetDeleted.toString())
+                        .type(eventType)
                         .timestamp(System.currentTimeMillis())
                         .source(MAPPER.convertValue(source, Map.class))
+                        .data(data)
                         .build();
 
         final String recordValue = MAPPER.writeValueAsString(event);
@@ -355,17 +388,28 @@ public final class ApplicationDeployer implements AutoCloseable {
             TopicConnectionsRuntime topicConnectionsRuntime) {
         Objects.requireNonNull(assetManagerRegistry, "Asset manager registry is not set");
         Map<String, TopicProducer> producers = new HashMap<>();
-        for (AssetNode assetNode : executionPlan.getAssets()) {
-            AssetDefinition asset = MAPPER.convertValue(assetNode.config(), AssetDefinition.class);
-            boolean deleted = cleanupAsset(asset);
-            if (deleted) {
-                sendAssetEvent(
-                        false, tenant, executionPlan, topicConnectionsRuntime, producers, asset);
+        try {
+            for (AssetNode assetNode : executionPlan.getAssets()) {
+                AssetDefinition asset = MAPPER.convertValue(assetNode.config(), AssetDefinition.class);
+                try {
+                    boolean deleted = cleanupAsset(asset);
+                    if (deleted) {
+                        sendAssetEvent(false, tenant, executionPlan, topicConnectionsRuntime, producers, asset, null);
+                    }
+                } catch (Throwable tt) {
+                    log.error("Error cleaning up asset {}", asset.getId(), tt);
+                    sendAssetEvent(
+                            false, tenant, executionPlan, topicConnectionsRuntime, producers, asset, tt);
+                    throw tt;
+                }
+
+            }
+        } finally {
+            for (TopicProducer producer : producers.values()) {
+                producer.close();
             }
         }
-        for (TopicProducer producer : producers.values()) {
-            producer.close();
-        }
+
     }
 
     @SneakyThrows

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/assets/DeployAssetsIT.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/assets/DeployAssetsIT.java
@@ -25,6 +25,7 @@ import ai.langstream.testrunners.AbstractGenericStreamingApplicationRunner;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
 import lombok.SneakyThrows;
@@ -45,6 +46,7 @@ class DeployAssetsIT extends AbstractGenericStreamingApplicationRunner {
                             data:
                                password: "bar"
                         """;
+        String eventsTopic = "events-topic" + UUID.randomUUID();
         Map<String, String> application =
                 Map.of(
                         "configuration.yaml",
@@ -66,7 +68,7 @@ class DeployAssetsIT extends AbstractGenericStreamingApplicationRunner {
                                   - name: "my-table"
                                     creation-mode: create-if-not-exists
                                     asset-type: "mock-database-resource"
-                                    events-topic: "events-topic"
+                                    events-topic: "%s"
                                     deletion-mode: delete
                                     config:
                                         table: "${globals.table-name}"
@@ -82,7 +84,7 @@ class DeployAssetsIT extends AbstractGenericStreamingApplicationRunner {
                                     creation-mode: create-if-not-exists
                                   - name: "output-topic"
                                     creation-mode: create-if-not-exists
-                                  - name: "events-topic"
+                                  - name: "%s"
                                     creation-mode: create-if-not-exists
                                 pipeline:
                                   - name: "identity"
@@ -90,8 +92,9 @@ class DeployAssetsIT extends AbstractGenericStreamingApplicationRunner {
                                     type: "identity"
                                     input: "input-topic"
                                     output: "output-topic"
-                                """);
-        try (TopicConsumer consumer = createConsumer("events-topic");
+                                """
+                                .formatted(eventsTopic, eventsTopic));
+        try (TopicConsumer consumer = createConsumer(eventsTopic);
                 ApplicationRuntime applicationRuntime =
                         deployApplicationWithSecrets(
                                 tenant,
@@ -124,7 +127,8 @@ class DeployAssetsIT extends AbstractGenericStreamingApplicationRunner {
                                     assertEquals("AssetCreated", read.get("type"));
                                     assertEquals("Asset", read.get("category"));
                                     assertEquals(
-                                            "{\"tenant\":\"tenant\",\"applicationId\":\"app\",\"asset\":{\"id\":\"my-table\",\"name\":\"my-table\",\"config\":{\"datasource\":{\"configuration\":{\"service\":\"jdbc\",\"driverClass\":\"org.postgresql.Driver\",\"url\":\"bar\"}},\"table\":\"my-table\"},\"creation-mode\":\"create-if-not-exists\",\"deletion-mode\":\"delete\",\"asset-type\":\"mock-database-resource\",\"events-topic\":\"events-topic\"}}",
+                                            "{\"tenant\":\"tenant\",\"applicationId\":\"app\",\"asset\":{\"id\":\"my-table\",\"name\":\"my-table\",\"config\":{\"datasource\":{\"configuration\":{\"service\":\"jdbc\",\"driverClass\":\"org.postgresql.Driver\",\"url\":\"bar\"}},\"table\":\"my-table\"},\"creation-mode\":\"create-if-not-exists\",\"deletion-mode\":\"delete\",\"asset-type\":\"mock-database-resource\",\"events-topic\":\"%s\"}}"
+                                                    .formatted(eventsTopic),
                                             mapper.writeValueAsString(read.get("source")));
                                     assertNotNull(read.get("timestamp"));
                                 }
@@ -147,7 +151,8 @@ class DeployAssetsIT extends AbstractGenericStreamingApplicationRunner {
                                     assertEquals("AssetDeleted", read.get("type"));
                                     assertEquals("Asset", read.get("category"));
                                     assertEquals(
-                                            "{\"tenant\":\"tenant\",\"applicationId\":\"app\",\"asset\":{\"id\":\"my-table\",\"name\":\"my-table\",\"config\":{\"datasource\":{\"configuration\":{\"service\":\"jdbc\",\"driverClass\":\"org.postgresql.Driver\",\"url\":\"bar\"}},\"table\":\"my-table\"},\"creation-mode\":\"create-if-not-exists\",\"deletion-mode\":\"delete\",\"asset-type\":\"mock-database-resource\",\"events-topic\":\"events-topic\"}}",
+                                            "{\"tenant\":\"tenant\",\"applicationId\":\"app\",\"asset\":{\"id\":\"my-table\",\"name\":\"my-table\",\"config\":{\"datasource\":{\"configuration\":{\"service\":\"jdbc\",\"driverClass\":\"org.postgresql.Driver\",\"url\":\"bar\"}},\"table\":\"my-table\"},\"creation-mode\":\"create-if-not-exists\",\"deletion-mode\":\"delete\",\"asset-type\":\"mock-database-resource\",\"events-topic\":\"%s\"}}"
+                                                    .formatted(eventsTopic),
                                             mapper.writeValueAsString(read.get("source")));
                                     assertNotNull(read.get("timestamp"));
                                 }
@@ -167,6 +172,7 @@ class DeployAssetsIT extends AbstractGenericStreamingApplicationRunner {
                             data:
                                password: "bar"
                         """;
+        String eventsTopic = "events-topic" + UUID.randomUUID();
         Map<String, String> application =
                 Map.of(
                         "configuration.yaml",
@@ -188,7 +194,7 @@ class DeployAssetsIT extends AbstractGenericStreamingApplicationRunner {
                                   - name: "my-table"
                                     creation-mode: create-if-not-exists
                                     asset-type: "mock-database-resource"
-                                    events-topic: "events-topic"
+                                    events-topic: "%s"
                                     deletion-mode: delete
                                     config:
                                         fail: true
@@ -198,7 +204,7 @@ class DeployAssetsIT extends AbstractGenericStreamingApplicationRunner {
                                     creation-mode: create-if-not-exists
                                   - name: "output-topic"
                                     creation-mode: create-if-not-exists
-                                  - name: "events-topic"
+                                  - name: "%s"
                                     creation-mode: create-if-not-exists
                                 pipeline:
                                   - name: "identity"
@@ -206,8 +212,9 @@ class DeployAssetsIT extends AbstractGenericStreamingApplicationRunner {
                                     type: "identity"
                                     input: "input-topic"
                                     output: "output-topic"
-                                """);
-        try (TopicConsumer consumer = createConsumer("events-topic"); ) {
+                                """
+                                .formatted(eventsTopic, eventsTopic));
+        try (TopicConsumer consumer = createConsumer(eventsTopic); ) {
 
             try {
                 deployApplicationWithSecrets(
@@ -229,7 +236,8 @@ class DeployAssetsIT extends AbstractGenericStreamingApplicationRunner {
                                     assertEquals("AssetCreationFailed", read.get("type"));
                                     assertEquals("Asset", read.get("category"));
                                     assertEquals(
-                                            "{\"tenant\":\"tenant\",\"applicationId\":\"app\",\"asset\":{\"id\":\"my-table\",\"name\":\"my-table\",\"config\":{\"fail\":true,\"datasource\":{\"configuration\":{\"service\":\"jdbc\",\"driverClass\":\"org.postgresql.Driver\",\"url\":\"bar\"}}},\"creation-mode\":\"create-if-not-exists\",\"deletion-mode\":\"delete\",\"asset-type\":\"mock-database-resource\",\"events-topic\":\"events-topic\"}}",
+                                            "{\"tenant\":\"tenant\",\"applicationId\":\"app\",\"asset\":{\"id\":\"my-table\",\"name\":\"my-table\",\"config\":{\"fail\":true,\"datasource\":{\"configuration\":{\"service\":\"jdbc\",\"driverClass\":\"org.postgresql.Driver\",\"url\":\"bar\"}}},\"creation-mode\":\"create-if-not-exists\",\"deletion-mode\":\"delete\",\"asset-type\":\"mock-database-resource\",\"events-topic\":\"%s\"}}"
+                                                    .formatted(eventsTopic),
                                             mapper.writeValueAsString(read.get("source")));
                                     assertEquals(
                                             "Mock failure to deploy asset",

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/assets/DeployAssetsIT.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/assets/DeployAssetsIT.java
@@ -15,23 +15,21 @@
  */
 package ai.langstream.assets;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import ai.langstream.api.model.AssetDefinition;
 import ai.langstream.api.runner.topics.TopicConsumer;
 import ai.langstream.api.runtime.ExecutionPlan;
 import ai.langstream.mockagents.MockAssetManagerCodeProvider;
 import ai.langstream.testrunners.AbstractGenericStreamingApplicationRunner;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
-
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 @Slf4j
 class DeployAssetsIT extends AbstractGenericStreamingApplicationRunner {
@@ -94,14 +92,14 @@ class DeployAssetsIT extends AbstractGenericStreamingApplicationRunner {
                                     output: "output-topic"
                                 """);
         try (TopicConsumer consumer = createConsumer("events-topic");
-             ApplicationRuntime applicationRuntime =
-                     deployApplicationWithSecrets(
-                             tenant,
-                             "app",
-                             application,
-                             buildInstanceYaml(),
-                             secrets,
-                             expectedAgents)) {
+                ApplicationRuntime applicationRuntime =
+                        deployApplicationWithSecrets(
+                                tenant,
+                                "app",
+                                application,
+                                buildInstanceYaml(),
+                                secrets,
+                                expectedAgents)) {
             CopyOnWriteArrayList<AssetDefinition> deployedAssets =
                     MockAssetManagerCodeProvider.MockDatabaseResourceAssetManager.DEPLOYED_ASSETS;
             assertEquals(2, deployedAssets.size());
@@ -157,7 +155,6 @@ class DeployAssetsIT extends AbstractGenericStreamingApplicationRunner {
         }
     }
 
-
     @Test
     public void testDeployAssetFailed() throws Exception {
         String tenant = "tenant";
@@ -210,16 +207,11 @@ class DeployAssetsIT extends AbstractGenericStreamingApplicationRunner {
                                     input: "input-topic"
                                     output: "output-topic"
                                 """);
-        try (TopicConsumer consumer = createConsumer("events-topic");) {
+        try (TopicConsumer consumer = createConsumer("events-topic"); ) {
 
             try {
                 deployApplicationWithSecrets(
-                        tenant,
-                        "app",
-                        application,
-                        buildInstanceYaml(),
-                        secrets,
-                        expectedAgents);
+                        tenant, "app", application, buildInstanceYaml(), secrets, expectedAgents);
                 fail();
             } catch (Throwable e) {
                 assertTrue(e.getMessage().contains("Mock failure to deploy asset"));
@@ -241,8 +233,12 @@ class DeployAssetsIT extends AbstractGenericStreamingApplicationRunner {
                                             mapper.writeValueAsString(read.get("source")));
                                     assertEquals(
                                             "Mock failure to deploy asset",
-                                            ((Map<String, Object>) read.get("data")).get("error-message") + "");
-                                    assertNotNull(((Map<String, Object>) read.get("data")).get("error-stacktrace"));
+                                            ((Map<String, Object>) read.get("data"))
+                                                            .get("error-message")
+                                                    + "");
+                                    assertNotNull(
+                                            ((Map<String, Object>) read.get("data"))
+                                                    .get("error-stacktrace"));
                                     assertNotNull(read.get("timestamp"));
                                 }
                             }));

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/mockagents/MockAssetManagerCodeProvider.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/mockagents/MockAssetManagerCodeProvider.java
@@ -63,6 +63,9 @@ public class MockAssetManagerCodeProvider implements AssetManagerProvider {
         @Override
         public synchronized void deployAsset() throws Exception {
             log.info("Deploying asset {}", assetDefinition);
+            if ((boolean)assetDefinition.getConfig().getOrDefault("fail", false)) {
+                throw new IllegalStateException("Mock failure to deploy asset");
+            }
             Map<String, Object> datasource =
                     ConfigurationUtils.getMap("datasource", null, assetDefinition.getConfig());
             if (datasource == null) {

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/mockagents/MockAssetManagerCodeProvider.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/mockagents/MockAssetManagerCodeProvider.java
@@ -63,7 +63,7 @@ public class MockAssetManagerCodeProvider implements AssetManagerProvider {
         @Override
         public synchronized void deployAsset() throws Exception {
             log.info("Deploying asset {}", assetDefinition);
-            if ((boolean)assetDefinition.getConfig().getOrDefault("fail", false)) {
+            if ((boolean) assetDefinition.getConfig().getOrDefault("fail", false)) {
                 throw new IllegalStateException("Mock failure to deploy asset");
             }
             Map<String, Object> datasource =


### PR DESCRIPTION
Event is sent with type AssetCreationFailed or AssetDeletionFailed. 
Inside `data` there's `error-message` and `error-stacktrace`
