### PR TITLE
feat: add confluence source

### DIFF
--- a/langstream-agents/langstream-agents-atlassian/pom.xml
+++ b/langstream-agents/langstream-agents-atlassian/pom.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright DataStax, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>langstream-agents</artifactId>
+    <groupId>ai.langstream</groupId>
+    <version>0.23.1-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>langstream-agents-atlassian</artifactId>
+  <dependencyManagement>
+
+  </dependencyManagement>
+
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>langstream-api</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>langstream-agents-commons</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>ai.langstream</groupId>
+      <artifactId>langstream-agents-commons-storage-provider</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.dropbox.core</groupId>
+      <artifactId>dropbox-core-sdk</artifactId>
+      <version>7.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.azure</groupId>
+      <artifactId>azure-core</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.nifi</groupId>
+        <artifactId>nifi-nar-maven-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <classifier>nar</classifier>
+        </configuration>
+        <executions>
+          <execution>
+            <id>default-nar</id>
+            <phase>package</phase>
+            <goals>
+              <goal>nar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/langstream-agents/langstream-agents-atlassian/src/main/java/ai/langstream/agents/atlassian/AtlassianAgentsCodeProvider.java
+++ b/langstream-agents/langstream-agents-atlassian/src/main/java/ai/langstream/agents/atlassian/AtlassianAgentsCodeProvider.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.agents.atlassian;
+
+import ai.langstream.agents.atlassian.confluence.ConfluenceSource;
+import ai.langstream.api.runner.code.AgentCode;
+import ai.langstream.api.runner.code.AgentCodeProvider;
+import java.util.List;
+
+public class AtlassianAgentsCodeProvider implements AgentCodeProvider {
+
+    public static final String CONFLUENCE_SOURCE = "confluence-source";
+    private static final List<String> AGENTS = List.of(CONFLUENCE_SOURCE);
+
+    @Override
+    public boolean supports(String agentType) {
+        return AGENTS.contains(agentType);
+    }
+
+    @Override
+    public AgentCode createInstance(String agentType) {
+        switch (agentType) {
+            case CONFLUENCE_SOURCE:
+                return new ConfluenceSource();
+            default:
+                throw new IllegalArgumentException("Unsupported agent type: " + agentType);
+        }
+    }
+}

--- a/langstream-agents/langstream-agents-atlassian/src/main/java/ai/langstream/agents/atlassian/confluence/ConfluenceSource.java
+++ b/langstream-agents/langstream-agents-atlassian/src/main/java/ai/langstream/agents/atlassian/confluence/ConfluenceSource.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.agents.atlassian.confluence;
+
+import ai.langstream.agents.atlassian.confluence.client.ConfluencePage;
+import ai.langstream.agents.atlassian.confluence.client.ConfluenceRestAPIClient;
+import ai.langstream.agents.atlassian.confluence.client.ConfluenceSpace;
+import ai.langstream.ai.agents.commons.storage.provider.StorageProviderObjectReference;
+import ai.langstream.ai.agents.commons.storage.provider.StorageProviderSource;
+import ai.langstream.ai.agents.commons.storage.provider.StorageProviderSourceState;
+import ai.langstream.api.runner.code.Header;
+import ai.langstream.api.runner.code.SimpleRecord;
+import ai.langstream.api.util.ConfigurationUtils;
+import com.dropbox.core.v2.files.*;
+
+import java.util.*;
+import java.util.function.Consumer;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class ConfluenceSource extends StorageProviderSource<ConfluenceSource.ConfluenceSourceState> {
+
+    public static class ConfluenceSourceState extends StorageProviderSourceState {}
+
+    private ConfluenceRestAPIClient client;
+
+    private List<String> spaces;
+    private Set<String> rootParents;
+
+    @Override
+    public Class<ConfluenceSourceState> getStateClass() {
+        return ConfluenceSourceState.class;
+    }
+
+    @Override
+    public void initializeClientAndConfig(Map<String, Object> configuration) {
+        String username =
+                ConfigurationUtils.requiredField(
+                        configuration, "username", () -> "confluence source");
+        String apiToken =
+                ConfigurationUtils.requiredField(
+                        configuration, "api-token", () -> "confluence source");
+        String domain =
+                ConfigurationUtils.requiredField(
+                        configuration, "domain", () -> "confluence source");
+        client = new ConfluenceRestAPIClient(username, apiToken, domain);
+        initializeConfig(configuration);
+    }
+
+    void initializeConfig(Map<String, Object> configuration) {
+        spaces = ConfigurationUtils.getList("spaces", configuration);
+        if (spaces.isEmpty()) {
+            throw new IllegalArgumentException("At least one space (name or key) must be specified");
+        }
+        rootParents = ConfigurationUtils.getSet("root-parents", configuration);
+    }
+
+    @Override
+    public String getBucketName() {
+        return "";
+    }
+
+    @Override
+    public boolean isDeleteObjects() {
+        return false;
+    }
+
+    @Override
+    public Collection<StorageProviderObjectReference> listObjects() throws Exception {
+        List<StorageProviderObjectReference> collect = new ArrayList<>();
+        for (String space : spaces) {
+            List<ConfluenceSpace> spacesForSpace = client.findSpaceByNameOrKeyOrId(space);
+            if (spacesForSpace.isEmpty()) {
+                log.error("Space {} not found, make sure you inserted the name or the key or the id of the space", space);
+                continue;
+            }
+            for (ConfluenceSpace confluenceSpace : spacesForSpace) {
+                log.info("Found space {}", confluenceSpace);
+                int before = collect.size();
+                client.visitSpacePages(confluenceSpace.id(), rootParents, confluencePage -> collect.add(new StorageProviderObjectReference() {
+                    @Override
+                    public String id() {
+                        return confluencePage.id();
+                    }
+
+                    @Override
+                    public long size() {
+                        return -1;
+                    }
+
+                    @Override
+                    public String contentDigest() {
+                        return confluencePage.pageVersion();
+                    }
+
+                    @Override
+                    public Collection<Header> additionalRecordHeaders() {
+                        return List.of(
+                                SimpleRecord.SimpleHeader.of("confluence-space-name", confluenceSpace.name()),
+                                SimpleRecord.SimpleHeader.of("confluence-space-key", confluenceSpace.key()),
+                                SimpleRecord.SimpleHeader.of("confluence-space-id", confluenceSpace.key()),
+                                SimpleRecord.SimpleHeader.of("confluence-page-title", confluencePage.title())
+                                );
+                    }
+                }));
+                log.info("Found {} pages in space {}", collect.size() - before, confluenceSpace);
+            }
+        }
+        return collect;
+    }
+
+    @Override
+    public byte[] downloadObject(StorageProviderObjectReference object) throws Exception {
+        try {
+            return client.exportPage(object.id());
+        } catch (Exception e) {
+            log.error("Error downloading page {} ({})", object.id(), object.additionalRecordHeaders(), e);
+            throw e;
+        }
+    }
+
+    @Override
+    public void deleteObject(String id) throws Exception {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isStateStorageRequired() {
+        return true;
+    }
+}

--- a/langstream-agents/langstream-agents-atlassian/src/main/java/ai/langstream/agents/atlassian/confluence/client/ConfluencePage.java
+++ b/langstream-agents/langstream-agents-atlassian/src/main/java/ai/langstream/agents/atlassian/confluence/client/ConfluencePage.java
@@ -1,5 +1,3 @@
 package ai.langstream.agents.atlassian.confluence.client;
 
-public record ConfluencePage(long spaceId, String id, String title, String pageVersion) {
-
-}
+public record ConfluencePage(long spaceId, String id, String title, String pageVersion) {}

--- a/langstream-agents/langstream-agents-atlassian/src/main/java/ai/langstream/agents/atlassian/confluence/client/ConfluencePage.java
+++ b/langstream-agents/langstream-agents-atlassian/src/main/java/ai/langstream/agents/atlassian/confluence/client/ConfluencePage.java
@@ -1,0 +1,5 @@
+package ai.langstream.agents.atlassian.confluence.client;
+
+public record ConfluencePage(long spaceId, String id, String title, String pageVersion) {
+
+}

--- a/langstream-agents/langstream-agents-atlassian/src/main/java/ai/langstream/agents/atlassian/confluence/client/ConfluenceRestAPIClient.java
+++ b/langstream-agents/langstream-agents-atlassian/src/main/java/ai/langstream/agents/atlassian/confluence/client/ConfluenceRestAPIClient.java
@@ -1,0 +1,207 @@
+package ai.langstream.agents.atlassian.confluence.client;
+
+import ai.langstream.api.util.ObjectMapperFactory;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.function.Consumer;
+
+@Slf4j
+public class ConfluenceRestAPIClient {
+    private final String domain;
+    private final String basicHeader;
+    private final HttpClient httpClient = HttpClient.newHttpClient();
+
+    public ConfluenceRestAPIClient(String username, String apiToken, String domain) {
+        this.domain = domain;
+        this.basicHeader = "Basic " + Base64.getEncoder().encodeToString((username + ":" + apiToken).getBytes(StandardCharsets.UTF_8));
+    }
+
+
+    private record Links(String next) {
+    }
+
+    private record SpaceObject(long id, String key, String name) {
+    }
+    private record SpacesResponse(List<SpaceObject> results, Links _links) {
+    }
+
+    public List<ConfluenceSpace> findSpaceByNameOrKeyOrId(String nameOrKeyOrId) throws IOException, InterruptedException {
+
+        List<ConfluenceSpace> result = new ArrayList<>();
+
+        String uri = "https://%s/wiki/api/v2/spaces?limit=250".formatted(domain);
+        while (true) {
+            HttpResponse<String> response = executeGet(uri);
+            SpacesResponse spaces = ObjectMapperFactory.getDefaultMapper()
+                    .readValue(response.body(), SpacesResponse.class);
+            for (SpaceObject space : spaces.results) {
+                if (space.name.equals(nameOrKeyOrId) || space.key.equals(nameOrKeyOrId) || (space.id + "").equals(nameOrKeyOrId)) {
+                    result.add(new ConfluenceSpace(space.id(), space.name(), space.key()));
+                }
+            }
+            if (spaces._links().next() == null) {
+                break;
+            } else {
+                uri = "https://%s%s".formatted(domain, spaces._links().next());
+            }
+        }
+
+        return result;
+    }
+
+    private HttpResponse<String> executeGet(String uri) throws IOException, InterruptedException {
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(uri))
+                .header("Authorization", basicHeader)
+                .GET().build();
+
+        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        if (response.statusCode() >= 300) {
+            throw new RuntimeException("GET failed to " + uri + " with status " + response.statusCode() + " and body " + response.body());
+        }
+        return response;
+    }
+
+
+
+    private record PageVersion(int number) {}
+    private record PageObject(String id, String title, PageVersion version, String parentId) {
+    }
+    private record PagesResponse(List<PageObject> results, Links _links) {
+    }
+
+    @SneakyThrows
+    public void visitSpacePages(long spaceId, Set<String> rootParents, Consumer<ConfluencePage> consumer){
+        List<ConfluencePage> result = new ArrayList<>();
+        String uri = "https://%s/wiki/api/v2/spaces/%d/pages?limit=250&sort=modified-date".formatted(domain, spaceId);
+        Map<String, String> pageToParent = new HashMap<>();
+        while (true) {
+            HttpResponse<String> response = executeGet(uri);
+            PagesResponse pages = ObjectMapperFactory.getDefaultMapper()
+                    .readValue(response.body(), PagesResponse.class);
+            for (PageObject page : pages.results) {
+                if (!rootParents.isEmpty()) {
+                    if (page.parentId() == null) {
+                        continue;
+                    }
+                    pageToParent.put(page.id(), page.parentId());
+                    result.add(new ConfluencePage(spaceId, page.id(), page.title(), page.version().number() + ""));
+                } else {
+                    consumer.accept(new ConfluencePage(spaceId, page.id(), page.title(), page.version().number() + ""));
+                }
+            }
+            if (pages._links().next() == null) {
+                break;
+            } else {
+                uri = "https://%s%s".formatted(domain, pages._links().next());
+            }
+        }
+        if (rootParents.isEmpty()) {
+            return;
+        }
+        for (ConfluencePage confluencePage : result) {
+            String currentPageId = confluencePage.id();
+            boolean include = false;
+            while (true) {
+                if (rootParents.contains(currentPageId)) {
+                    include = true;
+                    break;
+                }
+                String parentId = pageToParent.get(currentPageId);
+                if (parentId == null) {
+                    break;
+                }
+                currentPageId = parentId;
+            }
+            if (include) {
+                consumer.accept(confluencePage);
+            } else {
+                log.debug("Skipping page {}", confluencePage);
+            }
+        }
+    }
+
+
+    private record ExportView(String value) {
+    }
+    private record ExportViewBody(ExportView export_view) {
+    }
+    private record PageObjectWithBody(ExportViewBody body) {
+    }
+
+    @SneakyThrows
+    public byte[] exportPage(String pageId) {
+        String pageUri = "https://%s/wiki/api/v2/pages/%s?body-format=export_view".formatted(domain, pageId);
+        HttpResponse<String> pageBody = executeGet(pageUri);
+        PageObjectWithBody pageObjectWithBody = ObjectMapperFactory.getDefaultMapper().readValue(pageBody.body(), PageObjectWithBody.class);
+        String value = pageObjectWithBody.body().export_view().value();
+        return value.getBytes(StandardCharsets.UTF_8);
+    }
+
+
+
+    public void deletePageByTitle(long spaceId, String title) {
+        visitSpacePages(spaceId, Set.of(), page -> {
+            if (page.title().equals(title)) {
+                deletePage(page.id());
+            }
+        });
+    }
+    @SneakyThrows
+    public void deletePage(String pageId) {
+        String uri = "https://%s/wiki/api/v2/pages/%s".formatted(domain, pageId);
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(uri))
+                .header("Authorization", basicHeader)
+                .DELETE().build();
+
+        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        if (response.statusCode() >= 300) {
+            throw new RuntimeException("DELETE failed to " + uri + " with status " + response.statusCode() + " and body " + response.body());
+        }
+
+
+    }
+    @SneakyThrows
+    public String createPage(long spaceId, String title, String content, String parentId) {
+        Map<String, Object> payloadMap = new HashMap<>();
+        payloadMap.put("spaceId", spaceId + "");
+        payloadMap.put("status", "current");
+        payloadMap.put("title", title);
+        payloadMap.put("body", Map.of(
+                "storage", Map.of(
+                        "value", content,
+                        "representation", "storage"
+                )
+        ));
+        if (parentId != null) {
+            payloadMap.put("parentId", parentId);
+        }
+        String payload = ObjectMapperFactory
+                .getDefaultMapper()
+                .writeValueAsString(payloadMap);
+
+        String uri = "https://%s/wiki/api/v2/pages".formatted(domain);
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(uri))
+                .header("Authorization", basicHeader)
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(payload)).build();
+
+        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        if (response.statusCode() >= 300) {
+            throw new RuntimeException("POST failed to " + uri + " with status " + response.statusCode() + " and body " + response.body());
+        }
+        String body = response.body();
+        return ObjectMapperFactory.getDefaultMapper().readValue(body, PageObject.class).id();
+    }
+}

--- a/langstream-agents/langstream-agents-atlassian/src/main/java/ai/langstream/agents/atlassian/confluence/client/ConfluenceRestAPIClient.java
+++ b/langstream-agents/langstream-agents-atlassian/src/main/java/ai/langstream/agents/atlassian/confluence/client/ConfluenceRestAPIClient.java
@@ -1,10 +1,6 @@
 package ai.langstream.agents.atlassian.confluence.client;
 
 import ai.langstream.api.util.ObjectMapperFactory;
-import lombok.SneakyThrows;
-import lombok.extern.slf4j.Slf4j;
-import org.jetbrains.annotations.NotNull;
-
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -13,6 +9,8 @@ import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.function.Consumer;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class ConfluenceRestAPIClient {
@@ -22,29 +20,35 @@ public class ConfluenceRestAPIClient {
 
     public ConfluenceRestAPIClient(String username, String apiToken, String domain) {
         this.domain = domain;
-        this.basicHeader = "Basic " + Base64.getEncoder().encodeToString((username + ":" + apiToken).getBytes(StandardCharsets.UTF_8));
+        this.basicHeader =
+                "Basic "
+                        + Base64.getEncoder()
+                                .encodeToString(
+                                        (username + ":" + apiToken)
+                                                .getBytes(StandardCharsets.UTF_8));
     }
 
+    private record Links(String next) {}
 
-    private record Links(String next) {
-    }
+    private record SpaceObject(long id, String key, String name) {}
 
-    private record SpaceObject(long id, String key, String name) {
-    }
-    private record SpacesResponse(List<SpaceObject> results, Links _links) {
-    }
+    private record SpacesResponse(List<SpaceObject> results, Links _links) {}
 
-    public List<ConfluenceSpace> findSpaceByNameOrKeyOrId(String nameOrKeyOrId) throws IOException, InterruptedException {
+    public List<ConfluenceSpace> findSpaceByNameOrKeyOrId(String nameOrKeyOrId)
+            throws IOException, InterruptedException {
 
         List<ConfluenceSpace> result = new ArrayList<>();
 
         String uri = "https://%s/wiki/api/v2/spaces?limit=250".formatted(domain);
         while (true) {
             HttpResponse<String> response = executeGet(uri);
-            SpacesResponse spaces = ObjectMapperFactory.getDefaultMapper()
-                    .readValue(response.body(), SpacesResponse.class);
+            SpacesResponse spaces =
+                    ObjectMapperFactory.getDefaultMapper()
+                            .readValue(response.body(), SpacesResponse.class);
             for (SpaceObject space : spaces.results) {
-                if (space.name.equals(nameOrKeyOrId) || space.key.equals(nameOrKeyOrId) || (space.id + "").equals(nameOrKeyOrId)) {
+                if (space.name.equals(nameOrKeyOrId)
+                        || space.key.equals(nameOrKeyOrId)
+                        || (space.id + "").equals(nameOrKeyOrId)) {
                     result.add(new ConfluenceSpace(space.id(), space.name(), space.key()));
                 }
             }
@@ -59,44 +63,65 @@ public class ConfluenceRestAPIClient {
     }
 
     private HttpResponse<String> executeGet(String uri) throws IOException, InterruptedException {
-        HttpRequest request = HttpRequest.newBuilder()
-                .uri(URI.create(uri))
-                .header("Authorization", basicHeader)
-                .GET().build();
+        HttpRequest request =
+                HttpRequest.newBuilder()
+                        .uri(URI.create(uri))
+                        .header("Authorization", basicHeader)
+                        .GET()
+                        .build();
 
-        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        HttpResponse<String> response =
+                httpClient.send(request, HttpResponse.BodyHandlers.ofString());
         if (response.statusCode() >= 300) {
-            throw new RuntimeException("GET failed to " + uri + " with status " + response.statusCode() + " and body " + response.body());
+            throw new RuntimeException(
+                    "GET failed to "
+                            + uri
+                            + " with status "
+                            + response.statusCode()
+                            + " and body "
+                            + response.body());
         }
         return response;
     }
 
-
-
     private record PageVersion(int number) {}
-    private record PageObject(String id, String title, PageVersion version, String parentId) {
-    }
-    private record PagesResponse(List<PageObject> results, Links _links) {
-    }
+
+    private record PageObject(String id, String title, PageVersion version, String parentId) {}
+
+    private record PagesResponse(List<PageObject> results, Links _links) {}
 
     @SneakyThrows
-    public void visitSpacePages(long spaceId, Set<String> rootParents, Consumer<ConfluencePage> consumer){
+    public void visitSpacePages(
+            long spaceId, Set<String> rootParents, Consumer<ConfluencePage> consumer) {
         List<ConfluencePage> result = new ArrayList<>();
-        String uri = "https://%s/wiki/api/v2/spaces/%d/pages?limit=250&sort=modified-date".formatted(domain, spaceId);
+        String uri =
+                "https://%s/wiki/api/v2/spaces/%d/pages?limit=250&sort=modified-date"
+                        .formatted(domain, spaceId);
         Map<String, String> pageToParent = new HashMap<>();
         while (true) {
             HttpResponse<String> response = executeGet(uri);
-            PagesResponse pages = ObjectMapperFactory.getDefaultMapper()
-                    .readValue(response.body(), PagesResponse.class);
+            PagesResponse pages =
+                    ObjectMapperFactory.getDefaultMapper()
+                            .readValue(response.body(), PagesResponse.class);
             for (PageObject page : pages.results) {
                 if (!rootParents.isEmpty()) {
                     if (page.parentId() == null) {
                         continue;
                     }
                     pageToParent.put(page.id(), page.parentId());
-                    result.add(new ConfluencePage(spaceId, page.id(), page.title(), page.version().number() + ""));
+                    result.add(
+                            new ConfluencePage(
+                                    spaceId,
+                                    page.id(),
+                                    page.title(),
+                                    page.version().number() + ""));
                 } else {
-                    consumer.accept(new ConfluencePage(spaceId, page.id(), page.title(), page.version().number() + ""));
+                    consumer.accept(
+                            new ConfluencePage(
+                                    spaceId,
+                                    page.id(),
+                                    page.title(),
+                                    page.version().number() + ""));
                 }
             }
             if (pages._links().next() == null) {
@@ -130,76 +155,90 @@ public class ConfluenceRestAPIClient {
         }
     }
 
+    private record ExportView(String value) {}
 
-    private record ExportView(String value) {
-    }
-    private record ExportViewBody(ExportView export_view) {
-    }
-    private record PageObjectWithBody(ExportViewBody body) {
-    }
+    private record ExportViewBody(ExportView export_view) {}
+
+    private record PageObjectWithBody(ExportViewBody body) {}
 
     @SneakyThrows
     public byte[] exportPage(String pageId) {
-        String pageUri = "https://%s/wiki/api/v2/pages/%s?body-format=export_view".formatted(domain, pageId);
+        String pageUri =
+                "https://%s/wiki/api/v2/pages/%s?body-format=export_view".formatted(domain, pageId);
         HttpResponse<String> pageBody = executeGet(pageUri);
-        PageObjectWithBody pageObjectWithBody = ObjectMapperFactory.getDefaultMapper().readValue(pageBody.body(), PageObjectWithBody.class);
+        PageObjectWithBody pageObjectWithBody =
+                ObjectMapperFactory.getDefaultMapper()
+                        .readValue(pageBody.body(), PageObjectWithBody.class);
         String value = pageObjectWithBody.body().export_view().value();
         return value.getBytes(StandardCharsets.UTF_8);
     }
 
-
-
     public void deletePageByTitle(long spaceId, String title) {
-        visitSpacePages(spaceId, Set.of(), page -> {
-            if (page.title().equals(title)) {
-                deletePage(page.id());
-            }
-        });
+        visitSpacePages(
+                spaceId,
+                Set.of(),
+                page -> {
+                    if (page.title().equals(title)) {
+                        deletePage(page.id());
+                    }
+                });
     }
+
     @SneakyThrows
     public void deletePage(String pageId) {
         String uri = "https://%s/wiki/api/v2/pages/%s".formatted(domain, pageId);
-        HttpRequest request = HttpRequest.newBuilder()
-                .uri(URI.create(uri))
-                .header("Authorization", basicHeader)
-                .DELETE().build();
+        HttpRequest request =
+                HttpRequest.newBuilder()
+                        .uri(URI.create(uri))
+                        .header("Authorization", basicHeader)
+                        .DELETE()
+                        .build();
 
-        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        HttpResponse<String> response =
+                httpClient.send(request, HttpResponse.BodyHandlers.ofString());
         if (response.statusCode() >= 300) {
-            throw new RuntimeException("DELETE failed to " + uri + " with status " + response.statusCode() + " and body " + response.body());
+            throw new RuntimeException(
+                    "DELETE failed to "
+                            + uri
+                            + " with status "
+                            + response.statusCode()
+                            + " and body "
+                            + response.body());
         }
-
-
     }
+
     @SneakyThrows
     public String createPage(long spaceId, String title, String content, String parentId) {
         Map<String, Object> payloadMap = new HashMap<>();
         payloadMap.put("spaceId", spaceId + "");
         payloadMap.put("status", "current");
         payloadMap.put("title", title);
-        payloadMap.put("body", Map.of(
-                "storage", Map.of(
-                        "value", content,
-                        "representation", "storage"
-                )
-        ));
+        payloadMap.put(
+                "body", Map.of("storage", Map.of("value", content, "representation", "storage")));
         if (parentId != null) {
             payloadMap.put("parentId", parentId);
         }
-        String payload = ObjectMapperFactory
-                .getDefaultMapper()
-                .writeValueAsString(payloadMap);
+        String payload = ObjectMapperFactory.getDefaultMapper().writeValueAsString(payloadMap);
 
         String uri = "https://%s/wiki/api/v2/pages".formatted(domain);
-        HttpRequest request = HttpRequest.newBuilder()
-                .uri(URI.create(uri))
-                .header("Authorization", basicHeader)
-                .header("Content-Type", "application/json")
-                .POST(HttpRequest.BodyPublishers.ofString(payload)).build();
+        HttpRequest request =
+                HttpRequest.newBuilder()
+                        .uri(URI.create(uri))
+                        .header("Authorization", basicHeader)
+                        .header("Content-Type", "application/json")
+                        .POST(HttpRequest.BodyPublishers.ofString(payload))
+                        .build();
 
-        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        HttpResponse<String> response =
+                httpClient.send(request, HttpResponse.BodyHandlers.ofString());
         if (response.statusCode() >= 300) {
-            throw new RuntimeException("POST failed to " + uri + " with status " + response.statusCode() + " and body " + response.body());
+            throw new RuntimeException(
+                    "POST failed to "
+                            + uri
+                            + " with status "
+                            + response.statusCode()
+                            + " and body "
+                            + response.body());
         }
         String body = response.body();
         return ObjectMapperFactory.getDefaultMapper().readValue(body, PageObject.class).id();

--- a/langstream-agents/langstream-agents-atlassian/src/main/java/ai/langstream/agents/atlassian/confluence/client/ConfluenceSpace.java
+++ b/langstream-agents/langstream-agents-atlassian/src/main/java/ai/langstream/agents/atlassian/confluence/client/ConfluenceSpace.java
@@ -1,0 +1,5 @@
+package ai.langstream.agents.atlassian.confluence.client;
+
+public record ConfluenceSpace(long id, String name, String key){
+
+}

--- a/langstream-agents/langstream-agents-atlassian/src/main/java/ai/langstream/agents/atlassian/confluence/client/ConfluenceSpace.java
+++ b/langstream-agents/langstream-agents-atlassian/src/main/java/ai/langstream/agents/atlassian/confluence/client/ConfluenceSpace.java
@@ -1,5 +1,3 @@
 package ai.langstream.agents.atlassian.confluence.client;
 
-public record ConfluenceSpace(long id, String name, String key){
-
-}
+public record ConfluenceSpace(long id, String name, String key) {}

--- a/langstream-agents/langstream-agents-atlassian/src/main/resources/META-INF/ai.langstream.agents.index
+++ b/langstream-agents/langstream-agents-atlassian/src/main/resources/META-INF/ai.langstream.agents.index
@@ -1,0 +1,1 @@
+confluence-source

--- a/langstream-agents/langstream-agents-atlassian/src/main/resources/META-INF/services/ai.langstream.api.runner.code.AgentCodeProvider
+++ b/langstream-agents/langstream-agents-atlassian/src/main/resources/META-INF/services/ai.langstream.api.runner.code.AgentCodeProvider
@@ -1,0 +1,1 @@
+ai.langstream.agents.atlassian.AtlassianAgentsCodeProvider

--- a/langstream-agents/pom.xml
+++ b/langstream-agents/pom.xml
@@ -45,5 +45,6 @@
         <module>langstream-agents-google</module>
         <module>langstream-agents-ms365</module>
         <module>langstream-agents-dropbox</module>
+        <module>langstream-agents-atlassian</module>
     </modules>
 </project>

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/StorageProviderSourceAgentProvider.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/StorageProviderSourceAgentProvider.java
@@ -41,6 +41,7 @@ public class StorageProviderSourceAgentProvider extends AbstractComposableAgentP
     protected static final String MS_365_SHAREPOINT_SOURCE = "ms365-sharepoint-source";
     protected static final String MS_365_ONEDRIVE_SOURCE = "ms365-onedrive-source";
     protected static final String DROPBOX_SOURCE = "dropbox-source";
+    protected static final String CONFLUENCE_SOURCE = "confluence-source";
 
     public StorageProviderSourceAgentProvider() {
         super(
@@ -51,7 +52,8 @@ public class StorageProviderSourceAgentProvider extends AbstractComposableAgentP
                         GOOGLE_DRIVE_SOURCE,
                         MS_365_SHAREPOINT_SOURCE,
                         MS_365_ONEDRIVE_SOURCE,
-                        DROPBOX_SOURCE),
+                        DROPBOX_SOURCE,
+                        CONFLUENCE_SOURCE),
                 List.of(KubernetesClusterRuntime.CLUSTER_TYPE, "none"));
     }
 
@@ -77,6 +79,8 @@ public class StorageProviderSourceAgentProvider extends AbstractComposableAgentP
                 return MS365OneDriveSourceConfiguration.class;
             case DROPBOX_SOURCE:
                 return DropboxSourceConfiguration.class;
+            case CONFLUENCE_SOURCE:
+                return ConfluenceSourceConfiguration.class;
             default:
                 throw new IllegalArgumentException("Unknown agent type: " + type);
         }
@@ -565,5 +569,61 @@ public class StorageProviderSourceAgentProvider extends AbstractComposableAgentP
                 defaultValue = "")
         @JsonProperty("path-prefix")
         private String pathPrefix;
+    }
+
+    @AgentConfig(
+            name = "Confluence Source",
+            description =
+                    """
+                            Reads data from Confluence Spaces.
+                            """)
+    @Data
+    @EqualsAndHashCode(callSuper = true)
+    public static class ConfluenceSourceConfiguration extends StorageProviderSourceBaseConfiguration {
+
+        @ConfigProperty(
+                required = true,
+                description =
+                        """
+                                Username to authenticate with.
+                                """)
+        @JsonProperty("username")
+        private String username;
+
+
+        @ConfigProperty(
+                required = true,
+                description =
+                        """
+                               API token to authenticate with.
+                                """)
+        @JsonProperty("api-token")
+        private String apiToken;
+
+        @ConfigProperty(
+                required = true,
+                description =
+                        """
+                               Confluence domain (e.g. https://my-domain.atlassian.net or confluence.<my-company>.com).
+                                """)
+        private String domain;
+
+
+        @ConfigProperty(
+                required = true,
+                description =
+                        """
+                                Confluence Spaces to read from. A space can be referenced by name, key or numeric id.
+                                        """)
+        private List<String> spaces;
+
+        @ConfigProperty(
+                description =
+                        """
+                                Filter by parent pages. By default, all pages are included.
+                                Set a list of parent page ids to filter by.
+                                        """)
+        @JsonProperty("root-parents")
+        private List<String> rootParents;
     }
 }

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/StorageProviderSourceAgentProvider.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/StorageProviderSourceAgentProvider.java
@@ -579,7 +579,8 @@ public class StorageProviderSourceAgentProvider extends AbstractComposableAgentP
                             """)
     @Data
     @EqualsAndHashCode(callSuper = true)
-    public static class ConfluenceSourceConfiguration extends StorageProviderSourceBaseConfiguration {
+    public static class ConfluenceSourceConfiguration
+            extends StorageProviderSourceBaseConfiguration {
 
         @ConfigProperty(
                 required = true,
@@ -589,7 +590,6 @@ public class StorageProviderSourceAgentProvider extends AbstractComposableAgentP
                                 """)
         @JsonProperty("username")
         private String username;
-
 
         @ConfigProperty(
                 required = true,
@@ -607,7 +607,6 @@ public class StorageProviderSourceAgentProvider extends AbstractComposableAgentP
                                Confluence domain (e.g. https://my-domain.atlassian.net or confluence.<my-company>.com).
                                 """)
         private String domain;
-
 
         @ConfigProperty(
                 required = true,

--- a/langstream-runtime/langstream-runtime-impl/pom.xml
+++ b/langstream-runtime/langstream-runtime-impl/pom.xml
@@ -354,6 +354,13 @@
 
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>langstream-agents-atlassian</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>langstream-agent-webcrawler</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
@@ -685,6 +692,16 @@
                 <artifactItem>
                   <groupId>${project.groupId}</groupId>
                   <artifactId>langstream-agents-dropbox</artifactId>
+                  <version>${project.version}</version>
+                  <type>nar</type>
+                  <classifier>nar</classifier>
+                  <overWrite>false</overWrite>
+                  <outputDirectory>${project.build.directory}/agents</outputDirectory>
+                </artifactItem>
+
+                <artifactItem>
+                  <groupId>${project.groupId}</groupId>
+                  <artifactId>langstream-agents-atlassian</artifactId>
                   <version>${project.version}</version>
                   <type>nar</type>
                   <classifier>nar</classifier>

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/agents/ConfluenceSourceIT.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/agents/ConfluenceSourceIT.java
@@ -15,13 +15,15 @@
  */
 package ai.langstream.agents;
 
+import static ai.langstream.testrunners.AbstractApplicationRunner.INTEGRATION_TESTS_GROUP1;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.testcontainers.containers.localstack.LocalStackContainer.Service.S3;
+
 import ai.langstream.agents.atlassian.confluence.client.ConfluenceRestAPIClient;
 import ai.langstream.api.runner.topics.TopicConsumer;
 import ai.langstream.testrunners.AbstractGenericStreamingApplicationRunner;
-import com.dropbox.core.DbxRequestConfig;
-import com.dropbox.core.v2.DbxClientV2;
-import com.dropbox.core.v2.files.DeleteErrorException;
-import com.dropbox.core.v2.files.FileMetadata;
+import java.util.*;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
@@ -30,15 +32,6 @@ import org.testcontainers.containers.localstack.LocalStackContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
-
-import java.io.ByteArrayInputStream;
-import java.nio.charset.StandardCharsets;
-import java.util.*;
-
-import static ai.langstream.testrunners.AbstractApplicationRunner.INTEGRATION_TESTS_GROUP1;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.testcontainers.containers.localstack.LocalStackContainer.Service.S3;
 
 @Slf4j
 @Testcontainers
@@ -57,16 +50,20 @@ class ConfluenceSourceIT extends AbstractGenericStreamingApplicationRunner {
 
     @Test
     public void test() throws Exception {
-        ConfluenceRestAPIClient confluence = new ConfluenceRestAPIClient(USERNAME, API_TOKEN, DOMAIN);
+        ConfluenceRestAPIClient confluence =
+                new ConfluenceRestAPIClient(USERNAME, API_TOKEN, DOMAIN);
 
         long spaceId = confluence.findSpaceByNameOrKeyOrId(SPACE).iterator().next().id();
-        confluence.visitSpacePages(spaceId, Set.of(), page -> {
-            if (page.title().equals("Langstream Parent")) {
-                confluence.deletePage(page.id());
-            }
-        });
-        String parentPageId = confluence.createPage(spaceId, "Langstream Parent", "Parent page", null);
-
+        confluence.visitSpacePages(
+                spaceId,
+                Set.of(),
+                page -> {
+                    if (page.title().equals("Langstream Parent")) {
+                        confluence.deletePage(page.id());
+                    }
+                });
+        String parentPageId =
+                confluence.createPage(spaceId, "Langstream Parent", "Parent page", null);
 
         final String appId = "app-" + UUID.randomUUID().toString().substring(0, 4);
 
@@ -101,7 +98,13 @@ class ConfluenceSourceIT extends AbstractGenericStreamingApplicationRunner {
                                     id: step2
                                     output: "${globals.output-topic}"
                                 """
-                                .formatted(USERNAME, API_TOKEN, DOMAIN, SPACE, localstack.getEndpointOverride(S3), parentPageId));
+                                .formatted(
+                                        USERNAME,
+                                        API_TOKEN,
+                                        DOMAIN,
+                                        SPACE,
+                                        localstack.getEndpointOverride(S3),
+                                        parentPageId));
 
         List<String> pageIds = new ArrayList<>();
         pageIds.add(parentPageId);

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/agents/ConfluenceSourceIT.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/agents/ConfluenceSourceIT.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.agents;
+
+import ai.langstream.agents.atlassian.confluence.client.ConfluenceRestAPIClient;
+import ai.langstream.api.runner.topics.TopicConsumer;
+import ai.langstream.testrunners.AbstractGenericStreamingApplicationRunner;
+import com.dropbox.core.DbxRequestConfig;
+import com.dropbox.core.v2.DbxClientV2;
+import com.dropbox.core.v2.files.DeleteErrorException;
+import com.dropbox.core.v2.files.FileMetadata;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+
+import static ai.langstream.testrunners.AbstractApplicationRunner.INTEGRATION_TESTS_GROUP1;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.testcontainers.containers.localstack.LocalStackContainer.Service.S3;
+
+@Slf4j
+@Testcontainers
+@Tag(INTEGRATION_TESTS_GROUP1)
+@Disabled
+class ConfluenceSourceIT extends AbstractGenericStreamingApplicationRunner {
+    @Container
+    private static final LocalStackContainer localstack =
+            new LocalStackContainer(DockerImageName.parse("localstack/localstack:2.2.0"))
+                    .withServices(S3);
+
+    private static final String USERNAME = "";
+    private static final String API_TOKEN = "";
+    private static final String DOMAIN = "";
+    private static final String SPACE = "";
+
+    @Test
+    public void test() throws Exception {
+        ConfluenceRestAPIClient confluence = new ConfluenceRestAPIClient(USERNAME, API_TOKEN, DOMAIN);
+
+        long spaceId = confluence.findSpaceByNameOrKeyOrId(SPACE).iterator().next().id();
+        confluence.visitSpacePages(spaceId, Set.of(), page -> {
+            if (page.title().equals("Langstream Parent")) {
+                confluence.deletePage(page.id());
+            }
+        });
+        String parentPageId = confluence.createPage(spaceId, "Langstream Parent", "Parent page", null);
+
+
+        final String appId = "app-" + UUID.randomUUID().toString().substring(0, 4);
+
+        String tenant = "tenant";
+        String[] expectedAgents = new String[] {appId + "-step1", appId + "-step2"};
+        Map<String, String> application =
+                Map.of(
+                        "module.yaml",
+                        """
+                                module: "module-1"
+                                id: "pipeline-1"
+                                topics:
+                                  - name: "${globals.output-topic}"
+                                    creation-mode: create-if-not-exists
+                                  - name: "deleted-documents"
+                                    creation-mode: create-if-not-exists
+                                pipeline:
+                                  - type: "confluence-source"
+                                    id: "step1"
+                                    configuration:
+                                        username: %s
+                                        api-token: %s
+                                        domain: %s
+                                        spaces: [%s]
+                                        state-storage: s3
+                                        state-storage-s3-bucket: "test-state-bucket"
+                                        state-storage-s3-endpoint: "%s"
+                                        deleted-objects-topic: "deleted-objects"
+                                        idle-time: 1
+                                        root-parents: ["%s"]
+                                  - type: text-extractor
+                                    id: step2
+                                    output: "${globals.output-topic}"
+                                """
+                                .formatted(USERNAME, API_TOKEN, DOMAIN, SPACE, localstack.getEndpointOverride(S3), parentPageId));
+
+        List<String> pageIds = new ArrayList<>();
+        pageIds.add(parentPageId);
+        for (int i = 0; i < 2; i++) {
+            String title = "Langstream test-" + i;
+            confluence.deletePageByTitle(spaceId, title);
+            String pageId = confluence.createPage(spaceId, title, "document " + i, parentPageId);
+            pageIds.add(pageId);
+        }
+
+        try (ApplicationRuntime applicationRuntime =
+                deployApplication(
+                        tenant, appId, application, buildInstanceYaml(), expectedAgents)) {
+
+            try (TopicConsumer deletedDocumentsConsumer = createConsumer("deleted-objects");
+                    TopicConsumer consumer =
+                            createConsumer(applicationRuntime.getGlobal("output-topic")); ) {
+
+                executeAgentRunners(applicationRuntime, 5);
+                waitForMessages(
+                        consumer,
+                        3,
+                        (consumerRecords, objects) -> {
+                            assertEquals(3, consumerRecords.size());
+                            assertEquals(pageIds.get(0), consumerRecords.get(0).key());
+                            assertTrue(
+                                    ((String) consumerRecords.get(0).value())
+                                            .contains("Parent page"));
+                            assertEquals(pageIds.get(1), consumerRecords.get(1).key());
+                            assertTrue(
+                                    ((String) consumerRecords.get(1).value())
+                                            .contains("document 0"));
+                            assertEquals(pageIds.get(2), consumerRecords.get(2).key());
+                            assertTrue(
+                                    ((String) consumerRecords.get(2).value())
+                                            .contains("document 1"));
+                        });
+
+                confluence.deletePage(pageIds.get(1));
+                executeAgentRunners(applicationRuntime, 5);
+                waitForMessages(deletedDocumentsConsumer, List.of(pageIds.get(1)));
+            }
+        } finally {
+            for (String pageId : pageIds) {
+                try {
+                    confluence.deletePage(pageId);
+                } catch (Exception e) {
+                    log.error("Error deleting page {}", pageId, e);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
- New `confluence-source` agent

```
- type: "confluence-source"
                                    id: "step1"
                                    configuration:
                                        username: ""
                                        api-token: ""
                                        domain: ""
                                        spaces: [""]
                                        state-storage: s3
                                        state-storage-s3-bucket: "test-state-bucket"
                                        state-storage-s3-endpoint: "%s"
                                        deleted-objects-topic: "deleted-objects"
                                        idle-time: 1
                                        root-parents: [""]
```

Fields:
- `username`: the connector uses basic auth, you need to put your user email
- `api-token`: Generate an api token from here https://id.atlassian.com/manage-profile/security/api-tokens
- `domain`: Domain of the confluence instance (e.g. vectorize.atlassian.net)
- `spaces`: List of spaces to read pages from. Space might be the internal id (numeric), the Display name or the key (that you get from the URL in the browser)
- `root-parents`: instead of reading the whole space, you can filter by root pages (must be the numerical ids that you can find in the URL in the browser)

The exported content is in HTML format using confluence export method.
The checksum is not computed but we use the page version (which normally means something has changed in the content)