### PR TITLE
feat(webcrawler): improve unchanged pages sourcing

### DIFF
--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/WebCrawlerSource.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/WebCrawlerSource.java
@@ -155,23 +155,24 @@ public class WebCrawlerSource extends AbstractAgentCode implements AgentSource {
                                                 entry.getKey(), entry.getValue()))
                         .collect(Collectors.toUnmodifiableList());
 
-        final boolean onlyMainContent =
-                getBoolean("only-main-content", false, configuration);
-        final Set<String> excludeFromMainContentTags = getSet("exclude-from-main-content-tags", configuration);
+        final boolean onlyMainContent = getBoolean("only-main-content", false, configuration);
+        final Set<String> excludeFromMainContentTags =
+                getSet("exclude-from-main-content-tags", configuration);
 
-        WebCrawlerConfiguration.WebCrawlerConfigurationBuilder builder = WebCrawlerConfiguration.builder()
-                .allowedDomains(allowedDomains)
-                .allowNonHtmlContents(allowNonHtmlContents)
-                .maxUrls(maxUrls)
-                .maxDepth(maxDepth)
-                .forbiddenPaths(forbiddenPaths)
-                .handleRobotsFile(handleRobotsFile)
-                .minTimeBetweenRequests(minTimeBetweenRequests)
-                .userAgent(userAgent)
-                .handleCookies(handleCookies)
-                .httpTimeout(httpTimeout)
-                .maxErrorCount(maxErrorCount)
-                .onlyMainContent(onlyMainContent);
+        WebCrawlerConfiguration.WebCrawlerConfigurationBuilder builder =
+                WebCrawlerConfiguration.builder()
+                        .allowedDomains(allowedDomains)
+                        .allowNonHtmlContents(allowNonHtmlContents)
+                        .maxUrls(maxUrls)
+                        .maxDepth(maxDepth)
+                        .forbiddenPaths(forbiddenPaths)
+                        .handleRobotsFile(handleRobotsFile)
+                        .minTimeBetweenRequests(minTimeBetweenRequests)
+                        .userAgent(userAgent)
+                        .handleCookies(handleCookies)
+                        .httpTimeout(httpTimeout)
+                        .maxErrorCount(maxErrorCount)
+                        .onlyMainContent(onlyMainContent);
         if (!excludeFromMainContentTags.isEmpty()) {
             builder.excludeFromMainContentTags(excludeFromMainContentTags);
         }
@@ -182,9 +183,10 @@ public class WebCrawlerSource extends AbstractAgentCode implements AgentSource {
         // this can be overwritten when the status is reloaded
         status.setLastIndexStartTimestamp(System.currentTimeMillis());
 
-
-        final List<String> emitContentDiff = getList("emit-content-diff", configuration).
-                stream().map(String::toLowerCase).toList();
+        final List<String> emitContentDiff =
+                getList("emit-content-diff", configuration).stream()
+                        .map(String::toLowerCase)
+                        .toList();
 
         crawler =
                 new WebCrawler(
@@ -193,12 +195,15 @@ public class WebCrawlerSource extends AbstractAgentCode implements AgentSource {
                         new DocumentVisitor() {
                             @Override
                             public void visit(Document document) {
-                                if (document.contentDiff() == null ||
-                                        emitContentDiff.isEmpty() ||
-                                        emitContentDiff.contains(document.contentDiff().toString().toLowerCase())) {
+                                if (document.contentDiff() == null
+                                        || emitContentDiff.isEmpty()
+                                        || emitContentDiff.contains(
+                                                document.contentDiff().toString().toLowerCase())) {
                                     foundDocuments.add(document);
                                 } else {
-                                    log.info("Discarding document with content diff {}", document.contentDiff());
+                                    log.info(
+                                            "Discarding document with content diff {}",
+                                            document.contentDiff());
                                 }
                             }
                         },

--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/WebCrawlerSource.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/WebCrawlerSource.java
@@ -18,11 +18,7 @@ package ai.langstream.agents.webcrawler;
 import static ai.langstream.agents.webcrawler.crawler.WebCrawlerConfiguration.DEFAULT_USER_AGENT;
 import static ai.langstream.api.util.ConfigurationUtils.*;
 
-import ai.langstream.agents.webcrawler.crawler.Document;
-import ai.langstream.agents.webcrawler.crawler.StatusStorage;
-import ai.langstream.agents.webcrawler.crawler.WebCrawler;
-import ai.langstream.agents.webcrawler.crawler.WebCrawlerConfiguration;
-import ai.langstream.agents.webcrawler.crawler.WebCrawlerStatus;
+import ai.langstream.agents.webcrawler.crawler.*;
 import ai.langstream.ai.agents.commons.state.LocalDiskStateStorage;
 import ai.langstream.ai.agents.commons.state.S3StateStorage;
 import ai.langstream.ai.agents.commons.state.StateStorage;
@@ -159,42 +155,53 @@ public class WebCrawlerSource extends AbstractAgentCode implements AgentSource {
                                                 entry.getKey(), entry.getValue()))
                         .collect(Collectors.toUnmodifiableList());
 
-        log.info("allowed-domains: {}", allowedDomains);
-        log.info("forbidden-paths: {}", forbiddenPaths);
-        log.info("allow-non-html-contents: {}", allowNonHtmlContents);
-        log.info("seed-urls: {}", seedUrls);
-        log.info("max-urls: {}", maxUrls);
-        log.info("max-depth: {}", maxDepth);
-        log.info("handle-robots-file: {}", handleRobotsFile);
-        log.info("scan-html-documents: {}", scanHtmlDocuments);
-        log.info("user-agent: {}", userAgent);
-        log.info("max-unflushed-pages: {}", maxUnflushedPages);
-        log.info("min-time-between-requests: {}", minTimeBetweenRequests);
-        log.info("reindex-interval-seconds: {}", reindexIntervalSeconds);
+        final boolean onlyMainContent =
+                getBoolean("only-main-content", false, configuration);
+        final Set<String> excludeFromMainContentTags = getSet("exclude-from-main-content-tags", configuration);
 
-        WebCrawlerConfiguration webCrawlerConfiguration =
-                WebCrawlerConfiguration.builder()
-                        .allowedDomains(allowedDomains)
-                        .allowNonHtmlContents(allowNonHtmlContents)
-                        .maxUrls(maxUrls)
-                        .maxDepth(maxDepth)
-                        .forbiddenPaths(forbiddenPaths)
-                        .handleRobotsFile(handleRobotsFile)
-                        .minTimeBetweenRequests(minTimeBetweenRequests)
-                        .userAgent(userAgent)
-                        .handleCookies(handleCookies)
-                        .httpTimeout(httpTimeout)
-                        .maxErrorCount(maxErrorCount)
-                        .build();
+        WebCrawlerConfiguration.WebCrawlerConfigurationBuilder builder = WebCrawlerConfiguration.builder()
+                .allowedDomains(allowedDomains)
+                .allowNonHtmlContents(allowNonHtmlContents)
+                .maxUrls(maxUrls)
+                .maxDepth(maxDepth)
+                .forbiddenPaths(forbiddenPaths)
+                .handleRobotsFile(handleRobotsFile)
+                .minTimeBetweenRequests(minTimeBetweenRequests)
+                .userAgent(userAgent)
+                .handleCookies(handleCookies)
+                .httpTimeout(httpTimeout)
+                .maxErrorCount(maxErrorCount)
+                .onlyMainContent(onlyMainContent);
+        if (!excludeFromMainContentTags.isEmpty()) {
+            builder.excludeFromMainContentTags(excludeFromMainContentTags);
+        }
+        WebCrawlerConfiguration webCrawlerConfiguration = builder.build();
+        log.info("configuration: {}", webCrawlerConfiguration);
 
         WebCrawlerStatus status = new WebCrawlerStatus();
         // this can be overwritten when the status is reloaded
         status.setLastIndexStartTimestamp(System.currentTimeMillis());
+
+
+        final List<String> emitContentDiff = getList("emit-content-diff", configuration).
+                stream().map(String::toLowerCase).toList();
+
         crawler =
                 new WebCrawler(
                         webCrawlerConfiguration,
                         status,
-                        foundDocuments::add,
+                        new DocumentVisitor() {
+                            @Override
+                            public void visit(Document document) {
+                                if (document.contentDiff() == null ||
+                                        emitContentDiff.isEmpty() ||
+                                        emitContentDiff.contains(document.contentDiff().toString().toLowerCase())) {
+                                    foundDocuments.add(document);
+                                } else {
+                                    log.info("Discarding document with content diff {}", document.contentDiff());
+                                }
+                            }
+                        },
                         this::sendDeletedDocument);
 
         sourceActivitySummaryTopic =

--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/WebCrawler.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/WebCrawler.java
@@ -271,9 +271,9 @@ public class WebCrawler {
                                 });
             }
             if (configuration.isOnlyMainContent()) {
-                for (String excludeFromMainContentTag : configuration.getExcludeFromMainContentTags()) {
-                    document.getElementsByTag(excludeFromMainContentTag)
-                            .remove();
+                for (String excludeFromMainContentTag :
+                        configuration.getExcludeFromMainContentTags()) {
+                    document.getElementsByTag(excludeFromMainContentTag).remove();
                 }
             }
             onDocumentFound(current, document.html().getBytes(StandardCharsets.UTF_8), contentType);

--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/WebCrawler.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/WebCrawler.java
@@ -270,6 +270,12 @@ public class WebCrawler {
                                     }
                                 });
             }
+            if (configuration.isOnlyMainContent()) {
+                for (String excludeFromMainContentTag : configuration.getExcludeFromMainContentTags()) {
+                    document.getElementsByTag(excludeFromMainContentTag)
+                            .remove();
+                }
+            }
             onDocumentFound(current, document.html().getBytes(StandardCharsets.UTF_8), contentType);
         }
 

--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerConfiguration.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerConfiguration.java
@@ -40,8 +40,10 @@ public class WebCrawlerConfiguration {
     @Builder.Default private boolean handleRobotsFile = true;
     @Builder.Default private boolean scanHtmlDocuments = true;
     @Builder.Default private boolean allowNonHtmlContents = false;
+    @Builder.Default private boolean onlyMainContent = false;
+    @Builder.Default private Set<String> excludeFromMainContentTags = Set.of("script", "style", "noscript", "iframe", "link", "base", "meta", "object", "embed", "applet", "audio", "video", "canvas", "template", "comment");
 
-    @Builder.Default private Set<String> allowedTags = Set.of("a");
+    @Builder.Default private Set<String> allowedTagsForHtmlDocumentScan = Set.of("a");
 
     public boolean isAllowedUrl(String url) {
         final String domainOnly;
@@ -96,6 +98,6 @@ public class WebCrawlerConfiguration {
     }
 
     public boolean isAllowedTag(String tagName) {
-        return tagName != null && allowedTags.contains(tagName.toLowerCase());
+        return tagName != null && allowedTagsForHtmlDocumentScan.contains(tagName.toLowerCase());
     }
 }

--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerConfiguration.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerConfiguration.java
@@ -41,7 +41,25 @@ public class WebCrawlerConfiguration {
     @Builder.Default private boolean scanHtmlDocuments = true;
     @Builder.Default private boolean allowNonHtmlContents = false;
     @Builder.Default private boolean onlyMainContent = false;
-    @Builder.Default private Set<String> excludeFromMainContentTags = Set.of("script", "style", "noscript", "iframe", "link", "base", "meta", "object", "embed", "applet", "audio", "video", "canvas", "template", "comment");
+
+    @Builder.Default
+    private Set<String> excludeFromMainContentTags =
+            Set.of(
+                    "script",
+                    "style",
+                    "noscript",
+                    "iframe",
+                    "link",
+                    "base",
+                    "meta",
+                    "object",
+                    "embed",
+                    "applet",
+                    "audio",
+                    "video",
+                    "canvas",
+                    "template",
+                    "comment");
 
     @Builder.Default private Set<String> allowedTagsForHtmlDocumentScan = Set.of("a");
 

--- a/langstream-agents/langstream-agent-webcrawler/src/test/java/ai/langstream/agents/webcrawler/WebCrawlerSourceTest.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/test/java/ai/langstream/agents/webcrawler/WebCrawlerSourceTest.java
@@ -35,13 +35,11 @@ import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import io.minio.*;
 import io.minio.errors.ErrorResponseException;
 import io.minio.messages.Item;
-
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
-
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
@@ -121,20 +119,20 @@ public class WebCrawlerSourceTest {
         String allowed = "https://docs.langstream.ai/";
 
         try (WebCrawlerSource agentSource =
-                     buildAgentSource(
-                             bucket,
-                             allowed,
-                             Set.of("/pipeline-agents", "/building-applications"),
-                             url,
-                             Map.of(
-                                     "reindex-interval-seconds",
-                                     "1",
-                                     "max-urls",
-                                     10,
-                                     "state-storage-file-prepend-tenant",
-                                     "true",
-                                     "state-storage-file-prefix",
-                                     "langstream-apps/"));) {
+                buildAgentSource(
+                        bucket,
+                        allowed,
+                        Set.of("/pipeline-agents", "/building-applications"),
+                        url,
+                        Map.of(
+                                "reindex-interval-seconds",
+                                "1",
+                                "max-urls",
+                                10,
+                                "state-storage-file-prepend-tenant",
+                                "true",
+                                "state-storage-file-prefix",
+                                "langstream-apps/")); ) {
             List<Record> read = agentSource.read();
             Set<String> urls = new HashSet<>();
             agentSource.setOnReindexStart(
@@ -306,7 +304,7 @@ public class WebCrawlerSourceTest {
         Map<String, Object> additionalConfig =
                 Map.of("reindex-interval-seconds", "4", "handle-robots-file", "false");
         try (WebCrawlerSource agentSource =
-                     buildAgentSource(bucket, allowed, Set.of(), url, additionalConfig);) {
+                buildAgentSource(bucket, allowed, Set.of(), url, additionalConfig); ) {
             List<Record> read = agentSource.read();
             Set<String> urls = new HashSet<>();
             AtomicInteger reindexCount = new AtomicInteger();
@@ -427,7 +425,6 @@ public class WebCrawlerSourceTest {
                                         .build()));
     }
 
-
     @Test
     void testSkipUnchanged(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
         stubFor(
@@ -460,11 +457,14 @@ public class WebCrawlerSourceTest {
         String url = wmRuntimeInfo.getHttpBaseUrl() + "/index.html";
         String allowed = wmRuntimeInfo.getHttpBaseUrl();
         Map<String, Object> additionalConfig =
-                Map.of("reindex-interval-seconds", "2",
-                        "emit-content-diff", List.of("new", "content_changed"));
+                Map.of(
+                        "reindex-interval-seconds",
+                        "2",
+                        "emit-content-diff",
+                        List.of("new", "content_changed"));
 
         try (WebCrawlerSource agentSource =
-                     buildAgentSource(bucket, allowed, Set.of(), url, additionalConfig);) {
+                buildAgentSource(bucket, allowed, Set.of(), url, additionalConfig); ) {
             List<Record> read = agentSource.read();
             AtomicInteger reindexCount = new AtomicInteger();
             agentSource.setOnReindexStart(
@@ -523,7 +523,7 @@ public class WebCrawlerSourceTest {
         String allowed = wmRuntimeInfo.getHttpBaseUrl();
         Map<String, Object> additionalConfig = Map.of();
         try (WebCrawlerSource agentSource =
-                     buildAgentSource(bucket, allowed, Set.of(), url, additionalConfig);) {
+                buildAgentSource(bucket, allowed, Set.of(), url, additionalConfig); ) {
 
             WebCrawler crawler = agentSource.getCrawler();
             WebCrawlerStatus status = crawler.getStatus();
@@ -571,7 +571,7 @@ public class WebCrawlerSourceTest {
 
             // test reload robot rules from S3
             try (WebCrawlerSource agentSource2 =
-                         buildAgentSource(bucket, allowed, Set.of(), url, additionalConfig);) {
+                    buildAgentSource(bucket, allowed, Set.of(), url, additionalConfig); ) {
                 WebCrawler crawler2 = agentSource2.getCrawler();
                 assertEquals(crawler2.getStatus().getRobotsFiles(), status.getRobotsFiles());
             }
@@ -677,24 +677,23 @@ public class WebCrawlerSourceTest {
                                 5 * 1024 * 1024)
                         .build());
         try (WebCrawlerSource agentSource =
-                     buildAgentSource(
-                             bucket,
-                             allowed,
-                             Set.of(),
-                             url,
-                             Map.of(
-                                     "reindex-interval-seconds",
-                                     "3600",
-                                     "scan-html-documents",
-                                     "false",
-                                     "max-urls",
-                                     10000));) {
+                buildAgentSource(
+                        bucket,
+                        allowed,
+                        Set.of(),
+                        url,
+                        Map.of(
+                                "reindex-interval-seconds",
+                                "3600",
+                                "scan-html-documents",
+                                "false",
+                                "max-urls",
+                                10000)); ) {
             assertEquals(
                     "s3://%s/%s".formatted(bucket, objectName),
                     agentSource.buildAdditionalInfo().get("statusFileName"));
         }
     }
-
 
     @Test
     void testOnlyMainContent(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
@@ -723,22 +722,16 @@ public class WebCrawlerSourceTest {
                                                     </body>
                                                     </html>
                                                 """)));
-        stubFor(
-                get("/secondPage.html")
-                        .willReturn(
-                                okForContentType(
-                                        "text/html",
-                                        "Second")));
+        stubFor(get("/secondPage.html").willReturn(okForContentType("text/html", "Second")));
 
         String bucket = "langstream-test-" + UUID.randomUUID();
         String url = wmRuntimeInfo.getHttpBaseUrl() + "/index.html";
         String allowed = wmRuntimeInfo.getHttpBaseUrl();
         Map<String, Object> additionalConfig =
-                Map.of("only-main-content", true,
-                        "handle-robots-file", "false");
+                Map.of("only-main-content", true, "handle-robots-file", "false");
 
         try (WebCrawlerSource agentSource =
-                     buildAgentSource(bucket, allowed, Set.of(), url, additionalConfig);) {
+                buildAgentSource(bucket, allowed, Set.of(), url, additionalConfig); ) {
             List<Record> all = new ArrayList<>();
             for (int i = 0; i < 2; i++) {
                 all.addAll(agentSource.read());
@@ -747,7 +740,8 @@ public class WebCrawlerSourceTest {
             for (Record record : all) {
                 String content = new String((byte[]) record.value(), StandardCharsets.UTF_8);
                 if (record.key().toString().contains("index.html")) {
-                    assertEquals("""
+                    assertEquals(
+                            """
                             <html>
                              <head>
                               <title>Test</title>
@@ -757,16 +751,19 @@ public class WebCrawlerSourceTest {
                                <a href="secondPage.html">link</a> Hello World!
                               </div>
                              </body>
-                            </html>""", content);
+                            </html>""",
+                            content);
                 } else {
 
-                    assertEquals("""
+                    assertEquals(
+                            """
                             <html>
                              <head></head>
                              <body>
                               Second
                              </body>
-                            </html>""", content);
+                            </html>""",
+                            content);
                 }
             }
         }

--- a/langstream-agents/langstream-agents-ms365/pom.xml
+++ b/langstream-agents/langstream-agents-ms365/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>langstream-agents</artifactId>
     <groupId>ai.langstream</groupId>
-    <version>0.21.5-SNAPSHOT</version>
+    <version>0.22.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/WebCrawlerSourceAgentProvider.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/WebCrawlerSourceAgentProvider.java
@@ -306,6 +306,25 @@ public class WebCrawlerSourceAgentProvider extends AbstractComposableAgentProvid
         @ConfigProperty(
                 description =
                         """
+                        Whether to remove non semantic tags from the content. (script, style..)
+                        """,
+                defaultValue = "false")
+        @JsonProperty("only-main-content")
+        private boolean onlyMainContent;
+
+        @ConfigProperty(
+                description =
+                        """
+                        If only-main-content is enabled, this list of tags will be excluded from the main content.
+                                """,
+                defaultValue = "[\"script\", \"style\", \"noscript\", \"iframe\", \"link\", \"base\", \"meta\", \"object\", \"embed\", \"applet\", \"audio\", \"video\", \"canvas\", \"template\", \"comment\"]")
+        @JsonProperty("exclude-from-main-content-tags")
+        private List<String> excludeFromMainContentTags;
+
+
+        @ConfigProperty(
+                description =
+                        """
                         Detect documents that have been deleted from the website and send the URL to this topic.
                         """,
                 defaultValue = "")
@@ -354,5 +373,18 @@ public class WebCrawlerSourceAgentProvider extends AbstractComposableAgentProvid
                                 """)
         @JsonProperty("source-activity-summary-time-seconds-threshold")
         private int sourceActivitySummaryTimeSecondsThreshold;
+
+        @ConfigProperty(
+                description =
+                        """
+                        Filter content diff you want to emit. By default all content diff are emitted.
+                        To emit only new content diff, set to 'new'.
+                        To emit only changed content diff, set to 'content_changed'.
+                        To skip emitting unchanged content diff, set to 'new', 'content_changed'.
+                                """,
+                defaultValue = "true")
+        @JsonProperty("emit-content-diff")
+        private List<String> emitContentDiff;
     }
+
 }

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/WebCrawlerSourceAgentProvider.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/WebCrawlerSourceAgentProvider.java
@@ -317,10 +317,10 @@ public class WebCrawlerSourceAgentProvider extends AbstractComposableAgentProvid
                         """
                         If only-main-content is enabled, this list of tags will be excluded from the main content.
                                 """,
-                defaultValue = "[\"script\", \"style\", \"noscript\", \"iframe\", \"link\", \"base\", \"meta\", \"object\", \"embed\", \"applet\", \"audio\", \"video\", \"canvas\", \"template\", \"comment\"]")
+                defaultValue =
+                        "[\"script\", \"style\", \"noscript\", \"iframe\", \"link\", \"base\", \"meta\", \"object\", \"embed\", \"applet\", \"audio\", \"video\", \"canvas\", \"template\", \"comment\"]")
         @JsonProperty("exclude-from-main-content-tags")
         private List<String> excludeFromMainContentTags;
-
 
         @ConfigProperty(
                 description =
@@ -386,5 +386,4 @@ public class WebCrawlerSourceAgentProvider extends AbstractComposableAgentProvid
         @JsonProperty("emit-content-diff")
         private List<String> emitContentDiff;
     }
-
 }


### PR DESCRIPTION
New flags:
- `only-main-content`: default to false, if enabled it will remove script, style (and others) tags from the emitted document. This is particalury helpful in order to verify actual semantic changes to the pages, not related to sldf (script versioning, cache busting, etc)  
- `emit-content-diff`: list, default to all the content diff. You can filter the content diff you want the source to emit, if available. For example, to not emit content_unchanged, you can set `emit-content-diff: ['new', 'content_diff']`