### PR TITLE
feat: dropbox source

### DIFF
--- a/langstream-agents/langstream-agents-dropbox/pom.xml
+++ b/langstream-agents/langstream-agents-dropbox/pom.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright DataStax, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>langstream-agents</artifactId>
+    <groupId>ai.langstream</groupId>
+    <version>0.23.1-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>langstream-agents-dropbox</artifactId>
+  <dependencyManagement>
+
+  </dependencyManagement>
+
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>langstream-api</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>langstream-agents-commons</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>ai.langstream</groupId>
+      <artifactId>langstream-agents-commons-storage-provider</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.dropbox.core</groupId>
+      <artifactId>dropbox-core-sdk</artifactId>
+      <version>7.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.nifi</groupId>
+        <artifactId>nifi-nar-maven-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <classifier>nar</classifier>
+        </configuration>
+        <executions>
+          <execution>
+            <id>default-nar</id>
+            <phase>package</phase>
+            <goals>
+              <goal>nar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/langstream-agents/langstream-agents-dropbox/src/main/java/ai/langstream/agents/dropbox/DropboxAgentsCodeProvider.java
+++ b/langstream-agents/langstream-agents-dropbox/src/main/java/ai/langstream/agents/dropbox/DropboxAgentsCodeProvider.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.agents.dropbox;
+
+import ai.langstream.api.runner.code.AgentCode;
+import ai.langstream.api.runner.code.AgentCodeProvider;
+import java.util.List;
+
+public class DropboxAgentsCodeProvider implements AgentCodeProvider {
+
+    public static final String DROPBOX_SOURCE = "dropbox-source";
+    private static final List<String> AGENTS = List.of(DROPBOX_SOURCE);
+
+    @Override
+    public boolean supports(String agentType) {
+        return AGENTS.contains(agentType);
+    }
+
+    @Override
+    public AgentCode createInstance(String agentType) {
+        switch (agentType) {
+            case DROPBOX_SOURCE:
+                return new DropboxSource();
+            default:
+                throw new IllegalArgumentException("Unsupported agent type: " + agentType);
+        }
+    }
+}

--- a/langstream-agents/langstream-agents-dropbox/src/main/java/ai/langstream/agents/dropbox/DropboxSource.java
+++ b/langstream-agents/langstream-agents-dropbox/src/main/java/ai/langstream/agents/dropbox/DropboxSource.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.agents.dropbox;
+
+import ai.langstream.ai.agents.commons.storage.provider.StorageProviderObjectReference;
+import ai.langstream.ai.agents.commons.storage.provider.StorageProviderSource;
+import ai.langstream.ai.agents.commons.storage.provider.StorageProviderSourceState;
+import ai.langstream.api.runner.code.Header;
+import ai.langstream.api.runner.code.SimpleRecord;
+import ai.langstream.api.util.ConfigurationUtils;
+import com.dropbox.core.DbxDownloader;
+import com.dropbox.core.DbxRequestConfig;
+import com.dropbox.core.v2.DbxClientV2;
+import com.dropbox.core.v2.files.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.ByteArrayOutputStream;
+import java.util.*;
+
+@Slf4j
+public class DropboxSource extends StorageProviderSource<DropboxSource.DropboxSourceState> {
+
+    public static class DropboxSourceState extends StorageProviderSourceState {
+    }
+
+    private DbxClientV2 client;
+
+    private String pathPrefix;
+    private Set<String> extensions;
+
+    @Override
+    public Class<DropboxSourceState> getStateClass() {
+        return DropboxSourceState.class;
+    }
+
+    @Override
+    public void initializeClientAndConfig(Map<String, Object> configuration) {
+        String accessToken = ConfigurationUtils.requiredField(configuration, "access-token", () -> "dropbox source");
+        String clientIdentifier = ConfigurationUtils.getString("client-identifier", "langstream-source", configuration);
+        DbxRequestConfig config = DbxRequestConfig.newBuilder(clientIdentifier)
+                .withAutoRetryEnabled()
+                .build();
+        client = new DbxClientV2(config, accessToken);
+        initializeConfig(configuration);
+
+    }
+
+    void initializeConfig(Map<String, Object> configuration) {
+        pathPrefix = configuration.getOrDefault("path-prefix", "").toString();
+        if (StringUtils.isNotEmpty(pathPrefix) && pathPrefix.endsWith("/")) {
+            pathPrefix = pathPrefix.substring(0, pathPrefix.length() - 1);
+        }
+
+        extensions = ConfigurationUtils.getSet("extensions", configuration);
+        if (extensions.isEmpty()) {
+            log.info("No extensions filter set, getting all files");
+        }
+    }
+
+    @Override
+    public String getBucketName() {
+        return "";
+    }
+
+    @Override
+    public boolean isDeleteObjects() {
+        return false;
+    }
+
+    @Override
+    public Collection<StorageProviderObjectReference> listObjects() throws Exception {
+        List<StorageProviderObjectReference> collect = new ArrayList<>();
+        collectFiles(pathPrefix, collect);
+        log.info("Found {} files", collect.size());
+        return collect;
+    }
+
+
+    private void collectFiles(String path, List<StorageProviderObjectReference> collect) throws Exception {
+        log.debug("Listing path {}", path);
+        ListFolderResult result = client.files().listFolder(path);
+        while (true) {
+            for (Metadata metadata : result.getEntries()) {
+                if (metadata instanceof DeletedMetadata) {
+                    continue;
+                } else if (metadata instanceof FolderMetadata folder) {
+                    collectFiles(folder.getPathDisplay(), collect);
+                } else if (metadata instanceof FileMetadata file) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("found file {}", file);
+                    }
+                    if (file.getContentHash() == null) {
+                        log.warn("No content hash for file {}", file.getPathDisplay());
+                        continue;
+                    }
+                    if (!extensions.isEmpty()) {
+                        final String extension;
+                        if (file.getName().contains(".")) {
+                            extension = file.getName().substring(file.getName().lastIndexOf('.') + 1);
+                        } else {
+                            extension = "";
+                        }
+                        if (!extensions.contains(extension)) {
+                            log.info("Skipping file with extension {} (extension {})", file.getPathDisplay(), extension);
+                            continue;
+                        }
+                    }
+                    if (log.isDebugEnabled()) {
+                        log.debug("Adding file {}, id {}, size {}, digest {}, path {}", file.getName(), file.getId(),
+                                file.getSize(), file.getContentHash(),
+                                file.getPathDisplay());
+                    }
+                    collect.add(new DropboxObject(file));
+                } else {
+                    log.warn("Unknown metadata type {}", metadata);
+                }
+            }
+            if (!result.getHasMore()) {
+                break;
+            }
+            result = client.files().listFolderContinue(result.getCursor());
+        }
+    }
+
+    @Override
+    public byte[] downloadObject(StorageProviderObjectReference object) throws Exception {
+        DropboxObject file = (DropboxObject) object;
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try {
+            log.info("Downloading file {}", file.getFile().getPathDisplay());
+            try (DbxDownloader<FileMetadata> downloader = client.files().download(file.getFile().getPathDisplay());) {
+                downloader.download(baos);
+            }
+            return baos.toByteArray();
+        } catch (Exception e) {
+            log.error("Error downloading file {}", file.getFile().getPathDisplay(), e);
+            throw e;
+        }
+    }
+
+    @Override
+    public void deleteObject(String id) throws Exception {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isStateStorageRequired() {
+        return true;
+    }
+
+    @AllArgsConstructor
+    @Getter
+    private static class DropboxObject implements StorageProviderObjectReference {
+        private final FileMetadata file;
+
+        @Override
+        public String id() {
+            return file.getId();
+        }
+
+        @Override
+        public long size() {
+            return file.getSize();
+        }
+
+        @Override
+        public String contentDigest() {
+            return file.getContentHash();
+        }
+
+        @Override
+        public Collection<Header> additionalRecordHeaders() {
+            return List.of(
+                    SimpleRecord.SimpleHeader.of("dropbox-path", file.getPathDisplay()),
+                    SimpleRecord.SimpleHeader.of("dropbox-filename", file.getName())
+            );
+        }
+    }
+}

--- a/langstream-agents/langstream-agents-dropbox/src/main/resources/META-INF/ai.langstream.agents.index
+++ b/langstream-agents/langstream-agents-dropbox/src/main/resources/META-INF/ai.langstream.agents.index
@@ -1,0 +1,1 @@
+dropbox-source

--- a/langstream-agents/langstream-agents-dropbox/src/main/resources/META-INF/services/ai.langstream.api.runner.code.AgentCodeProvider
+++ b/langstream-agents/langstream-agents-dropbox/src/main/resources/META-INF/services/ai.langstream.api.runner.code.AgentCodeProvider
@@ -1,0 +1,1 @@
+ai.langstream.agents.dropbox.DropboxAgentsCodeProvider

--- a/langstream-agents/pom.xml
+++ b/langstream-agents/pom.xml
@@ -27,10 +27,6 @@
     <artifactId>langstream-agents</artifactId>
     <name>LangStream - Agents</name>
     <packaging>pom</packaging>
-    <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
-    </properties>
     <modules>
         <module>langstream-agents-commons</module>
         <module>langstream-agents-commons-state-storage</module>
@@ -48,5 +44,6 @@
         <module>langstream-agent-azure-blob-storage-source</module>
         <module>langstream-agents-google</module>
         <module>langstream-agents-ms365</module>
+        <module>langstream-agents-dropbox</module>
     </modules>
 </project>

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/StorageProviderSourceAgentProvider.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/StorageProviderSourceAgentProvider.java
@@ -22,17 +22,13 @@ import ai.langstream.api.runtime.ComponentType;
 import ai.langstream.impl.agents.AbstractComposableAgentProvider;
 import ai.langstream.runtime.impl.k8s.KubernetesClusterRuntime;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.util.List;
 import java.util.Set;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.extern.slf4j.Slf4j;
 
-/**
- * Implements support for Storage provider source Agents.
- */
+/** Implements support for Storage provider source Agents. */
 @Slf4j
 public class StorageProviderSourceAgentProvider extends AbstractComposableAgentProvider {
 
@@ -532,8 +528,7 @@ public class StorageProviderSourceAgentProvider extends AbstractComposableAgentP
                             """)
     @Data
     @EqualsAndHashCode(callSuper = true)
-    public static class DropboxSourceConfiguration
-            extends StorageProviderSourceBaseConfiguration {
+    public static class DropboxSourceConfiguration extends StorageProviderSourceBaseConfiguration {
 
         @ConfigProperty(
                 required = true,
@@ -564,7 +559,7 @@ public class StorageProviderSourceAgentProvider extends AbstractComposableAgentP
                 description =
                         """
                                 The root directory to read from.
-                                Use a leading slash. 
+                                Use a leading slash.
                                 Examples: /my-root/ or /my-root/sub-folder
                                 """,
                 defaultValue = "")

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/StorageProviderSourceAgentProvider.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/StorageProviderSourceAgentProvider.java
@@ -22,13 +22,17 @@ import ai.langstream.api.runtime.ComponentType;
 import ai.langstream.impl.agents.AbstractComposableAgentProvider;
 import ai.langstream.runtime.impl.k8s.KubernetesClusterRuntime;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.List;
 import java.util.Set;
+
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.extern.slf4j.Slf4j;
 
-/** Implements support for Storage provider source Agents. */
+/**
+ * Implements support for Storage provider source Agents.
+ */
 @Slf4j
 public class StorageProviderSourceAgentProvider extends AbstractComposableAgentProvider {
 
@@ -40,6 +44,7 @@ public class StorageProviderSourceAgentProvider extends AbstractComposableAgentP
 
     protected static final String MS_365_SHAREPOINT_SOURCE = "ms365-sharepoint-source";
     protected static final String MS_365_ONEDRIVE_SOURCE = "ms365-onedrive-source";
+    protected static final String DROPBOX_SOURCE = "dropbox-source";
 
     public StorageProviderSourceAgentProvider() {
         super(
@@ -49,7 +54,8 @@ public class StorageProviderSourceAgentProvider extends AbstractComposableAgentP
                         GCS_SOURCE,
                         GOOGLE_DRIVE_SOURCE,
                         MS_365_SHAREPOINT_SOURCE,
-                        MS_365_ONEDRIVE_SOURCE),
+                        MS_365_ONEDRIVE_SOURCE,
+                        DROPBOX_SOURCE),
                 List.of(KubernetesClusterRuntime.CLUSTER_TYPE, "none"));
     }
 
@@ -73,6 +79,8 @@ public class StorageProviderSourceAgentProvider extends AbstractComposableAgentP
                 return MS365SharepointSourceConfiguration.class;
             case MS_365_ONEDRIVE_SOURCE:
                 return MS365OneDriveSourceConfiguration.class;
+            case DROPBOX_SOURCE:
+                return DropboxSourceConfiguration.class;
             default:
                 throw new IllegalArgumentException("Unknown agent type: " + type);
         }
@@ -512,6 +520,54 @@ public class StorageProviderSourceAgentProvider extends AbstractComposableAgentP
                                 The root directory to read from.
                                 Do not use a leading slash. To specify a directory, include a trailing slash.                                 """,
                 defaultValue = "/")
+        @JsonProperty("path-prefix")
+        private String pathPrefix;
+    }
+
+    @AgentConfig(
+            name = "Dropbox Source",
+            description =
+                    """
+                            Reads data from Dropbox via an application.
+                            """)
+    @Data
+    @EqualsAndHashCode(callSuper = true)
+    public static class DropboxSourceConfiguration
+            extends StorageProviderSourceBaseConfiguration {
+
+        @ConfigProperty(
+                required = true,
+                description =
+                        """
+                                Access token for the Dropbox application.
+                                """)
+        @JsonProperty("access-token")
+        private String accessToken;
+
+        @ConfigProperty(
+                description =
+                        """
+                                Entra MS registered application's tenant ID.
+                                """,
+                defaultValue = "langstream-source")
+        @JsonProperty("client-identifier")
+        private String clientIdentifier;
+
+        @ConfigProperty(
+                description =
+                        """
+                                Filter by file extension. By default, all files are included.
+                                        """)
+        private Set<String> extensions;
+
+        @ConfigProperty(
+                description =
+                        """
+                                The root directory to read from.
+                                Use a leading slash. 
+                                Examples: /my-root/ or /my-root/sub-folder
+                                """,
+                defaultValue = "")
         @JsonProperty("path-prefix")
         private String pathPrefix;
     }

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/test/java/ai/langstream/runtime/impl/k8s/agents/S3SourceAgentProviderTest.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/test/java/ai/langstream/runtime/impl/k8s/agents/S3SourceAgentProviderTest.java
@@ -239,6 +239,115 @@ class S3SourceAgentProviderTest {
                               }
                             }
                           },
+                          "dropbox-source" : {
+                            "name" : "Dropbox Source",
+                            "description" : "Reads data from Dropbox via an application.",
+                            "properties" : {
+                              "access-token" : {
+                                "description" : "Access token for the Dropbox application.",
+                                "required" : true,
+                                "type" : "string"
+                              },
+                              "client-identifier" : {
+                                "description" : "Entra MS registered application's tenant ID.",
+                                "required" : false,
+                                "type" : "string",
+                                "defaultValue" : "langstream-source"
+                              },
+                              "deleted-objects-topic" : {
+                                "description" : "Write a message to this topic when an object has been detected as deleted for any reason.",
+                                "required" : false,
+                                "type" : "string"
+                              },
+                              "extensions" : {
+                                "description" : "Filter by file extension. By default, all files are included.",
+                                "required" : false,
+                                "type" : "array",
+                                "items" : {
+                                  "description" : "Filter by file extension. By default, all files are included.",
+                                  "required" : false,
+                                  "type" : "string"
+                                }
+                              },
+                              "idle-time" : {
+                                "description" : "Time in seconds to sleep after polling for new files.",
+                                "required" : false,
+                                "type" : "integer",
+                                "defaultValue" : "5"
+                              },
+                              "path-prefix" : {
+                                "description" : "The root directory to read from.\\nUse a leading slash.\\nExamples: /my-root/ or /my-root/sub-folder",
+                                "required" : false,
+                                "type" : "string"
+                              },
+                              "source-activity-summary-events" : {
+                                "description" : "List of events (comma separated) to include in the source activity summary. ('new', 'updated', 'deleted')\\nTo include all: 'new,updated,deleted'.\\nUse this property to disable the source activity summary (by leaving default to empty).",
+                                "required" : false,
+                                "type" : "string"
+                              },
+                              "source-activity-summary-events-threshold" : {
+                                "description" : "Trigger source activity summary emission when this number of events have been detected, even if the time threshold has not been reached yet.",
+                                "required" : false,
+                                "type" : "integer",
+                                "defaultValue" : "60"
+                              },
+                              "source-activity-summary-time-seconds-threshold" : {
+                                "description" : "Trigger source activity summary emission every time this time threshold has been reached.",
+                                "required" : false,
+                                "type" : "integer"
+                              },
+                              "source-activity-summary-topic" : {
+                                "description" : "Write a message to this topic periodically with a summary of the activity in the source.",
+                                "required" : false,
+                                "type" : "string"
+                              },
+                              "source-record-headers" : {
+                                "description" : "Additional headers to add to emitted records.",
+                                "required" : false,
+                                "type" : "object"
+                              },
+                              "state-storage" : {
+                                "description" : "State storage type (s3, disk).",
+                                "required" : false,
+                                "type" : "string"
+                              },
+                              "state-storage-file-prefix" : {
+                                "description" : "Prepend a prefix to the state storage file. (valid for all types)",
+                                "required" : false,
+                                "type" : "string"
+                              },
+                              "state-storage-file-prepend-tenant" : {
+                                "description" : "Prepend tenant to the state storage file. (valid for all types)",
+                                "required" : false,
+                                "type" : "string"
+                              },
+                              "state-storage-s3-access-key" : {
+                                "description" : "State storage S3 access key.",
+                                "required" : false,
+                                "type" : "string"
+                              },
+                              "state-storage-s3-bucket" : {
+                                "description" : "State storage S3 bucket.",
+                                "required" : false,
+                                "type" : "string"
+                              },
+                              "state-storage-s3-endpoint" : {
+                                "description" : "State storage S3 endpoint.",
+                                "required" : false,
+                                "type" : "string"
+                              },
+                              "state-storage-s3-region" : {
+                                "description" : "State storage S3 region.",
+                                "required" : false,
+                                "type" : "string"
+                              },
+                              "state-storage-s3-secret-key" : {
+                                "description" : "State storage S3 secret key.",
+                                "required" : false,
+                                "type" : "string"
+                              }
+                            }
+                          },
                           "google-cloud-storage-source" : {
                             "name" : "Google Cloud Storage Source",
                             "description" : "Reads data from Google Cloud Storage. The only authentication supported is via service account JSON.",

--- a/langstream-runtime/langstream-runtime-impl/pom.xml
+++ b/langstream-runtime/langstream-runtime-impl/pom.xml
@@ -347,6 +347,13 @@
 
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>langstream-agents-dropbox</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>langstream-agent-webcrawler</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
@@ -668,6 +675,16 @@
                 <artifactItem>
                   <groupId>${project.groupId}</groupId>
                   <artifactId>langstream-agents-ms365</artifactId>
+                  <version>${project.version}</version>
+                  <type>nar</type>
+                  <classifier>nar</classifier>
+                  <overWrite>false</overWrite>
+                  <outputDirectory>${project.build.directory}/agents</outputDirectory>
+                </artifactItem>
+
+                <artifactItem>
+                  <groupId>${project.groupId}</groupId>
+                  <artifactId>langstream-agents-dropbox</artifactId>
                   <version>${project.version}</version>
                   <type>nar</type>
                   <classifier>nar</classifier>

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/agents/DropboxSourceIT.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/agents/DropboxSourceIT.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.agents;
+
+import ai.langstream.api.runner.topics.TopicConsumer;
+import ai.langstream.api.util.ConfigurationUtils;
+import ai.langstream.testrunners.AbstractGenericStreamingApplicationRunner;
+import com.azure.identity.ClientSecretCredential;
+import com.azure.identity.ClientSecretCredentialBuilder;
+import com.dropbox.core.DbxRequestConfig;
+import com.dropbox.core.v2.DbxClientV2;
+import com.dropbox.core.v2.files.DeleteErrorException;
+import com.dropbox.core.v2.files.FileMetadata;
+import com.microsoft.graph.models.*;
+import com.microsoft.graph.serviceclient.GraphServiceClient;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.io.ByteArrayInputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static ai.langstream.testrunners.AbstractApplicationRunner.INTEGRATION_TESTS_GROUP1;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.testcontainers.containers.localstack.LocalStackContainer.Service.S3;
+
+@Slf4j
+@Testcontainers
+@Tag(INTEGRATION_TESTS_GROUP1)
+@Disabled
+class DropboxSourceIT extends AbstractGenericStreamingApplicationRunner {
+    @Container
+    private static final LocalStackContainer localstack =
+            new LocalStackContainer(DockerImageName.parse("localstack/localstack:2.2.0"))
+                    .withServices(S3);
+
+    private static final String ACCESS_TOKEN = "";
+
+    @Test
+    public void test() throws Exception {
+
+        DbxRequestConfig config = DbxRequestConfig.newBuilder("langstream-test")
+                .withAutoRetryEnabled()
+                .build();
+        DbxClientV2 client = new DbxClientV2(config, ACCESS_TOKEN);
+        try {
+            client.files().deleteV2("/langstream-test");
+        } catch (DeleteErrorException e) {
+        }
+        client.files().createFolderV2("/langstream-test");
+
+
+        final String appId = "app-" + UUID.randomUUID().toString().substring(0, 4);
+
+        String tenant = "tenant";
+        String[] expectedAgents = new String[] {appId + "-step1", appId + "-step2"};
+        Map<String, String> application =
+                Map.of(
+                        "module.yaml",
+                        """
+                                module: "module-1"
+                                id: "pipeline-1"
+                                topics:
+                                  - name: "${globals.output-topic}"
+                                    creation-mode: create-if-not-exists
+                                  - name: "deleted-documents"
+                                    creation-mode: create-if-not-exists
+                                pipeline:
+                                  - type: "dropbox-source"
+                                    id: "step1"
+                                    configuration:
+                                        access-token: %s
+                                        path-prefix: /langstream-test
+                                        state-storage: s3
+                                        state-storage-s3-bucket: "test-state-bucket"
+                                        state-storage-s3-endpoint: "%s"
+                                        deleted-objects-topic: "deleted-objects"
+                                        idle-time: 1
+                                  - type: text-extractor
+                                    id: step2
+                                    output: "${globals.output-topic}"
+                                """
+                                .formatted(
+                                        ACCESS_TOKEN,
+                                        localstack.getEndpointOverride(S3)));
+
+        List<String> fileIds = new ArrayList<>();
+        List<byte[]> docs =
+                List.of(
+                        DropboxSourceIT.class.getResourceAsStream("/doc1.docx").readAllBytes(),
+                        DropboxSourceIT.class
+                                .getResourceAsStream("/doc2.docx")
+                                .readAllBytes());
+
+        for (int i = 0; i < 2; i++) {
+            byte[] bytes = docs.get(i);
+
+            FileMetadata fileMetadata = client.files().upload("/langstream-test/test-" + i + ".docx")
+                    .uploadAndFinish(new ByteArrayInputStream(bytes));
+
+            fileIds.add(fileMetadata.getId());
+        }
+
+        try (ApplicationRuntime applicationRuntime =
+                deployApplication(
+                        tenant, appId, application, buildInstanceYaml(), expectedAgents)) {
+
+            try (TopicConsumer deletedDocumentsConsumer = createConsumer("deleted-objects");
+                    TopicConsumer consumer =
+                            createConsumer(applicationRuntime.getGlobal("output-topic")); ) {
+
+                executeAgentRunners(applicationRuntime, 5);
+                waitForMessages(
+                        consumer,
+                        2,
+                        (consumerRecords, objects) -> {
+                            assertEquals(2, consumerRecords.size());
+                            assertEquals(fileIds.get(0), consumerRecords.get(0).key());
+                            assertTrue(
+                                    ((String) consumerRecords.get(0).value())
+                                            .contains("This is a document"));
+                            assertEquals(fileIds.get(1), consumerRecords.get(1).key());
+                            assertTrue(
+                                    ((String) consumerRecords.get(1).value())
+                                            .contains("This is a another document"));
+                        });
+
+
+                client.files().deleteV2("/langstream-test/test-0.docx");
+                executeAgentRunners(applicationRuntime);
+                waitForMessages(deletedDocumentsConsumer, List.of(fileIds.get(0)));
+            }
+        }
+    }
+}


### PR DESCRIPTION
- New `dropbox-source`
```
- type: "dropbox-source"
                                    id: "step1"
                                    configuration:
                                        access-token: sl.xxxxx
                                        path-prefix: /langstream-test
                                        state-storage: s3
                                        state-storage-s3-bucket: "test-state-bucket"
                                        state-storage-s3-endpoint: "%s"
                                        deleted-objects-topic: "deleted-objects"
```

- `access-token` for the app (Follow [this](https://github.com/dropbox/dropbox-sdk-java?tab=readme-ov-file#register-a-dropbox-api-app))
- `path-prefix` for reading from a different root path
- `extensions` , list for extensions to filter in (by defaut all are included)


